### PR TITLE
chore: add dotnet-format to the tools

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "minver"
       ]
+    },
+    "dotnet-format": {
+      "version": "5.1.250801",
+      "commands": [
+        "dotnet-format"
+      ]
     }
   }
 }


### PR DESCRIPTION
This is just to make it easier to install dotnet format if you don't have it globally installed, also ensures the correct version is used.

`dotnet tool restore` will install both dotnet format and minver