### PR TITLE
Removed evaluation options from provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,36 +53,31 @@ public class MyFeatureProvider : FeatureProvider
     }
 
     public Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
-        EvaluationContext context = null,
-        FlagEvaluationOptions config = null)
+        EvaluationContext context = null)
     {
         // code to resolve boolean details
     }
 
     public Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
-        EvaluationContext context = null,
-        FlagEvaluationOptions config = null)
+        EvaluationContext context = null)
     {
         // code to resolve string details
     }
 
     public Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
-        EvaluationContext context = null,
-        FlagEvaluationOptions config = null)
+        EvaluationContext context = null)
     {
         // code to resolve integer details
     }
 
     public Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
-        EvaluationContext context = null,
-        FlagEvaluationOptions config = null)
+        EvaluationContext context = null)
     {
         // code to resolve integer details
     }
 
     public Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue,
-        EvaluationContext context = null,
-        FlagEvaluationOptions config = null)
+        EvaluationContext context = null)
     {
         // code to resolve object details
     }

--- a/src/OpenFeature.SDK/FeatureProvider.cs
+++ b/src/OpenFeature.SDK/FeatureProvider.cs
@@ -37,10 +37,9 @@ namespace OpenFeature.SDK
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
-        /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
         public abstract Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
-            EvaluationContext context = null, FlagEvaluationOptions config = null);
+            EvaluationContext context = null);
 
         /// <summary>
         /// Resolves a string feature flag
@@ -48,10 +47,9 @@ namespace OpenFeature.SDK
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
-        /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
         public abstract Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
-            EvaluationContext context = null, FlagEvaluationOptions config = null);
+            EvaluationContext context = null);
 
         /// <summary>
         /// Resolves a integer feature flag
@@ -59,10 +57,9 @@ namespace OpenFeature.SDK
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
-        /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
         public abstract Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
-            EvaluationContext context = null, FlagEvaluationOptions config = null);
+            EvaluationContext context = null);
 
         /// <summary>
         /// Resolves a double feature flag
@@ -70,10 +67,9 @@ namespace OpenFeature.SDK
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
-        /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
         public abstract Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
-            EvaluationContext context = null, FlagEvaluationOptions config = null);
+            EvaluationContext context = null);
 
         /// <summary>
         /// Resolves a structured feature flag
@@ -81,10 +77,9 @@ namespace OpenFeature.SDK
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
-        /// <param name="config"><see cref="FlagEvaluationOptions"/></param>
         /// <typeparam name="T">Type of object</typeparam>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
         public abstract Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue,
-            EvaluationContext context = null, FlagEvaluationOptions config = null);
+            EvaluationContext context = null);
     }
 }

--- a/src/OpenFeature.SDK/NoOpProvider.cs
+++ b/src/OpenFeature.SDK/NoOpProvider.cs
@@ -13,28 +13,27 @@ namespace OpenFeature.SDK
             return this._metadata;
         }
 
-        public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
+        public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
+        public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
+        public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null,
-            FlagEvaluationOptions config = null)
+        public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null)
+        public override Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue, EvaluationContext context = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }

--- a/src/OpenFeature.SDK/OpenFeatureClient.cs
+++ b/src/OpenFeature.SDK/OpenFeatureClient.cs
@@ -201,7 +201,7 @@ namespace OpenFeature.SDK
                 defaultValue, context, config);
 
         private async Task<FlagEvaluationDetails<T>> EvaluateFlag<T>(
-            Func<string, T, EvaluationContext, FlagEvaluationOptions, Task<ResolutionDetails<T>>> resolveValueDelegate,
+            Func<string, T, EvaluationContext, Task<ResolutionDetails<T>>> resolveValueDelegate,
             FlagValueType flagValueType, string flagKey, T defaultValue, EvaluationContext context = null,
             FlagEvaluationOptions options = null)
         {
@@ -244,7 +244,7 @@ namespace OpenFeature.SDK
                 await this.TriggerBeforeHooks(allHooks, hookContext, options);
 
                 evaluation =
-                    (await resolveValueDelegate.Invoke(flagKey, defaultValue, hookContext.EvaluationContext, options))
+                    (await resolveValueDelegate.Invoke(flagKey, defaultValue, hookContext.EvaluationContext))
                     .ToFlagEvaluationDetails();
 
                 await this.TriggerAfterHooks(allHooksReversed, hookContext, evaluation, options);

--- a/test/OpenFeature.SDK.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.SDK.Tests/FeatureProviderTests.cs
@@ -21,7 +21,7 @@ namespace OpenFeature.SDK.Tests
         }
 
         [Fact]
