### PR TITLE
Bug: FlagEvaluationOptions.HookHints should be optional

### DIFF
--- a/src/OpenFeature/Model/FlagEvaluationOptions.cs
+++ b/src/OpenFeature/Model/FlagEvaluationOptions.cs
@@ -23,22 +23,22 @@ namespace OpenFeature.SDK.Model
         /// Initializes a new instance of the <see cref="FlagEvaluationOptions"/> class.
         /// </summary>
         /// <param name="hooks"></param>
-        /// <param name="hookHints"></param>
-        public FlagEvaluationOptions(IReadOnlyList<Hook> hooks, IReadOnlyDictionary<string, object> hookHints)
+        /// <param name="hookHints">Optional - a list of hints that are passed through the hook lifecycle</param>
+        public FlagEvaluationOptions(IReadOnlyList<Hook> hooks, IReadOnlyDictionary<string, object> hookHints = null)
         {
             this.Hooks = hooks;
-            this.HookHints = hookHints;
+            this.HookHints = hookHints ?? new Dictionary<string, object>();
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FlagEvaluationOptions"/> class.
         /// </summary>
         /// <param name="hook"></param>
-        /// <param name="hookHints"></param>
-        public FlagEvaluationOptions(Hook hook, IReadOnlyDictionary<string, object> hookHints)
+        /// <param name="hookHints">Optional - a list of hints that are passed through the hook lifecycle</param>
+        public FlagEvaluationOptions(Hook hook, IReadOnlyDictionary<string, object> hookHints = null)
         {
             this.Hooks = new[] { hook };
-            this.HookHints = hookHints;
+            this.HookHints = hookHints ?? new Dictionary<string, object>();
         }
     }
 }


### PR DESCRIPTION
Issue #28

As per requirement 4.5.1 of the specification, the hook hints should be option on the FlagEvaluationOptions constructor.

Should default to empty dictionary

https://github.com/open-feature/spec/blob/1bbbb361952adfa4a94618ffe66e943719be9e50/specification/hooks.md#requirement-451
