### PR TITLE
Add dependabot to repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependency"


### PR DESCRIPTION
This will help monitor the GitHub actions we use in the repo and ensure we keep them up to date.