### PR TITLE
Update namespace from OpenFeature -> OpenFeature.SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The packages will aim to support all current .NET versions. Refer to the current
 ## Basic Usage
 
 ```csharp
+using OpenFeature.SDK;
+
 OpenFeature.Instance.SetProvider(new NoOpProvider());
 var client = OpenFeature.Instance.GetClient();
 

--- a/src/OpenFeature/Constant/ErrorType.cs
+++ b/src/OpenFeature/Constant/ErrorType.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
 
-namespace OpenFeature.Constant
+namespace OpenFeature.SDK.Constant
 {
     /// <summary>
     /// These errors are used to indicate abnormal execution when evaluation a flag

--- a/src/OpenFeature/Constant/FlagValueType.cs
+++ b/src/OpenFeature/Constant/FlagValueType.cs
@@ -1,4 +1,4 @@
-namespace OpenFeature.Constant
+namespace OpenFeature.SDK.Constant
 {
     /// <summary>
     ///  Used to identity what object type of flag being evaluated

--- a/src/OpenFeature/Constant/NoOpProvider.cs
+++ b/src/OpenFeature/Constant/NoOpProvider.cs
@@ -1,4 +1,4 @@
-namespace OpenFeature.Constant
+namespace OpenFeature.SDK.Constant
 {
     internal static class NoOpProvider
     {

--- a/src/OpenFeature/Constant/Reason.cs
+++ b/src/OpenFeature/Constant/Reason.cs
@@ -1,4 +1,4 @@
-namespace OpenFeature.Constant
+namespace OpenFeature.SDK.Constant
 {
     /// <summary>
     /// Common reasons used during flag resolution

--- a/src/OpenFeature/Error/FeatureProviderException.cs
+++ b/src/OpenFeature/Error/FeatureProviderException.cs
@@ -1,8 +1,8 @@
 using System;
-using OpenFeature.Constant;
-using OpenFeature.Extension;
+using OpenFeature.SDK.Constant;
+using OpenFeature.SDK.Extension;
 
-namespace OpenFeature.Error
+namespace OpenFeature.SDK.Error
 {
     /// <summary>
     /// Used to represent an abnormal error when evaluating a flag. This exception should be thrown

--- a/src/OpenFeature/Extension/EnumExtensions.cs
+++ b/src/OpenFeature/Extension/EnumExtensions.cs
@@ -2,7 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 
-namespace OpenFeature.Extension
+namespace OpenFeature.SDK.Extension
 {
     internal static class EnumExtensions
     {

--- a/src/OpenFeature/Extension/ResolutionDetailsExtensions.cs
+++ b/src/OpenFeature/Extension/ResolutionDetailsExtensions.cs
@@ -1,6 +1,6 @@
-using OpenFeature.Model;
+using OpenFeature.SDK.Model;
 
-namespace OpenFeature.Extension
+namespace OpenFeature.SDK.Extension
 {
     internal static class ResolutionDetailsExtensions
     {

--- a/src/OpenFeature/Hook.cs
+++ b/src/OpenFeature/Hook.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using OpenFeature.Model;
+using OpenFeature.SDK.Model;
 
-namespace OpenFeature
+namespace OpenFeature.SDK
 {
     internal interface IHook
     {

--- a/src/OpenFeature/IFeatureClient.cs
+++ b/src/OpenFeature/IFeatureClient.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using OpenFeature.Model;
+using OpenFeature.SDK.Model;
 
-namespace OpenFeature
+namespace OpenFeature.SDK
 {
     internal interface IFeatureClient
     {

--- a/src/OpenFeature/IFeatureProvider.cs
+++ b/src/OpenFeature/IFeatureProvider.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
-using OpenFeature.Model;
+using OpenFeature.SDK.Model;
 
-namespace OpenFeature
+namespace OpenFeature.SDK
 {
     /// <summary>
     /// The provider interface describes the abstraction layer for a feature flag provider.

--- a/src/OpenFeature/Model/ClientMetadata.cs
+++ b/src/OpenFeature/Model/ClientMetadata.cs
@@ -1,4 +1,4 @@
-namespace OpenFeature.Model
+namespace OpenFeature.SDK.Model
 {
     /// <summary>
     /// Represents the client metadata

--- a/src/OpenFeature/Model/EvaluationContext.cs
+++ b/src/OpenFeature/Model/EvaluationContext.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenFeature.Model
+namespace OpenFeature.SDK.Model
 {
     /// <summary>
     /// A KeyValuePair with a string key and object value that is used to apply user defined properties

--- a/src/OpenFeature/Model/FlagEvaluationOptions.cs
+++ b/src/OpenFeature/Model/FlagEvaluationOptions.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace OpenFeature.Model
+namespace OpenFeature.SDK.Model
 {
     /// <summary>
     /// A structure containing the one or more hooks and hook hints

--- a/src/OpenFeature/Model/FlagEvalusationDetails.cs
+++ b/src/OpenFeature/Model/FlagEvalusationDetails.cs
@@ -1,7 +1,7 @@
-using OpenFeature.Constant;
-using OpenFeature.Extension;
+using OpenFeature.SDK.Constant;
+using OpenFeature.SDK.Extension;
 
-namespace OpenFeature.Model
+namespace OpenFeature.SDK.Model
 {
     /// <summary>
     /// The contract returned to the caller that describes the result of the flag evaluation process.

--- a/src/OpenFeature/Model/HookContext.cs
+++ b/src/OpenFeature/Model/HookContext.cs
@@ -1,7 +1,7 @@
 using System;
-using OpenFeature.Constant;
+using OpenFeature.SDK.Constant;
 
-namespace OpenFeature.Model
+namespace OpenFeature.SDK.Model
 {
     /// <summary>
     /// Context provided to hook execution

--- a/src/OpenFeature/Model/Metadata.cs
+++ b/src/OpenFeature/Model/Metadata.cs
@@ -1,4 +1,4 @@
-namespace OpenFeature.Model
+namespace OpenFeature.SDK.Model
 {
     /// <summary>
     /// <see cref="OpenFeature"/> metadata

--- a/src/OpenFeature/Model/ResolutionDetails.cs
+++ b/src/OpenFeature/Model/ResolutionDetails.cs
@@ -1,6 +1,6 @@
-using OpenFeature.Constant;
+using OpenFeature.SDK.Constant;
 
-namespace OpenFeature.Model
+namespace OpenFeature.SDK.Model
 {
     /// <summary>
     /// Defines the contract that the <see cref="IFeatureProvider"/> is required to return

--- a/src/OpenFeature/NoOpProvider.cs
+++ b/src/OpenFeature/NoOpProvider.cs
@@ -1,8 +1,8 @@
 using System.Threading.Tasks;
-using OpenFeature.Constant;
-using OpenFeature.Model;
+using OpenFeature.SDK.Constant;
+using OpenFeature.SDK.Model;
 
-namespace OpenFeature
+namespace OpenFeature.SDK
 {
     internal class NoOpFeatureProvider : IFeatureProvider
     {

--- a/src/OpenFeature/OpenFeature.cs
+++ b/src/OpenFeature/OpenFeature.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
-using OpenFeature.Model;
+using OpenFeature.SDK.Model;
 
-namespace OpenFeature
+namespace OpenFeature.SDK
 {
     /// <summary>
     /// The evaluation API allows for the evaluation of feature flag values, independent of any flag control plane or vendor.

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -4,12 +4,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using OpenFeature.Constant;
-using OpenFeature.Error;
-using OpenFeature.Extension;
-using OpenFeature.Model;
+using OpenFeature.SDK.Constant;
+using OpenFeature.SDK.Error;
+using OpenFeature.SDK.Extension;
+using OpenFeature.SDK.Model;
 
-namespace OpenFeature
+namespace OpenFeature.SDK
 {
     /// <summary>
     ///

--- a/test/OpenFeature.Tests/FeatureProviderExceptionTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderExceptionTests.cs
@@ -1,10 +1,10 @@
 using System;
 using FluentAssertions;
-using OpenFeature.Constant;
-using OpenFeature.Error;
+using OpenFeature.SDK.Constant;
+using OpenFeature.SDK.Error;
 using Xunit;
 
-namespace OpenFeature.Tests
+namespace OpenFeature.SDK.Tests
 {
     public class FeatureProviderExceptionTests
     {

--- a/test/OpenFeature.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderTests.cs
@@ -2,12 +2,12 @@ using System.Threading.Tasks;
 using AutoFixture;
 using FluentAssertions;
 using Moq;
-using OpenFeature.Constant;
-using OpenFeature.Model;
-using OpenFeature.Tests.Internal;
+using OpenFeature.SDK.Constant;
+using OpenFeature.SDK.Model;
+using OpenFeature.SDK.Tests.Internal;
 using Xunit;
 
-namespace OpenFeature.Tests
+namespace OpenFeature.SDK.Tests
 {
     public class FeatureProviderTests
     {

--- a/test/OpenFeature.Tests/Internal/SpecificationAttribute.cs
+++ b/test/OpenFeature.Tests/Internal/SpecificationAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OpenFeature.Tests.Internal
+namespace OpenFeature.SDK.Tests.Internal
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class SpecificationAttribute : Attribute

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -5,14 +5,14 @@ using AutoFixture;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
-using OpenFeature.Constant;
-using OpenFeature.Error;
-using OpenFeature.Extension;
-using OpenFeature.Model;
-using OpenFeature.Tests.Internal;
+using OpenFeature.SDK.Constant;
+using OpenFeature.SDK.Error;
+using OpenFeature.SDK.Extension;
+using OpenFeature.SDK.Model;
+using OpenFeature.SDK.Tests.Internal;
 using Xunit;
 
-namespace OpenFeature.Tests
+namespace OpenFeature.SDK.Tests
 {
     public class OpenFeatureClientTests
     {
@@ -296,6 +296,13 @@ namespace OpenFeature.Tests
             response.ErrorType.Should().Be(ErrorType.ParseError.GetDescription());
             response.Reason.Should().Be(Reason.Error);
             featureProviderMock.Verify(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
+        }
+
+        [Fact]
+        public void Should_Throw_ArgumentNullException_When_Provider_Is_Null()
+        {
+            TestProvider provider = null;
+            Assert.Throws<ArgumentNullException>(() => new FeatureClient(provider, "test", "test"));
         }
     }
 }

--- a/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 using AutoFixture;
 using FluentAssertions;
-using OpenFeature.Model;
-using OpenFeature.Tests.Internal;
+using OpenFeature.SDK.Model;
+using OpenFeature.SDK.Tests.Internal;
 using Xunit;
 
-namespace OpenFeature.Tests
+namespace OpenFeature.SDK.Tests
 {
     public class OpenFeatureEvaluationContextTests
     {

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -4,12 +4,12 @@ using System.Threading.Tasks;
 using AutoFixture;
 using FluentAssertions;
 using Moq;
-using OpenFeature.Constant;
-using OpenFeature.Model;
-using OpenFeature.Tests.Internal;
+using OpenFeature.SDK.Constant;
+using OpenFeature.SDK.Model;
+using OpenFeature.SDK.Tests.Internal;
 using Xunit;
 
-namespace OpenFeature.Tests
+namespace OpenFeature.SDK.Tests
 {
     public class OpenFeatureHookTests
     {

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -5,12 +5,12 @@ using AutoFixture;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
-using OpenFeature.Constant;
-using OpenFeature.Model;
-using OpenFeature.Tests.Internal;
+using OpenFeature.SDK.Constant;
+using OpenFeature.SDK.Model;
+using OpenFeature.SDK.Tests.Internal;
 using Xunit;
 
-namespace OpenFeature.Tests
+namespace OpenFeature.SDK.Tests
 {
     public class OpenFeatureTests
     {

--- a/test/OpenFeature.Tests/TestImplementations.cs
+++ b/test/OpenFeature.Tests/TestImplementations.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using OpenFeature.Model;
+using OpenFeature.SDK.Model;
 
-namespace OpenFeature.Tests
+namespace OpenFeature.SDK.Tests
 {
     public class TestStructure
     {


### PR DESCRIPTION
It is recommended not to share a namespace and class name to avoid import issues and code like OpenFeature.OpenFeature.Instance.*

Add test case for FeatureClient constructor that tests null provider