### PR TITLE
Chore: Add github action to perform release

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "minver-cli": {
+      "version": "4.1.0",
+      "commands": [
+        "minver"
+      ]
+    }
+  }
+}

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -3,7 +3,7 @@ name: Release Package
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release-package:

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,36 @@
+name: Release Package
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release-package:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        version: [net462,net6.0]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Restore Tools
+      run: dotnet tool restore
+
+    - name: Install dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --configuration Release --no-restore -p:Deterministic=true
+
+    - name: Pack
+      run: dotnet pack OpenFeature.proj --configuration Release --no-build
+
+    - name: Publish to Nuget
+      run: |
+        VERSION=$(dotnet minver -v e)
+        dotnet nuget push OpenFeature.{VERSION}.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/OpenFeature.SDK.sln
+++ b/OpenFeature.SDK.sln
@@ -12,7 +12,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{72005F60
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 		.github\workflows\dotnet-format.yml = .github\workflows\dotnet-format.yml
 		.github\workflows\linux-ci.yml = .github\workflows\linux-ci.yml
-		.github\workflows\prerelease-package.yml = .github\workflows\prerelease-package.yml
 		.github\workflows\release-package.yml = .github\workflows\release-package.yml
 		.github\workflows\windows-ci.yml = .github\workflows\windows-ci.yml
 	EndProjectSection


### PR DESCRIPTION
This action will trigger when a new tag is push match {major}.{minor}.{patch}
semver format.


This that need to be setup
-  [x] NUGET_API_KEY needs to be set in github secrets, A key can be generated on nuget.org
- [x] We need to lockdown tag pushing if we haven't already done so https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules