### PR TITLE
Feat: Implement seperate methods for integer and double

### DIFF
--- a/src/OpenFeature/IFeatureClient.cs
+++ b/src/OpenFeature/IFeatureClient.cs
@@ -15,8 +15,11 @@ namespace OpenFeature.SDK
         Task<string> GetStringValue(string flagKey, string defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
         Task<FlagEvaluationDetails<string>> GetStringDetails(string flagKey, string defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
 
-        Task<int> GetNumberValue(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
-        Task<FlagEvaluationDetails<int>> GetNumberDetails(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<int> GetIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<FlagEvaluationDetails<int>> GetIntegerDetails(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+
+        Task<double> GetDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<FlagEvaluationDetails<double>> GetDoubleDetails(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
 
         Task<T> GetObjectValue<T>(string flagKey, T defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
         Task<FlagEvaluationDetails<T>> GetObjectDetails<T>(string flagKey, T defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);

--- a/src/OpenFeature/IFeatureProvider.cs
+++ b/src/OpenFeature/IFeatureProvider.cs
@@ -39,14 +39,25 @@ namespace OpenFeature.SDK
             EvaluationContext context = null, FlagEvaluationOptions config = null);
 
         /// <summary>
-        /// Resolves a number feature flag
+        /// Resolves a integer feature flag
         /// </summary>
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
         /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        Task<ResolutionDetails<int>> ResolveNumberValue(string flagKey, int defaultValue,
+        Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
+            EvaluationContext context = null, FlagEvaluationOptions config = null);
+
+        /// <summary>
+        /// Resolves a double feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
+        /// <returns><see cref="ResolutionDetails{T}"/></returns>
+        Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null);
 
         /// <summary>

--- a/src/OpenFeature/NoOpProvider.cs
+++ b/src/OpenFeature/NoOpProvider.cs
@@ -23,7 +23,13 @@ namespace OpenFeature.SDK
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public Task<ResolutionDetails<int>> ResolveNumberValue(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
+        public Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
+        {
+            return Task.FromResult(NoOpResponse(flagKey, defaultValue));
+        }
+
+        public Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null,
+            FlagEvaluationOptions config = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -116,28 +116,54 @@ namespace OpenFeature.SDK
                 defaultValue, context, config);
 
         /// <summary>
-        /// Resolves a number feature flag
+        /// Resolves a integer feature flag
         /// </summary>
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        public async Task<int> GetNumberValue(string flagKey, int defaultValue, EvaluationContext context = null,
+        public async Task<int> GetIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null,
             FlagEvaluationOptions config = null) =>
-            (await this.GetNumberDetails(flagKey, defaultValue, context, config)).Value;
+            (await this.GetIntegerDetails(flagKey, defaultValue, context, config)).Value;
 
         /// <summary>
-        /// Resolves a number feature flag
+        /// Resolves a integer feature flag
         /// </summary>
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        public async Task<FlagEvaluationDetails<int>> GetNumberDetails(string flagKey, int defaultValue,
+        public async Task<FlagEvaluationDetails<int>> GetIntegerDetails(string flagKey, int defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
-            await this.EvaluateFlag(this._featureProvider.ResolveNumberValue, FlagValueType.Number, flagKey,
+            await this.EvaluateFlag(this._featureProvider.ResolveIntegerValue, FlagValueType.Number, flagKey,
+                defaultValue, context, config);
+
+        /// <summary>
+        /// Resolves a double feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        public async Task<double> GetDoubleValue(string flagKey, double defaultValue,
+            EvaluationContext context = null,
+            FlagEvaluationOptions config = null) =>
+            (await this.GetDoubleDetails(flagKey, defaultValue, context, config)).Value;
+
+        /// <summary>
+        /// Resolves a double feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        public async Task<FlagEvaluationDetails<double>> GetDoubleDetails(string flagKey, double defaultValue,
+            EvaluationContext context = null, FlagEvaluationOptions config = null) =>
+            await this.EvaluateFlag(this._featureProvider.ResolveDoubleValue, FlagValueType.Number, flagKey,
                 defaultValue, context, config);
 
         /// <summary>

--- a/test/OpenFeature.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderTests.cs
@@ -34,16 +34,23 @@ namespace OpenFeature.SDK.Tests
             var flagName = fixture.Create<string>();
             var defaultBoolValue = fixture.Create<bool>();
             var defaultStringValue = fixture.Create<string>();
-            var defaultNumberValue = fixture.Create<int>();
+            var defaultIntegerValue = fixture.Create<int>();
+            var defaultDoubleValue = fixture.Create<double>();
             var defaultStructureValue = fixture.Create<TestStructure>();
             var provider = new NoOpFeatureProvider();
 
             var boolResolutionDetails = new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await provider.ResolveBooleanValue(flagName, defaultBoolValue)).Should().BeEquivalentTo(boolResolutionDetails);
-            var numberResolutionDetails = new ResolutionDetails<int>(flagName, defaultNumberValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveNumberValue(flagName, defaultNumberValue)).Should().BeEquivalentTo(numberResolutionDetails);
+
+            var integerResolutionDetails = new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            (await provider.ResolveIntegerValue(flagName, defaultIntegerValue)).Should().BeEquivalentTo(integerResolutionDetails);
+
+            var doubleResolutionDetails = new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            (await provider.ResolveDoubleValue(flagName, defaultDoubleValue)).Should().BeEquivalentTo(doubleResolutionDetails);
+
             var stringResolutionDetails = new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await provider.ResolveStringValue(flagName, defaultStringValue)).Should().BeEquivalentTo(stringResolutionDetails);
+
             var structureResolutionDetails = new ResolutionDetails<TestStructure>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await provider.ResolveStructureValue(flagName, defaultStructureValue)).Should().BeEquivalentTo(structureResolutionDetails);
         }
@@ -57,15 +64,19 @@ namespace OpenFeature.SDK.Tests
             var flagName2 = fixture.Create<string>();
             var defaultBoolValue = fixture.Create<bool>();
             var defaultStringValue = fixture.Create<string>();
-            var defaultNumberValue = fixture.Create<int>();
+            var defaultIntegerValue = fixture.Create<int>();
+            var defaultDoubleValue = fixture.Create<double>();
             var defaultStructureValue = fixture.Create<TestStructure>();
             var providerMock = new Mock<IFeatureProvider>();
 
             providerMock.Setup(x => x.ResolveBooleanValue(flagName, defaultBoolValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
                 .ReturnsAsync(new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.General, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
-            providerMock.Setup(x => x.ResolveNumberValue(flagName, defaultNumberValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
-                .ReturnsAsync(new ResolutionDetails<int>(flagName, defaultNumberValue, ErrorType.ParseError, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+            providerMock.Setup(x => x.ResolveIntegerValue(flagName, defaultIntegerValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
+                .ReturnsAsync(new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.ParseError, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+
+            providerMock.Setup(x => x.ResolveDoubleValue(flagName, defaultDoubleValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
+                .ReturnsAsync(new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.ParseError, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
             providerMock.Setup(x => x.ResolveStringValue(flagName, defaultStringValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
                 .ReturnsAsync(new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.TypeMismatch, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
@@ -79,7 +90,8 @@ namespace OpenFeature.SDK.Tests
             var provider = providerMock.Object;
 
             (await provider.ResolveBooleanValue(flagName, defaultBoolValue)).ErrorType.Should().Be(ErrorType.General);
-            (await provider.ResolveNumberValue(flagName, defaultNumberValue)).ErrorType.Should().Be(ErrorType.ParseError);
+            (await provider.ResolveIntegerValue(flagName, defaultIntegerValue)).ErrorType.Should().Be(ErrorType.ParseError);
+            (await provider.ResolveDoubleValue(flagName, defaultDoubleValue)).ErrorType.Should().Be(ErrorType.ParseError);
             (await provider.ResolveStringValue(flagName, defaultStringValue)).ErrorType.Should().Be(ErrorType.TypeMismatch);
             (await provider.ResolveStructureValue(flagName, defaultStructureValue)).ErrorType.Should().Be(ErrorType.FlagNotFound);
             (await provider.ResolveStructureValue(flagName2, defaultStructureValue)).ErrorType.Should().Be(ErrorType.ProviderNotReady);

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -55,8 +55,9 @@ namespace OpenFeature.SDK.Tests
         }
 
         [Fact]
-        [Specification("1.3.1", "The `client` MUST provide methods for flag evaluation, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns the flag value.")]
-        [Specification("1.3.2.1", "The `client` MUST provide methods for typed flag evaluation, including boolean, numeric, string, and structure.")]
+        [Specification("1.3.1", "The `client` MUST provide methods for typed flag evaluation, including boolean, numeric, string, and structure, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns the flag value.")]
+        [Specification("1.3.2.1", "he client SHOULD provide functions for floating-point numbers and integers, consistent with language idioms.")]
+        [Specification("1.3.3", "The `client` SHOULD guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied `default value` should be returned.")]
         public async Task OpenFeatureClient_Should_Allow_Flag_Evaluation()
         {
             var fixture = new Fixture();
@@ -65,7 +66,8 @@ namespace OpenFeature.SDK.Tests
             var flagName = fixture.Create<string>();
             var defaultBoolValue = fixture.Create<bool>();
             var defaultStringValue = fixture.Create<string>();
-            var defaultNumberValue = fixture.Create<int>();
+            var defaultIntegerValue = fixture.Create<int>();
+            var defaultDoubleValue = fixture.Create<double>();
             var defaultStructureValue = fixture.Create<TestStructure>();
             var emptyFlagOptions = new FlagEvaluationOptions(new List<Hook>(), new Dictionary<string, object>());
 
@@ -76,9 +78,13 @@ namespace OpenFeature.SDK.Tests
             (await client.GetBooleanValue(flagName, defaultBoolValue, new EvaluationContext())).Should().Be(defaultBoolValue);
             (await client.GetBooleanValue(flagName, defaultBoolValue, new EvaluationContext(), emptyFlagOptions)).Should().Be(defaultBoolValue);
 
-            (await client.GetNumberValue(flagName, defaultNumberValue)).Should().Be(defaultNumberValue);
-            (await client.GetNumberValue(flagName, defaultNumberValue, new EvaluationContext())).Should().Be(defaultNumberValue);
-            (await client.GetNumberValue(flagName, defaultNumberValue, new EvaluationContext(), emptyFlagOptions)).Should().Be(defaultNumberValue);
+            (await client.GetIntegerValue(flagName, defaultIntegerValue)).Should().Be(defaultIntegerValue);
+            (await client.GetIntegerValue(flagName, defaultIntegerValue, new EvaluationContext())).Should().Be(defaultIntegerValue);
+            (await client.GetIntegerValue(flagName, defaultIntegerValue, new EvaluationContext(), emptyFlagOptions)).Should().Be(defaultIntegerValue);
+
+            (await client.GetDoubleValue(flagName, defaultDoubleValue)).Should().Be(defaultDoubleValue);
+            (await client.GetDoubleValue(flagName, defaultDoubleValue, new EvaluationContext())).Should().Be(defaultDoubleValue);
+            (await client.GetDoubleValue(flagName, defaultDoubleValue, new EvaluationContext(), emptyFlagOptions)).Should().Be(defaultDoubleValue);
 
             (await client.GetStringValue(flagName, defaultStringValue)).Should().Be(defaultStringValue);
             (await client.GetStringValue(flagName, defaultStringValue, new EvaluationContext())).Should().Be(defaultStringValue);
@@ -106,7 +112,8 @@ namespace OpenFeature.SDK.Tests
             var flagName = fixture.Create<string>();
             var defaultBoolValue = fixture.Create<bool>();
             var defaultStringValue = fixture.Create<string>();
-            var defaultNumberValue = fixture.Create<int>();
+            var defaultIntegerValue = fixture.Create<int>();
+            var defaultDoubleValue = fixture.Create<double>();
             var defaultStructureValue = fixture.Create<TestStructure>();
             var emptyFlagOptions = new FlagEvaluationOptions(new List<Hook>(), new Dictionary<string, object>());
 
@@ -118,10 +125,15 @@ namespace OpenFeature.SDK.Tests
             (await client.GetBooleanDetails(flagName, defaultBoolValue, new EvaluationContext())).Should().BeEquivalentTo(boolFlagEvaluationDetails);
             (await client.GetBooleanDetails(flagName, defaultBoolValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
 
-            var numberFlagEvaluationDetails = new FlagEvaluationDetails<int>(flagName, defaultNumberValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await client.GetNumberDetails(flagName, defaultNumberValue)).Should().BeEquivalentTo(numberFlagEvaluationDetails);
-            (await client.GetNumberDetails(flagName, defaultNumberValue, new EvaluationContext())).Should().BeEquivalentTo(numberFlagEvaluationDetails);
-            (await client.GetNumberDetails(flagName, defaultNumberValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(numberFlagEvaluationDetails);
+            var integerFlagEvaluationDetails = new FlagEvaluationDetails<int>(flagName, defaultIntegerValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            (await client.GetIntegerDetails(flagName, defaultIntegerValue)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
+            (await client.GetIntegerDetails(flagName, defaultIntegerValue, new EvaluationContext())).Should().BeEquivalentTo(integerFlagEvaluationDetails);
+            (await client.GetIntegerDetails(flagName, defaultIntegerValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
+
+            var doubleFlagEvaluationDetails = new FlagEvaluationDetails<double>(flagName, defaultDoubleValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            (await client.GetDoubleDetails(flagName, defaultDoubleValue)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
+            (await client.GetDoubleDetails(flagName, defaultDoubleValue, new EvaluationContext())).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
+            (await client.GetDoubleDetails(flagName, defaultDoubleValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
 
             var stringFlagEvaluationDetails = new FlagEvaluationDetails<string>(flagName, defaultStringValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await client.GetStringDetails(flagName, defaultStringValue)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
@@ -236,7 +248,7 @@ namespace OpenFeature.SDK.Tests
 
             var featureProviderMock = new Mock<IFeatureProvider>();
             featureProviderMock
-                .Setup(x => x.ResolveNumberValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
+                .Setup(x => x.ResolveIntegerValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
                 .ReturnsAsync(new ResolutionDetails<int>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
@@ -244,9 +256,9 @@ namespace OpenFeature.SDK.Tests
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetNumberValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetIntegerValue(flagName, defaultValue)).Should().Be(defaultValue);
 
-            featureProviderMock.Verify(x => x.ResolveNumberValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
+            featureProviderMock.Verify(x => x.ResolveIntegerValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
         }
 
         [Fact]

--- a/test/OpenFeature.Tests/TestImplementations.cs
+++ b/test/OpenFeature.Tests/TestImplementations.cs
@@ -60,7 +60,14 @@ namespace OpenFeature.SDK.Tests
             throw new NotImplementedException();
         }
 
-        public Task<ResolutionDetails<int>> ResolveNumberValue(string flagKey, int defaultValue,
+        public Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
+            EvaluationContext context = null,
+            FlagEvaluationOptions config = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
             EvaluationContext context = null,
             FlagEvaluationOptions config = null)
         {


### PR DESCRIPTION
As per the recent spec change https://github.com/open-feature/spec/pull/116

- Add GetDoubleValue, GetDoubleDetails and ResolveDoubleValue to FeatureProvider interface
and FeatureClient
- [Breaking change] Rename GetNumberValue, GetNumberDetails to GetIntegerValue, GetIntegerDetails
- Add tests for new methods
