### PR TITLE
Feat: Add support for provider hooks

### DIFF
--- a/src/OpenFeature.SDK/FeatureProvider.cs
+++ b/src/OpenFeature.SDK/FeatureProvider.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using OpenFeature.SDK.Model;
 
@@ -8,13 +10,26 @@ namespace OpenFeature.SDK
     /// A provider acts as the translates layer between the generic feature flag structure to a target feature flag system.
     /// </summary>
     /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/providers.md">Provider specification</seealso>
-    public interface IFeatureProvider
+    public abstract class FeatureProvider
     {
+        /// <summary>
+        /// Gets a immutable list of hooks that belong to the provider.
+        /// By default return a empty list
+        ///
+        /// Executed in the order of hooks
+        /// before: API, Client, Invocation, Provider
+        /// after: Provider, Invocation, Client, API
+        /// error (if applicable): Provider, Invocation, Client, API
+        /// finally: Provider, Invocation, Client, API
+        /// </summary>
+        /// <returns></returns>
+        public virtual IReadOnlyList<Hook> GetProviderHooks() => Array.Empty<Hook>();
+
         /// <summary>
         /// Metadata describing the provider.
         /// </summary>
         /// <returns><see cref="Metadata"/></returns>
-        Metadata GetMetadata();
+        public abstract Metadata GetMetadata();
 
         /// <summary>
         /// Resolves a boolean feature flag
@@ -24,7 +39,7 @@ namespace OpenFeature.SDK
         /// <param name="context"><see cref="EvaluationContext"/></param>
         /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
+        public abstract Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null);
 
         /// <summary>
@@ -35,7 +50,7 @@ namespace OpenFeature.SDK
         /// <param name="context"><see cref="EvaluationContext"/></param>
         /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
+        public abstract Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null);
 
         /// <summary>
@@ -46,7 +61,7 @@ namespace OpenFeature.SDK
         /// <param name="context"><see cref="EvaluationContext"/></param>
         /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
+        public abstract Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null);
 
         /// <summary>
@@ -57,7 +72,7 @@ namespace OpenFeature.SDK
         /// <param name="context"><see cref="EvaluationContext"/></param>
         /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
+        public abstract Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null);
 
         /// <summary>
@@ -69,7 +84,7 @@ namespace OpenFeature.SDK
         /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
         /// <typeparam name="T">Type of object</typeparam>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue,
+        public abstract Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null);
     }
 }

--- a/src/OpenFeature.SDK/Model/ResolutionDetails.cs
+++ b/src/OpenFeature.SDK/Model/ResolutionDetails.cs
@@ -3,7 +3,7 @@ using OpenFeature.SDK.Constant;
 namespace OpenFeature.SDK.Model
 {
     /// <summary>
-    /// Defines the contract that the <see cref="IFeatureProvider"/> is required to return
+    /// Defines the contract that the <see cref="FeatureProvider"/> is required to return
     /// Describes the details of the feature flag being evaluated
     /// </summary>
     /// <typeparam name="T">Flag value type</typeparam>

--- a/src/OpenFeature.SDK/NoOpProvider.cs
+++ b/src/OpenFeature.SDK/NoOpProvider.cs
@@ -4,37 +4,37 @@ using OpenFeature.SDK.Model;
 
 namespace OpenFeature.SDK
 {
-    internal class NoOpFeatureProvider : IFeatureProvider
+    internal class NoOpFeatureProvider : FeatureProvider
     {
         private readonly Metadata _metadata = new Metadata(NoOpProvider.NoOpProviderName);
 
-        public Metadata GetMetadata()
+        public override Metadata GetMetadata()
         {
             return this._metadata;
         }
 
-        public Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
+        public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
+        public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
+        public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null,
+        public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null,
             FlagEvaluationOptions config = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
+        public override Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }

--- a/src/OpenFeature.SDK/OpenFeature.cs
+++ b/src/OpenFeature.SDK/OpenFeature.cs
@@ -12,7 +12,7 @@ namespace OpenFeature.SDK
     public sealed class OpenFeature
     {
         private EvaluationContext _evaluationContext = new EvaluationContext();
-        private IFeatureProvider _featureProvider = new NoOpFeatureProvider();
+        private FeatureProvider _featureProvider = new NoOpFeatureProvider();
         private readonly List<Hook> _hooks = new List<Hook>();
 
         /// <summary>
@@ -29,14 +29,14 @@ namespace OpenFeature.SDK
         /// <summary>
         /// Sets the feature provider
         /// </summary>
-        /// <param name="featureProvider">Implementation of <see cref="IFeatureProvider"/></param>
-        public void SetProvider(IFeatureProvider featureProvider) => this._featureProvider = featureProvider;
+        /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
+        public void SetProvider(FeatureProvider featureProvider) => this._featureProvider = featureProvider;
 
         /// <summary>
         /// Gets the feature provider
         /// </summary>
-        /// <returns><see cref="IFeatureProvider"/></returns>
-        public IFeatureProvider GetProvider() => this._featureProvider;
+        /// <returns><see cref="FeatureProvider"/></returns>
+        public FeatureProvider GetProvider() => this._featureProvider;
 
         /// <summary>
         /// Gets providers metadata
@@ -81,7 +81,7 @@ namespace OpenFeature.SDK
         /// Sets the global <see cref="EvaluationContext"/>
         /// </summary>
         /// <param name="context"></param>
-        public void SetContext(EvaluationContext context) => this._evaluationContext = context;
+        public void SetContext(EvaluationContext context) => this._evaluationContext = context ?? new EvaluationContext();
 
         /// <summary>
         /// Gets the global <see cref="EvaluationContext"/>

--- a/src/OpenFeature.SDK/OpenFeatureClient.cs
+++ b/src/OpenFeature.SDK/OpenFeatureClient.cs
@@ -17,19 +17,19 @@ namespace OpenFeature.SDK
     public sealed class FeatureClient : IFeatureClient
     {
         private readonly ClientMetadata _metadata;
-        private readonly IFeatureProvider _featureProvider;
+        private readonly FeatureProvider _featureProvider;
         private readonly List<Hook> _hooks = new List<Hook>();
         private readonly ILogger _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FeatureClient"/> class.
         /// </summary>
-        /// <param name="featureProvider">Feature provider used by client <see cref="IFeatureProvider"/></param>
+        /// <param name="featureProvider">Feature provider used by client <see cref="FeatureProvider"/></param>
         /// <param name="name">Name of client <see cref="ClientMetadata"/></param>
         /// <param name="version">Version of client <see cref="ClientMetadata"/></param>
         /// <param name="logger">Logger used by client</param>
         /// <exception cref="ArgumentNullException">Throws if any of the required parameters are null</exception>
-        public FeatureClient(IFeatureProvider featureProvider, string name, string version, ILogger logger = null)
+        public FeatureClient(FeatureProvider featureProvider, string name, string version, ILogger logger = null)
         {
             this._featureProvider = featureProvider ?? throw new ArgumentNullException(nameof(featureProvider));
             this._metadata = new ClientMetadata(name, version);
@@ -209,6 +209,7 @@ namespace OpenFeature.SDK
                 .Concat(OpenFeature.Instance.GetHooks())
                 .Concat(this._hooks)
                 .Concat(options?.Hooks ?? Enumerable.Empty<Hook>())
+                .Concat(this._featureProvider.GetProviderHooks())
                 .ToList()
                 .AsReadOnly();
 

--- a/test/OpenFeature.SDK.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.SDK.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -1,0 +1,13 @@
+namespace OpenFeature.SDK.Tests
+{
+    public class ClearOpenFeatureInstanceFixture
+    {
+        // Make sure the singleton is cleared between tests
+        public ClearOpenFeatureInstanceFixture()
+        {
+            OpenFeature.Instance.SetContext(null);
+            OpenFeature.Instance.ClearHooks();
+            OpenFeature.Instance.SetProvider(new NoOpFeatureProvider());
+        }
+    }
+}

--- a/test/OpenFeature.SDK.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.SDK.Tests/FeatureProviderTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace OpenFeature.SDK.Tests
 {
-    public class FeatureProviderTests
+    public class FeatureProviderTests : ClearOpenFeatureInstanceFixture
     {
         [Fact]
         [Specification("2.1", "The provider interface MUST define a `metadata` member or accessor, containing a `name` field or accessor of type string, which identifies the provider implementation.")]
@@ -67,7 +67,7 @@ namespace OpenFeature.SDK.Tests
             var defaultIntegerValue = fixture.Create<int>();
             var defaultDoubleValue = fixture.Create<double>();
             var defaultStructureValue = fixture.Create<TestStructure>();
-            var providerMock = new Mock<IFeatureProvider>();
+            var providerMock = new Mock<FeatureProvider>(MockBehavior.Strict);
 
             providerMock.Setup(x => x.ResolveBooleanValue(flagName, defaultBoolValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
                 .ReturnsAsync(new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.General, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));

--- a/test/OpenFeature.SDK.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.SDK.Tests/OpenFeatureClientTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace OpenFeature.SDK.Tests
 {
-    public class OpenFeatureClientTests
+    public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
     {
         [Fact]
         [Specification("1.2.1", "The client MUST provide a method to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.")]
@@ -22,9 +22,9 @@ namespace OpenFeature.SDK.Tests
         {
             var fixture = new Fixture();
             var clientName = fixture.Create<string>();
-            var hook1 = new Mock<Hook>().Object;
-            var hook2 = new Mock<Hook>().Object;
-            var hook3 = new Mock<Hook>().Object;
+            var hook1 = new Mock<Hook>(MockBehavior.Strict).Object;
+            var hook2 = new Mock<Hook>(MockBehavior.Strict).Object;
+            var hook3 = new Mock<Hook>(MockBehavior.Strict).Object;
 
             var client = OpenFeature.Instance.GetClient(clientName);
 
@@ -160,8 +160,8 @@ namespace OpenFeature.SDK.Tests
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<TestStructure>();
-            var mockedFeatureProvider = new Mock<IFeatureProvider>();
-            var mockedLogger = new Mock<ILogger<OpenFeature>>();
+            var mockedFeatureProvider = new Mock<FeatureProvider>(MockBehavior.Strict);
+            var mockedLogger = new Mock<ILogger<OpenFeature>>(MockBehavior.Default);
 
             // This will fail to case a String to TestStructure
             mockedFeatureProvider
@@ -169,6 +169,8 @@ namespace OpenFeature.SDK.Tests
                 .ReturnsAsync(new ResolutionDetails<object>(flagName, "Mismatch"));
             mockedFeatureProvider.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
+            mockedFeatureProvider.Setup(x => x.GetProviderHooks())
+                .Returns(Array.Empty<Hook>());
 
             OpenFeature.Instance.SetProvider(mockedFeatureProvider.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion, mockedLogger.Object);
@@ -198,12 +200,14 @@ namespace OpenFeature.SDK.Tests
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<bool>();
 
-            var featureProviderMock = new Mock<IFeatureProvider>();
+            var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
                 .Setup(x => x.ResolveBooleanValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
                 .ReturnsAsync(new ResolutionDetails<bool>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
+            featureProviderMock.Setup(x => x.GetProviderHooks())
+                .Returns(Array.Empty<Hook>());
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -222,12 +226,14 @@ namespace OpenFeature.SDK.Tests
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<string>();
 
-            var featureProviderMock = new Mock<IFeatureProvider>();
+            var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
                 .Setup(x => x.ResolveStringValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
                 .ReturnsAsync(new ResolutionDetails<string>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
+            featureProviderMock.Setup(x => x.GetProviderHooks())
+                .Returns(Array.Empty<Hook>());
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -238,7 +244,7 @@ namespace OpenFeature.SDK.Tests
         }
 
         [Fact]
-        public async Task Should_Resolve_NumberValue()
+        public async Task Should_Resolve_IntegerValue()
         {
             var fixture = new Fixture();
             var clientName = fixture.Create<string>();
@@ -246,12 +252,14 @@ namespace OpenFeature.SDK.Tests
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<int>();
 
-            var featureProviderMock = new Mock<IFeatureProvider>();
+            var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
                 .Setup(x => x.ResolveIntegerValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
                 .ReturnsAsync(new ResolutionDetails<int>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
+            featureProviderMock.Setup(x => x.GetProviderHooks())
+                .Returns(Array.Empty<Hook>());
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -259,6 +267,32 @@ namespace OpenFeature.SDK.Tests
             (await client.GetIntegerValue(flagName, defaultValue)).Should().Be(defaultValue);
 
             featureProviderMock.Verify(x => x.ResolveIntegerValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
+        }
+
+        [Fact]
+        public async Task Should_Resolve_DoubleValue()
+        {
+            var fixture = new Fixture();
+            var clientName = fixture.Create<string>();
+            var clientVersion = fixture.Create<string>();
+            var flagName = fixture.Create<string>();
+            var defaultValue = fixture.Create<double>();
+
+            var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
+            featureProviderMock
+                .Setup(x => x.ResolveDoubleValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
+                .ReturnsAsync(new ResolutionDetails<double>(flagName, defaultValue));
+            featureProviderMock.Setup(x => x.GetMetadata())
+                .Returns(new Metadata(fixture.Create<string>()));
+            featureProviderMock.Setup(x => x.GetProviderHooks())
+                .Returns(Array.Empty<Hook>());
+
+            OpenFeature.Instance.SetProvider(featureProviderMock.Object);
+            var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
+
+            (await client.GetDoubleValue(flagName, defaultValue)).Should().Be(defaultValue);
+
+            featureProviderMock.Verify(x => x.ResolveDoubleValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
         }
 
         [Fact]
@@ -270,12 +304,14 @@ namespace OpenFeature.SDK.Tests
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<TestStructure>();
 
-            var featureProviderMock = new Mock<IFeatureProvider>();
+            var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
                 .Setup(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
                 .ReturnsAsync(new ResolutionDetails<TestStructure>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
+            featureProviderMock.Setup(x => x.GetProviderHooks())
+                .Returns(Array.Empty<Hook>());
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -294,12 +330,14 @@ namespace OpenFeature.SDK.Tests
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<TestStructure>();
 
-            var featureProviderMock = new Mock<IFeatureProvider>();
+            var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
                 .Setup(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
                 .Throws(new FeatureProviderException(ErrorType.ParseError));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
+            featureProviderMock.Setup(x => x.GetProviderHooks())
+                .Returns(Array.Empty<Hook>());
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);

--- a/test/OpenFeature.SDK.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.SDK.Tests/OpenFeatureTests.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using AutoFixture;
 using FluentAssertions;
-using Microsoft.Extensions.Logging;
 using Moq;
 using OpenFeature.SDK.Constant;
 using OpenFeature.SDK.Model;
@@ -12,7 +8,7 @@ using Xunit;
 
 namespace OpenFeature.SDK.Tests
 {
-    public class OpenFeatureTests
+    public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
     {
         [Fact]
         [Specification("1.1.1", "The API, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the API are present at runtime.")]
@@ -29,10 +25,10 @@ namespace OpenFeature.SDK.Tests
         public void OpenFeature_Should_Add_Hooks()
         {
             var openFeature = OpenFeature.Instance;
-            var hook1 = new Mock<Hook>().Object;
-            var hook2 = new Mock<Hook>().Object;
-            var hook3 = new Mock<Hook>().Object;
-            var hook4 = new Mock<Hook>().Object;
+            var hook1 = new Mock<Hook>(MockBehavior.Strict).Object;
+            var hook2 = new Mock<Hook>(MockBehavior.Strict).Object;
+            var hook3 = new Mock<Hook>(MockBehavior.Strict).Object;
+            var hook4 = new Mock<Hook>(MockBehavior.Strict).Object;
 
             openFeature.ClearHooks();
 

--- a/test/OpenFeature.SDK.Tests/TestImplementations.cs
+++ b/test/OpenFeature.SDK.Tests/TestImplementations.cs
@@ -37,48 +37,54 @@ namespace OpenFeature.SDK.Tests
         }
     }
 
-    public class TestProvider : IFeatureProvider
+    public class TestProvider : FeatureProvider
     {
+        private readonly List<Hook> _hooks = new List<Hook>();
+
         public static string Name => "test-provider";
 
-        public Metadata GetMetadata()
+        public void AddHook(Hook hook) => this._hooks.Add(hook);
+
+        public override IReadOnlyList<Hook> GetProviderHooks() => this._hooks.AsReadOnly();
+
+        public override Metadata GetMetadata()
         {
             return new Metadata(Name);
         }
 
-        public Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
+        public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
             EvaluationContext context = null,
             FlagEvaluationOptions config = null)
         {
-            throw new NotImplementedException();
+            return Task.FromResult(new ResolutionDetails<bool>(flagKey, defaultValue));
         }
 
-        public Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
+        public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
             EvaluationContext context = null,
             FlagEvaluationOptions config = null)
         {
-            throw new NotImplementedException();
+            return Task.FromResult(new ResolutionDetails<string>(flagKey, defaultValue));
         }
 
-        public Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
+        public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
             EvaluationContext context = null,
             FlagEvaluationOptions config = null)
         {
-            throw new NotImplementedException();
+            return Task.FromResult(new ResolutionDetails<int>(flagKey, defaultValue));
         }
 
-        public Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
+        public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
             EvaluationContext context = null,
             FlagEvaluationOptions config = null)
         {
-            throw new NotImplementedException();
+            return Task.FromResult(new ResolutionDetails<double>(flagKey, defaultValue));
         }
 
-        public Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue,
+        public override Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue,
             EvaluationContext context = null,
             FlagEvaluationOptions config = null)
         {
-            throw new NotImplementedException();
+            return Task.FromResult(new ResolutionDetails<T>(flagKey, defaultValue));
         }
     }
 }


### PR DESCRIPTION
Implement provider hook spec https://github.com/open-feature/spec/pull/119

- [Breaking] Remove IFeatureProvider interface in favor of FeatureProvider abstract class
so default implementations can exist
- Make sure Provider hooks are called in the correct order
- Use strick mocking mode so sequence is validated correctly
- Update test cases for provider hooks support