### PR TITLE
Chore: Remove IHook inteface and just use Hook class

### DIFF
--- a/src/OpenFeature.SDK/Hook.cs
+++ b/src/OpenFeature.SDK/Hook.cs
@@ -5,14 +5,6 @@ using OpenFeature.SDK.Model;
 
 namespace OpenFeature.SDK
 {
-    internal interface IHook
-    {
-        Task<EvaluationContext> Before<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null);
-        Task After<T>(HookContext<T> context, FlagEvaluationDetails<T> details, IReadOnlyDictionary<string, object> hints = null);
-        Task Error<T>(HookContext<T> context, Exception error, IReadOnlyDictionary<string, object> hints = null);
-        Task Finally<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null);
-    }
-
     /// <summary>
     /// The Hook abstract class describes the default implementation for a hook.
     /// A hook has multiple lifecycles, and is called in the following order when normal execution Before, After, Finally.
@@ -27,7 +19,7 @@ namespace OpenFeature.SDK
     ///
     /// </summary>
     /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/hooks.md">Hook Specification</seealso>
-    public abstract class Hook : IHook
+    public abstract class Hook
     {
         /// <summary>
         /// Called immediately before flag evaluation.

--- a/src/OpenFeature.SDK/OpenFeatureClient.cs
+++ b/src/OpenFeature.SDK/OpenFeatureClient.cs
@@ -260,7 +260,7 @@ namespace OpenFeature.SDK
             return evaluation;
         }
 
-        private async Task TriggerBeforeHooks<T>(IReadOnlyList<IHook> hooks, HookContext<T> context,
+        private async Task TriggerBeforeHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
             FlagEvaluationOptions options)
         {
             foreach (var hook in hooks)
@@ -278,7 +278,7 @@ namespace OpenFeature.SDK
             }
         }
 
-        private async Task TriggerAfterHooks<T>(IReadOnlyList<IHook> hooks, HookContext<T> context,
+        private async Task TriggerAfterHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
             FlagEvaluationDetails<T> evaluationDetails, FlagEvaluationOptions options)
         {
             foreach (var hook in hooks)
@@ -287,7 +287,7 @@ namespace OpenFeature.SDK
             }
         }
 
-        private async Task TriggerErrorHooks<T>(IReadOnlyList<IHook> hooks, HookContext<T> context, Exception exception,
+        private async Task TriggerErrorHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context, Exception exception,
             FlagEvaluationOptions options)
         {
             foreach (var hook in hooks)
@@ -303,7 +303,7 @@ namespace OpenFeature.SDK
             }
         }
 
-        private async Task TriggerFinallyHooks<T>(IReadOnlyList<IHook> hooks, HookContext<T> context,
+        private async Task TriggerFinallyHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
             FlagEvaluationOptions options)
         {
             foreach (var hook in hooks)


### PR DESCRIPTION
#27 

There is no reason to have the internal IHook interface anymore. C#8
included default implementations on interfaces but since we are on netstandard2.0
we only have access to C#7.3