-        [Specification("2.2", "The `feature provider` interface MUST define methods to resolve flag values, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns a `flag resolution` structure.")]
+        [Specification("2.2", "The `feature provider` interface MUST define methods to resolve flag values, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required) and `evaluation context` (optional), which returns a `flag resolution` structure.")]
         [Specification("2.3.1", "The `feature provider` interface MUST define methods for typed flag resolution, including boolean, numeric, string, and structure.")]
         [Specification("2.4", "In cases of normal execution, the `provider` MUST populate the `flag resolution` structure's `value` field with the resolved flag value.")]
         [Specification("2.5", "In cases of normal execution, the `provider` SHOULD populate the `flag resolution` structure's `variant` field with a string identifier corresponding to the returned flag value.")]
@@ -69,22 +69,22 @@ namespace OpenFeature.SDK.Tests
             var defaultStructureValue = fixture.Create<TestStructure>();
             var providerMock = new Mock<FeatureProvider>(MockBehavior.Strict);
 
-            providerMock.Setup(x => x.ResolveBooleanValue(flagName, defaultBoolValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
+            providerMock.Setup(x => x.ResolveBooleanValue(flagName, defaultBoolValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.General, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
-            providerMock.Setup(x => x.ResolveIntegerValue(flagName, defaultIntegerValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
+            providerMock.Setup(x => x.ResolveIntegerValue(flagName, defaultIntegerValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.ParseError, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
-            providerMock.Setup(x => x.ResolveDoubleValue(flagName, defaultDoubleValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
+            providerMock.Setup(x => x.ResolveDoubleValue(flagName, defaultDoubleValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.ParseError, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
-            providerMock.Setup(x => x.ResolveStringValue(flagName, defaultStringValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
+            providerMock.Setup(x => x.ResolveStringValue(flagName, defaultStringValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.TypeMismatch, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
-            providerMock.Setup(x => x.ResolveStructureValue(flagName, defaultStructureValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
+            providerMock.Setup(x => x.ResolveStructureValue(flagName, defaultStructureValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<TestStructure>(flagName, defaultStructureValue, ErrorType.FlagNotFound, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
-            providerMock.Setup(x => x.ResolveStructureValue(flagName2, defaultStructureValue, It.IsAny<EvaluationContext>(), It.IsAny<FlagEvaluationOptions>()))
+            providerMock.Setup(x => x.ResolveStructureValue(flagName2, defaultStructureValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<TestStructure>(flagName, defaultStructureValue, ErrorType.ProviderNotReady, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
             var provider = providerMock.Object;

--- a/test/OpenFeature.SDK.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.SDK.Tests/OpenFeatureClientTests.cs
@@ -165,7 +165,7 @@ namespace OpenFeature.SDK.Tests
 
             // This will fail to case a String to TestStructure
             mockedFeatureProvider
-                .Setup(x => x.ResolveStructureValue<object>(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
+                .Setup(x => x.ResolveStructureValue<object>(flagName, defaultValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<object>(flagName, "Mismatch"));
             mockedFeatureProvider.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
@@ -179,7 +179,7 @@ namespace OpenFeature.SDK.Tests
             evaluationDetails.ErrorType.Should().Be(ErrorType.TypeMismatch.GetDescription());
 
             mockedFeatureProvider
-                .Verify(x => x.ResolveStructureValue<object>(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
+                .Verify(x => x.ResolveStructureValue<object>(flagName, defaultValue, It.IsAny<EvaluationContext>()), Times.Once);
 
             mockedLogger.Verify(
                 x => x.Log(
@@ -202,7 +202,7 @@ namespace OpenFeature.SDK.Tests
 
             var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
-                .Setup(x => x.ResolveBooleanValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
+                .Setup(x => x.ResolveBooleanValue(flagName, defaultValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<bool>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
@@ -214,7 +214,7 @@ namespace OpenFeature.SDK.Tests
 
             (await client.GetBooleanValue(flagName, defaultValue)).Should().Be(defaultValue);
 
-            featureProviderMock.Verify(x => x.ResolveBooleanValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
+            featureProviderMock.Verify(x => x.ResolveBooleanValue(flagName, defaultValue, It.IsAny<EvaluationContext>()), Times.Once);
         }
 
         [Fact]
@@ -228,7 +228,7 @@ namespace OpenFeature.SDK.Tests
 
             var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
-                .Setup(x => x.ResolveStringValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
+                .Setup(x => x.ResolveStringValue(flagName, defaultValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<string>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
@@ -240,7 +240,7 @@ namespace OpenFeature.SDK.Tests
 
             (await client.GetStringValue(flagName, defaultValue)).Should().Be(defaultValue);
 
-            featureProviderMock.Verify(x => x.ResolveStringValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
+            featureProviderMock.Verify(x => x.ResolveStringValue(flagName, defaultValue, It.IsAny<EvaluationContext>()), Times.Once);
         }
 
         [Fact]
@@ -254,7 +254,7 @@ namespace OpenFeature.SDK.Tests
 
             var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
-                .Setup(x => x.ResolveIntegerValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
+                .Setup(x => x.ResolveIntegerValue(flagName, defaultValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<int>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
@@ -266,7 +266,7 @@ namespace OpenFeature.SDK.Tests
 
             (await client.GetIntegerValue(flagName, defaultValue)).Should().Be(defaultValue);
 
-            featureProviderMock.Verify(x => x.ResolveIntegerValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
+            featureProviderMock.Verify(x => x.ResolveIntegerValue(flagName, defaultValue, It.IsAny<EvaluationContext>()), Times.Once);
         }
 
         [Fact]
@@ -280,7 +280,7 @@ namespace OpenFeature.SDK.Tests
 
             var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
-                .Setup(x => x.ResolveDoubleValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
+                .Setup(x => x.ResolveDoubleValue(flagName, defaultValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<double>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
@@ -292,7 +292,7 @@ namespace OpenFeature.SDK.Tests
 
             (await client.GetDoubleValue(flagName, defaultValue)).Should().Be(defaultValue);
 
-            featureProviderMock.Verify(x => x.ResolveDoubleValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
+            featureProviderMock.Verify(x => x.ResolveDoubleValue(flagName, defaultValue, It.IsAny<EvaluationContext>()), Times.Once);
         }
 
         [Fact]
@@ -306,7 +306,7 @@ namespace OpenFeature.SDK.Tests
 
             var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
-                .Setup(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
+                .Setup(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<TestStructure>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
@@ -318,7 +318,7 @@ namespace OpenFeature.SDK.Tests
 
             (await client.GetObjectValue(flagName, defaultValue)).Should().Be(defaultValue);
 
-            featureProviderMock.Verify(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
+            featureProviderMock.Verify(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>()), Times.Once);
         }
 
         [Fact]
@@ -332,7 +332,7 @@ namespace OpenFeature.SDK.Tests
 
             var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
-                .Setup(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null))
+                .Setup(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>()))
                 .Throws(new FeatureProviderException(ErrorType.ParseError));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
@@ -345,7 +345,7 @@ namespace OpenFeature.SDK.Tests
 
             response.ErrorType.Should().Be(ErrorType.ParseError.GetDescription());
             response.Reason.Should().Be(Reason.Error);
-            featureProviderMock.Verify(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>(), null), Times.Once);
+            featureProviderMock.Verify(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>()), Times.Once);
         }
 
         [Fact]

--- a/test/OpenFeature.SDK.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.SDK.Tests/OpenFeatureHookTests.cs
@@ -235,7 +235,7 @@ namespace OpenFeature.SDK.Tests
             provider.Setup(x => x.GetProviderHooks())
                 .Returns(Array.Empty<Hook>());
 
-            provider.Setup(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>(), null))
+            provider.Setup(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>()))
             .ReturnsAsync(new ResolutionDetails<bool>("test", true));
 
             OpenFeature.Instance.SetProvider(provider.Object);
@@ -257,7 +257,7 @@ namespace OpenFeature.SDK.Tests
                 && y.Get<bool>(propClientToOverwrite)
                 && y.Get<bool>(propHook)
                 && y.Get<bool>(propInvocationToOverwrite)
-            ), It.IsAny<FlagEvaluationOptions>()), Times.Once);
+            )), Times.Once);
         }
 
         [Fact]
@@ -315,7 +315,7 @@ namespace OpenFeature.SDK.Tests
                 .ReturnsAsync(new EvaluationContext());
 
             featureProvider.InSequence(sequence)
-                .Setup(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>(), null))
+                .Setup(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<bool>("test", false));
 
             hook.InSequence(sequence).Setup(x => x.After(It.IsAny<HookContext<It.IsAnyType>>(),
@@ -333,7 +333,7 @@ namespace OpenFeature.SDK.Tests
             hook.Verify(x => x.Before(It.IsAny<HookContext<It.IsAnyType>>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
             hook.Verify(x => x.After(It.IsAny<HookContext<It.IsAnyType>>(), It.IsAny<FlagEvaluationDetails<It.IsAnyType>>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
             hook.Verify(x => x.Finally(It.IsAny<HookContext<It.IsAnyType>>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
-            featureProvider.Verify(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>(), null), Times.Once);
+            featureProvider.Verify(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>()), Times.Once);
         }
 
         [Fact]
@@ -384,8 +384,7 @@ namespace OpenFeature.SDK.Tests
                 .ReturnsAsync(new EvaluationContext());
 
             featureProvider.InSequence(sequence)
-                .Setup(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>(),
-                    null))
+                .Setup(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<bool>("test", false));
 
             hook2.InSequence(sequence).Setup(x => x.After(It.IsAny<HookContext<It.IsAnyType>>(),
@@ -413,7 +412,7 @@ namespace OpenFeature.SDK.Tests
 
             hook1.Verify(x => x.Before(It.IsAny<HookContext<It.IsAnyType>>(), null), Times.Once);
             hook2.Verify(x => x.Before(It.IsAny<HookContext<It.IsAnyType>>(), null), Times.Once);
-            featureProvider.Verify(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>(), null), Times.Once);
+            featureProvider.Verify(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>()), Times.Once);
             hook2.Verify(x => x.After(It.IsAny<HookContext<It.IsAnyType>>(), It.IsAny<FlagEvaluationDetails<It.IsAnyType>>(), null), Times.Once);
             hook1.Verify(x => x.After(It.IsAny<HookContext<It.IsAnyType>>(), It.IsAny<FlagEvaluationDetails<It.IsAnyType>>(), null), Times.Once);
             hook2.Verify(x => x.Finally(It.IsAny<HookContext<It.IsAnyType>>(), null), Times.Once);
@@ -444,8 +443,7 @@ namespace OpenFeature.SDK.Tests
                 .ReturnsAsync(new EvaluationContext());
 
             featureProvider1.InSequence(sequence)
-                .Setup(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>(),
-                    null))
+                .Setup(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>()))
                 .Throws(new Exception());
 
             hook2.InSequence(sequence).Setup(x =>
@@ -528,7 +526,7 @@ namespace OpenFeature.SDK.Tests
                 .ReturnsAsync(evaluationContext);
 
             featureProvider.InSequence(sequence)
-                .Setup(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>(), flagOptions))
+                .Setup(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>()))
                 .ReturnsAsync(new ResolutionDetails<bool>("test", false));
 
             hook.InSequence(sequence)
@@ -547,7 +545,7 @@ namespace OpenFeature.SDK.Tests
             hook.Verify(x => x.Before(It.IsAny<HookContext<It.IsAnyType>>(), defaultEmptyHookHints), Times.Once);
             hook.Verify(x => x.After(It.IsAny<HookContext<It.IsAnyType>>(), It.IsAny<FlagEvaluationDetails<It.IsAnyType>>(), defaultEmptyHookHints), Times.Once);
             hook.Verify(x => x.Finally(It.IsAny<HookContext<It.IsAnyType>>(), defaultEmptyHookHints), Times.Once);
-            featureProvider.Verify(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>(), flagOptions), Times.Once);
+            featureProvider.Verify(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<EvaluationContext>()), Times.Once);
         }
 
         [Fact]

--- a/test/OpenFeature.SDK.Tests/TestImplementations.cs
+++ b/test/OpenFeature.SDK.Tests/TestImplementations.cs
@@ -53,36 +53,31 @@ namespace OpenFeature.SDK.Tests
         }
 
         public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
-            EvaluationContext context = null,
-            FlagEvaluationOptions config = null)
+            EvaluationContext context = null)
         {
             return Task.FromResult(new ResolutionDetails<bool>(flagKey, defaultValue));
         }
 
         public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
-            EvaluationContext context = null,
-            FlagEvaluationOptions config = null)
+            EvaluationContext context = null)
         {
             return Task.FromResult(new ResolutionDetails<string>(flagKey, defaultValue));
         }
 
         public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
-            EvaluationContext context = null,
-            FlagEvaluationOptions config = null)
+            EvaluationContext context = null)
         {
             return Task.FromResult(new ResolutionDetails<int>(flagKey, defaultValue));
         }
 
         public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
-            EvaluationContext context = null,
-            FlagEvaluationOptions config = null)
+            EvaluationContext context = null)
         {
             return Task.FromResult(new ResolutionDetails<double>(flagKey, defaultValue));
         }
 
         public override Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue,
-            EvaluationContext context = null,
-            FlagEvaluationOptions config = null)
+            EvaluationContext context = null)
         {
             return Task.FromResult(new ResolutionDetails<T>(flagKey, defaultValue));
         }


### PR DESCRIPTION
#51

As per spec 0.4 remove flag evaluation option from the provider

- Update FeatureProvider
- Update doco
