### PR TITLE
Rework EvaluationContext to use Structure type

### DIFF
--- a/src/OpenFeature.SDK/FeatureProvider.cs
+++ b/src/OpenFeature.SDK/FeatureProvider.cs
@@ -72,14 +72,13 @@ namespace OpenFeature.SDK
             EvaluationContext context = null);
 
         /// <summary>
-        /// Resolves a structured feature flag
+        /// Resolves a structure feature flag
         /// </summary>
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
-        /// <typeparam name="T">Type of object</typeparam>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue,
+        public abstract Task<ResolutionDetails<Structure>> ResolveStructureValue(string flagKey, Structure defaultValue,
             EvaluationContext context = null);
     }
 }

--- a/src/OpenFeature.SDK/IFeatureClient.cs
+++ b/src/OpenFeature.SDK/IFeatureClient.cs
@@ -21,7 +21,7 @@ namespace OpenFeature.SDK
         Task<double> GetDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
         Task<FlagEvaluationDetails<double>> GetDoubleDetails(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
 
-        Task<T> GetObjectValue<T>(string flagKey, T defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
-        Task<FlagEvaluationDetails<T>> GetObjectDetails<T>(string flagKey, T defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<Structure> GetObjectValue(string flagKey, Structure defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<FlagEvaluationDetails<Structure>> GetObjectDetails(string flagKey, Structure defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
     }
 }

--- a/src/OpenFeature.SDK/Model/EvaluationContext.cs
+++ b/src/OpenFeature.SDK/Model/EvaluationContext.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace OpenFeature.SDK.Model
 {
@@ -10,55 +8,111 @@ namespace OpenFeature.SDK.Model
     /// to the feature flag evaluation context.
     /// </summary>
     /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/evaluation-context.md">Evaluation context</seealso>
-    public class EvaluationContext : IEnumerable<KeyValuePair<string, object>>
+    public class EvaluationContext
     {
-        private readonly Dictionary<string, object> _internalContext = new Dictionary<string, object>();
+        private readonly Structure _structure = new Structure();
 
         /// <summary>
-        /// Add a new key value pair to the evaluation context
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="value">Value</param>
-        /// <typeparam name="T">Type of value</typeparam>
-        public void Add<T>(string key, T value)
-        {
-            this._internalContext.Add(key, value);
-        }
-
-        /// <summary>
-        /// Remove an object by key from the evaluation context
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <exception cref="ArgumentException">Key is null</exception>
-        public bool Remove(string key)
-        {
-            return this._internalContext.Remove(key);
-        }
-
-        /// <summary>
-        /// Get an object from evaluation context by key
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <typeparam name="T">Type of object</typeparam>
-        /// <returns>Object casted to provided type</returns>
-        /// <exception cref="InvalidCastException">A type mismatch occurs</exception>
-        public T Get<T>(string key)
-        {
-            return (T)this._internalContext[key];
-        }
-
-        /// <summary>
-        /// Get value by key
         ///
-        /// Note: this will not case the object to type.
-        /// This will need to be done by the caller
         /// </summary>
-        /// <param name="key">Key</param>
-        public object this[string key]
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public Value GetValue(string key) => this._structure.GetValue(key);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        public void Remove(string key) => this._structure.Remove(key);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public EvaluationContext Add(string key, bool value)
         {
-            get => this._internalContext[key];
-            set => this._internalContext[key] = value;
+            this._structure.Add(key, value);
+            return this;
         }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public EvaluationContext Add(string key, int value)
+        {
+            this._structure.Add(key, value);
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public EvaluationContext Add(string key, string value)
+        {
+            this._structure.Add(key, value);
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public EvaluationContext Add(string key, double value)
+        {
+            this._structure.Add(key, value);
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public EvaluationContext Add(string key, DateTime value)
+        {
+            this._structure.Add(key, value);
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public EvaluationContext Add(string key, Structure value)
+        {
+            this._structure.Add(key, value);
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public EvaluationContext Add(string key, List<Value> value)
+        {
+            this._structure.Add(key, value);
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public int Count => this._structure.Count;
 
         /// <summary>
         /// Merges provided evaluation context into this one
@@ -68,38 +122,26 @@ namespace OpenFeature.SDK.Model
         /// <param name="other"><see cref="EvaluationContext"/></param>
         public void Merge(EvaluationContext other)
         {
-            foreach (var key in other._internalContext.Keys)
+            foreach (var key in other._structure.Keys)
             {
-                if (this._internalContext.ContainsKey(key))
+                if (this._structure.ContainsKey(key))
                 {
-                    this._internalContext[key] = other._internalContext[key];
+                    this._structure[key] = other._structure[key];
                 }
                 else
                 {
-                    this._internalContext.Add(key, other._internalContext[key]);
+                    this._structure.Add(key, other._structure[key]);
                 }
             }
         }
 
         /// <summary>
-        /// Returns the number of items in the evaluation context
+        ///
         /// </summary>
-        public int Count => this._internalContext.Count;
-
-        /// <summary>
-        /// Returns an enumerator that iterates through the evaluation context
-        /// </summary>
-        /// <returns>Enumerator of the Evaluation context</returns>
-        [ExcludeFromCodeCoverage]
-        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        /// <returns></returns>
+        public IEnumerator<KeyValuePair<string, Value>> GetEnumerator()
         {
-            return this._internalContext.GetEnumerator();
-        }
-
-        [ExcludeFromCodeCoverage]
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
+            return this._structure.GetEnumerator();
         }
     }
 }

--- a/src/OpenFeature.SDK/Model/EvaluationContext.cs
+++ b/src/OpenFeature.SDK/Model/EvaluationContext.cs
@@ -13,20 +13,44 @@ namespace OpenFeature.SDK.Model
         private readonly Structure _structure = new Structure();
 
         /// <summary>
-        ///
+        /// Gets the Value at the specified key
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
         public Value GetValue(string key) => this._structure.GetValue(key);
 
         /// <summary>
-        ///
+        /// Bool indicating if the specified key exists in the evaluation context
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public bool ContainsKey(string key) => this._structure.ContainsKey(key);
+
+        /// <summary>
+        /// Removes the Value at the specified key
         /// </summary>
         /// <param name="key"></param>
         public void Remove(string key) => this._structure.Remove(key);
 
         /// <summary>
-        ///
+        /// Gets the value associated with the specified key
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public bool TryGetValue(string key, out Value value) => this._structure.TryGetValue(key, out value);
+
+        /// <summary>
+        /// Gets all values as a Dictionary
+        /// </summary>
+        /// <returns></returns>
+        public IDictionary<string, Value> AsDictionary()
+        {
+            return new Dictionary<string, Value>(this._structure.AsDictionary());
+        }
+
+        /// <summary>
+        /// Add a new bool Value to the evaluation context
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -38,19 +62,7 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public EvaluationContext Add(string key, int value)
-        {
-            this._structure.Add(key, value);
-            return this;
-        }
-
-        /// <summary>
-        ///
+        /// Add a new string Value to the evaluation context
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -62,7 +74,19 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Add a new int Value to the evaluation context
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public EvaluationContext Add(string key, int value)
+        {
+            this._structure.Add(key, value);
+            return this;
+        }
+
+        /// <summary>
+        /// Add a new double Value to the evaluation context
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -74,7 +98,7 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Add a new DateTime Value to the evaluation context
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -86,7 +110,7 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Add a new Structure Value to the evaluation context
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -98,7 +122,7 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Add a new List Value to the evaluation context
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -110,14 +134,25 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Add a new Value to the evaluation context
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public EvaluationContext Add(string key, Value value)
+        {
+            this._structure.Add(key, value);
+            return this;
+        }
+
+        /// <summary>
+        /// Return a count of all values
         /// </summary>
         public int Count => this._structure.Count;
 
         /// <summary>
-        /// Merges provided evaluation context into this one
-        ///
-        /// Any duplicate keys will be overwritten
+        /// Merges provided evaluation context into this one.
+        /// Any duplicate keys will be overwritten.
         /// </summary>
         /// <param name="other"><see cref="EvaluationContext"/></param>
         public void Merge(EvaluationContext other)
@@ -136,7 +171,7 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Return an enumerator for all values
         /// </summary>
         /// <returns></returns>
         public IEnumerator<KeyValuePair<string, Value>> GetEnumerator()

--- a/src/OpenFeature.SDK/Model/Structure.cs
+++ b/src/OpenFeature.SDK/Model/Structure.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/OpenFeature.SDK/Model/Structure.cs
+++ b/src/OpenFeature.SDK/Model/Structure.cs
@@ -6,14 +6,14 @@ using System.Diagnostics.CodeAnalysis;
 namespace OpenFeature.SDK.Model
 {
     /// <summary>
-    ///
+    /// Structure represents a map of Values
     /// </summary>
     public class Structure : IEnumerable<KeyValuePair<string, Value>>
     {
         private readonly Dictionary<string, Value> _attributes;
 
         /// <summary>
-        ///
+        /// Creates a new structure with an empty set of attributes
         /// </summary>
         public Structure()
         {
@@ -21,7 +21,7 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Creates a new structure with the supplied attributes
         /// </summary>
         /// <param name="attributes"></param>
         public Structure(IDictionary<string, Value> attributes)
@@ -30,28 +30,28 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Gets the Value at the specified key
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
         public Value GetValue(string key) => this._attributes[key];
 
         /// <summary>
-        ///
+        /// Bool indicating if the specified key exists in the structure
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
         public bool ContainsKey(string key) => this._attributes.ContainsKey(key);
 
         /// <summary>
-        ///
+        /// Removes the Value at the specified key
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
         public bool Remove(string key) => this._attributes.Remove(key);
 
         /// <summary>
-        ///
+        /// Gets the value associated with the specified key.
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -59,7 +59,16 @@ namespace OpenFeature.SDK.Model
         public bool TryGetValue(string key, out Value value) => this._attributes.TryGetValue(key, out value);
 
         /// <summary>
-        ///
+        /// Gets all values as a Dictionary
+        /// </summary>
+        /// <returns></returns>
+        public IDictionary<string, Value> AsDictionary()
+        {
+            return new Dictionary<string, Value>(this._attributes);
+        }
+
+        /// <summary>
+        /// Return the value at the supplied index
         /// </summary>
         /// <param name="key"></param>
         public Value this[string key]
@@ -69,17 +78,17 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Return a collection containing all the keys in this structure
         /// </summary>
         public ICollection<string> Keys => this._attributes.Keys;
 
         /// <summary>
-        ///
+        /// Return a collection containing all the values in this structure
         /// </summary>
         public ICollection<Value> Values => this._attributes.Values;
 
         /// <summary>
-        ///
+        /// Add a new bool Value to the structure
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -91,7 +100,7 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Add a new string Value to the structure
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -103,7 +112,7 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Add a new int Value to the structure
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -115,7 +124,7 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Add a new double Value to the structure
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -127,7 +136,7 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Add a new DateTime Value to the structure
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -139,7 +148,7 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Add a new Structure Value to the structure
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -151,36 +160,36 @@ namespace OpenFeature.SDK.Model
         }
 
         /// <summary>
-        ///
+        /// Add a new List Value to the structure
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        public Structure Add(string key, List<Value> value)
+        public Structure Add(string key, IList<Value> value)
         {
             this._attributes.Add(key, new Value(value));
             return this;
         }
 
         /// <summary>
-        ///
+        /// Add a new Value to the structure
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <returns></returns>
         public Structure Add(string key, Value value)
         {
-            this._attributes.Add(key, value);
+            this._attributes.Add(key, new Value(value));
             return this;
         }
 
         /// <summary>
-        ///
+        /// Return a count of all values
         /// </summary>
         public int Count => this._attributes.Count;
 
         /// <summary>
-        ///
+        /// Return an enumerator for all values
         /// </summary>
         /// <returns></returns>
         public IEnumerator<KeyValuePair<string, Value>> GetEnumerator()

--- a/src/OpenFeature.SDK/Model/Structure.cs
+++ b/src/OpenFeature.SDK/Model/Structure.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OpenFeature.SDK.Model
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public class Structure : IEnumerable<KeyValuePair<string, Value>>
+    {
+        private readonly Dictionary<string, Value> _attributes;
+
+        /// <summary>
+        ///
+        /// </summary>
+        public Structure()
+        {
+            this._attributes = new Dictionary<string, Value>();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="attributes"></param>
+        public Structure(IDictionary<string, Value> attributes)
+        {
+            this._attributes = new Dictionary<string, Value>(attributes);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public Value GetValue(string key) => this._attributes[key];
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public bool ContainsKey(string key) => this._attributes.ContainsKey(key);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public bool Remove(string key) => this._attributes.Remove(key);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public bool TryGetValue(string key, out Value value) => this._attributes.TryGetValue(key, out value);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        public Value this[string key]
+        {
+            get => this._attributes[key];
+            set => this._attributes[key] = value;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public ICollection<string> Keys => this._attributes.Keys;
+
+        /// <summary>
+        ///
+        /// </summary>
+        public ICollection<Value> Values => this._attributes.Values;
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public Structure Add(string key, bool value)
+        {
+            this._attributes.Add(key, new Value(value));
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public Structure Add(string key, string value)
+        {
+            this._attributes.Add(key, new Value(value));
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public Structure Add(string key, int value)
+        {
+            this._attributes.Add(key, new Value(value));
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public Structure Add(string key, double value)
+        {
+            this._attributes.Add(key, new Value(value));
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public Structure Add(string key, DateTime value)
+        {
+            this._attributes.Add(key, new Value(value));
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public Structure Add(string key, Structure value)
+        {
+            this._attributes.Add(key, new Value(value));
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public Structure Add(string key, List<Value> value)
+        {
+            this._attributes.Add(key, new Value(value));
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public Structure Add(string key, Value value)
+        {
+            this._attributes.Add(key, value);
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public int Count => this._attributes.Count;
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerator<KeyValuePair<string, Value>> GetEnumerator()
+        {
+            return this._attributes.GetEnumerator();
+        }
+
+        [ExcludeFromCodeCoverage]
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/src/OpenFeature.SDK/Model/Structure.cs
+++ b/src/OpenFeature.SDK/Model/Structure.cs
@@ -32,36 +32,36 @@ namespace OpenFeature.SDK.Model
         /// <summary>
         /// Gets the Value at the specified key
         /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <returns><see cref="Value"/></returns>
         public Value GetValue(string key) => this._attributes[key];
 
         /// <summary>
         /// Bool indicating if the specified key exists in the structure
         /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <returns><see cref="bool"/>indicating the presence of the key.</returns>
         public bool ContainsKey(string key) => this._attributes.ContainsKey(key);
 
         /// <summary>
         /// Removes the Value at the specified key
         /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <returns><see cref="bool"/> indicating the presence of the key.</returns>
         public bool Remove(string key) => this._attributes.Remove(key);
 
         /// <summary>
-        /// Gets the value associated with the specified key.
+        /// Gets the value associated with the specified key by mutating the supplied value.
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <param name="value">value to be mutated</param>
+        /// <returns><see cref="bool"/> indicating the presence of the key.</returns>
         public bool TryGetValue(string key, out Value value) => this._attributes.TryGetValue(key, out value);
 
         /// <summary>
         /// Gets all values as a Dictionary
         /// </summary>
-        /// <returns></returns>
+        /// <returns>New <see cref="IDictionary"/> representation of this Structure</returns>
         public IDictionary<string, Value> AsDictionary()
         {
             return new Dictionary<string, Value>(this._attributes);
@@ -70,7 +70,7 @@ namespace OpenFeature.SDK.Model
         /// <summary>
         /// Return the value at the supplied index
         /// </summary>
-        /// <param name="key"></param>
+        /// <param name="key">The key of the value to be retrieved</param>
         public Value this[string key]
         {
             get => this._attributes[key];
@@ -90,9 +90,9 @@ namespace OpenFeature.SDK.Model
         /// <summary>
         /// Add a new bool Value to the structure
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <param name="value">The value to be added</param>
+        /// <returns>This <see cref="Structure"/></returns>
         public Structure Add(string key, bool value)
         {
             this._attributes.Add(key, new Value(value));
@@ -102,9 +102,9 @@ namespace OpenFeature.SDK.Model
         /// <summary>
         /// Add a new string Value to the structure
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <param name="value">The value to be added</param>
+        /// <returns>This <see cref="Structure"/></returns>
         public Structure Add(string key, string value)
         {
             this._attributes.Add(key, new Value(value));
@@ -114,9 +114,9 @@ namespace OpenFeature.SDK.Model
         /// <summary>
         /// Add a new int Value to the structure
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <param name="value">The value to be added</param>
+        /// <returns>This <see cref="Structure"/></returns>
         public Structure Add(string key, int value)
         {
             this._attributes.Add(key, new Value(value));
@@ -126,9 +126,9 @@ namespace OpenFeature.SDK.Model
         /// <summary>
         /// Add a new double Value to the structure
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <param name="value">The value to be added</param>
+        /// <returns>This <see cref="Structure"/></returns>
         public Structure Add(string key, double value)
         {
             this._attributes.Add(key, new Value(value));
@@ -138,9 +138,9 @@ namespace OpenFeature.SDK.Model
         /// <summary>
         /// Add a new DateTime Value to the structure
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <param name="value">The value to be added</param>
+        /// <returns>This <see cref="Structure"/></returns>
         public Structure Add(string key, DateTime value)
         {
             this._attributes.Add(key, new Value(value));
@@ -150,9 +150,9 @@ namespace OpenFeature.SDK.Model
         /// <summary>
         /// Add a new Structure Value to the structure
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <param name="value">The value to be added</param>
+        /// <returns>This <see cref="Structure"/></returns>
         public Structure Add(string key, Structure value)
         {
             this._attributes.Add(key, new Value(value));
@@ -162,9 +162,9 @@ namespace OpenFeature.SDK.Model
         /// <summary>
         /// Add a new List Value to the structure
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <param name="value">The value to be added</param>
+        /// <returns>This <see cref="Structure"/></returns>
         public Structure Add(string key, IList<Value> value)
         {
             this._attributes.Add(key, new Value(value));
@@ -174,9 +174,9 @@ namespace OpenFeature.SDK.Model
         /// <summary>
         /// Add a new Value to the structure
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <param name="key">The key of the value to be retrieved</param>
+        /// <param name="value">The value to be added</param>
+        /// <returns>This <see cref="Structure"/></returns>
         public Structure Add(string key, Value value)
         {
             this._attributes.Add(key, new Value(value));
@@ -191,7 +191,7 @@ namespace OpenFeature.SDK.Model
         /// <summary>
         /// Return an enumerator for all values
         /// </summary>
-        /// <returns></returns>
+        /// <returns><see cref="IEnumerator"/></returns>
         public IEnumerator<KeyValuePair<string, Value>> GetEnumerator()
         {
             return this._attributes.GetEnumerator();

--- a/src/OpenFeature.SDK/Model/Value.cs
+++ b/src/OpenFeature.SDK/Model/Value.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 

--- a/src/OpenFeature.SDK/Model/Value.cs
+++ b/src/OpenFeature.SDK/Model/Value.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace OpenFeature.SDK.Model
+{
+    /// <summary>
+    ///  Values server as a return type for provider objects. Providers may deal in protobufs or JSON in the backend and
+    ///  have no reasonable way to convert that into a type that users care about (e.g. an instance of `T`). This
+    ///  intermediate representation should provide a good medium of exchange.
+    /// </summary>
+    public class Value
+    {
+        private readonly object _innerValue;
+
+        /// <summary>
+        /// Sets the inner value to Value type
+        /// </summary>
+        /// <param name="value"><see cref="Value">Value type</see></param>
+        public Value(Value value) => this._innerValue = value;
+
+        /// <summary>
+        /// Set the inner value to a bool type
+        /// </summary>
+        /// <param name="value"><see cref="bool">Bool type</see></param>
+        public Value(bool value) => this._innerValue = value;
+
+        /// <summary>
+        /// Set the inner value to a int type
+        /// </summary>
+        /// <param name="value"><see cref="int">Int type</see></param>
+        public Value(int value) => this._innerValue = value;
+
+        /// <summary>
+        /// Set the inner value to a double type
+        /// </summary>
+        /// <param name="value"><see cref="double">Double type</see></param>
+        public Value(double value) => this._innerValue = value;
+
+        /// <summary>
+        /// Set the inner value to a string type
+        /// </summary>
+        /// <param name="value"><see cref="string">String type</see></param>
+        public Value(string value) => this._innerValue = value;
+
+        /// <summary>
+        /// Set the inner value to a structure type
+        /// </summary>
+        /// <param name="value"><see cref="Structure">Structure type</see></param>
+        public Value(Structure value) => this._innerValue = value;
+
+        /// <summary>
+        /// Set the inner value to a list type
+        /// </summary>
+        /// <param name="value"><see cref="List{T}">List type</see></param>
+        public Value(IList value) => this._innerValue = value;
+
+        /// <summary>
+        /// Set the inner value to a DateTime type
+        /// </summary>
+        /// <param name="value"><see cref="DateTime">DateTime type</see></param>
+        public Value(DateTime value) => this._innerValue = value;
+
+        /// <summary>
+        /// Determines if inner value is int
+        /// </summary>
+        /// <returns><see cref="bool">True if value is int</see></returns>
+        public bool IsInteger() => this._innerValue is int;
+
+        /// <summary>
+        /// Determines if inner value is bool
+        /// </summary>
+        /// <returns><see cref="bool">True if value is bool</see></returns>
+        public bool IsBoolean() => this._innerValue is bool;
+
+        /// <summary>
+        /// Determines if inner value is double
+        /// </summary>
+        /// <returns><see cref="bool">True if value is double</see></returns>
+        public bool IsDouble() => this._innerValue is double;
+
+        /// <summary>
+        /// Determines if inner value is string
+        /// </summary>
+        /// <returns><see cref="bool">True if value is string</see></returns>
+        public bool IsString() => this._innerValue is string;
+
+        /// <summary>
+        /// Determines if inner value is <see cref="Structure">Structure</see>
+        /// </summary>
+        /// <returns><see cref="bool">True if value is <see cref="Structure">Structure</see></see></returns>
+        public bool IsStructure() => this._innerValue is Structure;
+
+        /// <summary>
+        /// Determines if inner value is list
+        /// </summary>
+        /// <returns><see cref="bool">True if value is list</see></returns>
+        public bool IsList() => this._innerValue is IList;
+
+        /// <summary>
+        /// Determines if inner value is DateTime
+        /// </summary>
+        /// <returns><see cref="bool">True if value is DateTime</see></returns>
+        public bool IsDateTime() => this._innerValue is DateTime;
+
+        /// <summary>
+        /// Returns the underlying int value
+        /// Value will be null if it isn't a integer
+        /// </summary>
+        /// <returns>Value as int</returns>
+        public int? AsInteger() => this.IsInteger() ? (int?)this._innerValue : null;
+
+        /// <summary>
+        /// Returns the underlying bool value
+        /// Value will be null if it isn't a bool
+        /// </summary>
+        /// <returns>Value as bool</returns>
+        public bool? AsBoolean() => this.IsBoolean() ? (bool?)this._innerValue : null;
+
+        /// <summary>
+        /// Returns the underlying double value
+        /// Value will be null if it isn't a double
+        /// </summary>
+        /// <returns>Value as int</returns>
+        public double? AsDouble() => this.IsDouble() ? (double?)this._innerValue : null;
+
+        /// <summary>
+        /// Returns the underlying string value
+        /// Value will be null if it isn't a string
+        /// </summary>
+        /// <returns>Value as string</returns>
+        public string AsString() => this.IsString() ? (string)this._innerValue : null;
+
+        /// <summary>
+        /// Returns the underlying Structure value
+        /// Value will be null if it isn't a Structure
+        /// </summary>
+        /// <returns>Value as Structure</returns>
+        public Structure AsStructure() => this.IsStructure() ? (Structure)this._innerValue : null;
+
+        /// <summary>
+        /// Returns the underlying List value
+        /// Value will be null if it isn't a List
+        /// </summary>
+        /// <returns>Value as List</returns>
+        public IList AsList() => this.IsList() ? (IList)this._innerValue : null;
+
+        /// <summary>
+        /// Returns the underlying DateTime value
+        /// Value will be null if it isn't a DateTime
+        /// </summary>
+        /// <returns>Value as DateTime</returns>
+        public DateTime? AsDateTime() => this.IsDateTime() ? (DateTime?)this._innerValue : null;
+    }
+}

--- a/src/OpenFeature.SDK/Model/Value.cs
+++ b/src/OpenFeature.SDK/Model/Value.cs
@@ -30,10 +30,10 @@ namespace OpenFeature.SDK.Model
         public Value(bool value) => this._innerValue = value;
 
         /// <summary>
-        /// Creates a Value with the inner set to int type
+        /// Creates a Value by converting value to a double
         /// </summary>
         /// <param name="value"><see cref="int">Int type</see></param>
-        public Value(int value) => this._innerValue = value;
+        public Value(int value) => this._innerValue = Convert.ToDouble(value);
 
         /// <summary>
         /// Creates a Value with the inner set to double type
@@ -72,22 +72,16 @@ namespace OpenFeature.SDK.Model
         public bool IsNull() => this._innerValue is null;
 
         /// <summary>
-        /// Determines if inner value is int
-        /// </summary>
-        /// <returns><see cref="bool">True if value is int</see></returns>
-        public bool IsInteger() => this._innerValue is int;
-
-        /// <summary>
         /// Determines if inner value is bool
         /// </summary>
         /// <returns><see cref="bool">True if value is bool</see></returns>
         public bool IsBoolean() => this._innerValue is bool;
 
         /// <summary>
-        /// Determines if inner value is double
+        /// Determines if inner value is numeric
         /// </summary>
         /// <returns><see cref="bool">True if value is double</see></returns>
-        public bool IsDouble() => this._innerValue is double;
+        public bool IsNumber() => this._innerValue is double;
 
         /// <summary>
         /// Determines if inner value is string
@@ -118,7 +112,7 @@ namespace OpenFeature.SDK.Model
         /// Value will be null if it isn't a integer
         /// </summary>
         /// <returns>Value as int</returns>
-        public int? AsInteger() => this.IsInteger() ? (int?)this._innerValue : null;
+        public int? AsInteger() => this.IsNumber() ? (int?)Convert.ToInt32((double?)this._innerValue) : null;
 
         /// <summary>
         /// Returns the underlying bool value
@@ -132,7 +126,7 @@ namespace OpenFeature.SDK.Model
         /// Value will be null if it isn't a double
         /// </summary>
         /// <returns>Value as int</returns>
-        public double? AsDouble() => this.IsDouble() ? (double?)this._innerValue : null;
+        public double? AsDouble() => this.IsNumber() ? (double?)this._innerValue : null;
 
         /// <summary>
         /// Returns the underlying string value

--- a/src/OpenFeature.SDK/Model/Value.cs
+++ b/src/OpenFeature.SDK/Model/Value.cs
@@ -5,61 +5,71 @@ using System.Collections.Generic;
 namespace OpenFeature.SDK.Model
 {
     /// <summary>
-    ///  Values server as a return type for provider objects. Providers may deal in protobufs or JSON in the backend and
-    ///  have no reasonable way to convert that into a type that users care about (e.g. an instance of `T`). This
-    ///  intermediate representation should provide a good medium of exchange.
+    ///  Values serve as a return type for provider objects. Providers may deal in JSON, protobuf, XML or some other data-interchange format.
+    ///  This intermediate representation provides a good medium of exchange.
     /// </summary>
     public class Value
     {
         private readonly object _innerValue;
 
         /// <summary>
-        /// Sets the inner value to Value type
+        /// Creates a Value with the inner value set to null
         /// </summary>
-        /// <param name="value"><see cref="Value">Value type</see></param>
-        public Value(Value value) => this._innerValue = value;
+        public Value() => this._innerValue = null;
 
         /// <summary>
-        /// Set the inner value to a bool type
+        /// Creates a Value with the inner value to the inner value of the value param
+        /// </summary>
+        /// <param name="value"><see cref="Value">Value type</see></param>
+        public Value(Value value) => this._innerValue = value._innerValue;
+
+        /// <summary>
+        /// Creates a Value with the inner set to bool type
         /// </summary>
         /// <param name="value"><see cref="bool">Bool type</see></param>
         public Value(bool value) => this._innerValue = value;
 
         /// <summary>
-        /// Set the inner value to a int type
+        /// Creates a Value with the inner set to int type
         /// </summary>
         /// <param name="value"><see cref="int">Int type</see></param>
         public Value(int value) => this._innerValue = value;
 
         /// <summary>
-        /// Set the inner value to a double type
+        /// Creates a Value with the inner set to double type
         /// </summary>
         /// <param name="value"><see cref="double">Double type</see></param>
         public Value(double value) => this._innerValue = value;
 
         /// <summary>
-        /// Set the inner value to a string type
+        /// Creates a Value with the inner set to string type
         /// </summary>
         /// <param name="value"><see cref="string">String type</see></param>
         public Value(string value) => this._innerValue = value;
 
         /// <summary>
-        /// Set the inner value to a structure type
+        /// Creates a Value with the inner set to structure type
         /// </summary>
         /// <param name="value"><see cref="Structure">Structure type</see></param>
         public Value(Structure value) => this._innerValue = value;
 
         /// <summary>
-        /// Set the inner value to a list type
+        /// Creates a Value with the inner set to list type
         /// </summary>
         /// <param name="value"><see cref="List{T}">List type</see></param>
-        public Value(IList value) => this._innerValue = value;
+        public Value(IList<Value> value) => this._innerValue = value;
 
         /// <summary>
-        /// Set the inner value to a DateTime type
+        /// Creates a Value with the inner set to DateTime type
         /// </summary>
         /// <param name="value"><see cref="DateTime">DateTime type</see></param>
         public Value(DateTime value) => this._innerValue = value;
+
+        /// <summary>
+        /// Determines if inner value is null
+        /// </summary>
+        /// <returns><see cref="bool">True if value is null</see></returns>
+        public bool IsNull() => this._innerValue is null;
 
         /// <summary>
         /// Determines if inner value is int
@@ -143,7 +153,7 @@ namespace OpenFeature.SDK.Model
         /// Value will be null if it isn't a List
         /// </summary>
         /// <returns>Value as List</returns>
-        public IList AsList() => this.IsList() ? (IList)this._innerValue : null;
+        public IList<Value> AsList() => this.IsList() ? (IList<Value>)this._innerValue : null;
 
         /// <summary>
         /// Returns the underlying DateTime value

--- a/src/OpenFeature.SDK/NoOpProvider.cs
+++ b/src/OpenFeature.SDK/NoOpProvider.cs
@@ -33,7 +33,7 @@ namespace OpenFeature.SDK
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<Structure>> ResolveStructureValue(string flagKey, Structure defaultValue, EvaluationContext context = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }

--- a/src/OpenFeature.SDK/OpenFeatureClient.cs
+++ b/src/OpenFeature.SDK/OpenFeatureClient.cs
@@ -176,26 +176,26 @@ namespace OpenFeature.SDK
                 defaultValue, context, config);
 
         /// <summary>
-        /// Resolves a object feature flag
+        /// Resolves a structure object feature flag
         /// </summary>
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        public async Task<T> GetObjectValue<T>(string flagKey, T defaultValue, EvaluationContext context = null,
+        public async Task<Structure> GetObjectValue(string flagKey, Structure defaultValue, EvaluationContext context = null,
             FlagEvaluationOptions config = null) =>
             (await this.GetObjectDetails(flagKey, defaultValue, context, config)).Value;
 
         /// <summary>
-        /// Resolves a object feature flag
+        /// Resolves a structure object feature flag
         /// </summary>
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        public async Task<FlagEvaluationDetails<T>> GetObjectDetails<T>(string flagKey, T defaultValue,
+        public async Task<FlagEvaluationDetails<Structure>> GetObjectDetails(string flagKey, Structure defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
             await this.EvaluateFlag(this._featureProvider.ResolveStructureValue, FlagValueType.Object, flagKey,
                 defaultValue, context, config);

--- a/test/OpenFeature.SDK.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.SDK.Tests/FeatureProviderTests.cs
@@ -36,7 +36,7 @@ namespace OpenFeature.SDK.Tests
             var defaultStringValue = fixture.Create<string>();
             var defaultIntegerValue = fixture.Create<int>();
             var defaultDoubleValue = fixture.Create<double>();
-            var defaultStructureValue = fixture.Create<TestStructure>();
+            var defaultStructureValue = fixture.Create<Structure>();
             var provider = new NoOpFeatureProvider();
 
             var boolResolutionDetails = new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
@@ -51,7 +51,7 @@ namespace OpenFeature.SDK.Tests
             var stringResolutionDetails = new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await provider.ResolveStringValue(flagName, defaultStringValue)).Should().BeEquivalentTo(stringResolutionDetails);
 
-            var structureResolutionDetails = new ResolutionDetails<TestStructure>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            var structureResolutionDetails = new ResolutionDetails<Structure>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await provider.ResolveStructureValue(flagName, defaultStructureValue)).Should().BeEquivalentTo(structureResolutionDetails);
         }
 
@@ -66,7 +66,7 @@ namespace OpenFeature.SDK.Tests
             var defaultStringValue = fixture.Create<string>();
             var defaultIntegerValue = fixture.Create<int>();
             var defaultDoubleValue = fixture.Create<double>();
-            var defaultStructureValue = fixture.Create<TestStructure>();
+            var defaultStructureValue = fixture.Create<Structure>();
             var providerMock = new Mock<FeatureProvider>(MockBehavior.Strict);
 
             providerMock.Setup(x => x.ResolveBooleanValue(flagName, defaultBoolValue, It.IsAny<EvaluationContext>()))
@@ -82,10 +82,10 @@ namespace OpenFeature.SDK.Tests
                 .ReturnsAsync(new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.TypeMismatch, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
             providerMock.Setup(x => x.ResolveStructureValue(flagName, defaultStructureValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<TestStructure>(flagName, defaultStructureValue, ErrorType.FlagNotFound, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+                .ReturnsAsync(new ResolutionDetails<Structure>(flagName, defaultStructureValue, ErrorType.FlagNotFound, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
             providerMock.Setup(x => x.ResolveStructureValue(flagName2, defaultStructureValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<TestStructure>(flagName, defaultStructureValue, ErrorType.ProviderNotReady, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+                .ReturnsAsync(new ResolutionDetails<Structure>(flagName, defaultStructureValue, ErrorType.ProviderNotReady, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
             var provider = providerMock.Object;
 

--- a/test/OpenFeature.SDK.Tests/OpenFeature.SDK.Tests.csproj
+++ b/test/OpenFeature.SDK.Tests/OpenFeature.SDK.Tests.csproj
@@ -12,6 +12,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="$(CoverletCollectorVer)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVer)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="Moq" Version="$(MoqVer)" />

--- a/test/OpenFeature.SDK.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.SDK.Tests/OpenFeatureClientTests.cs
@@ -68,7 +68,7 @@ namespace OpenFeature.SDK.Tests
             var defaultStringValue = fixture.Create<string>();
             var defaultIntegerValue = fixture.Create<int>();
             var defaultDoubleValue = fixture.Create<double>();
-            var defaultStructureValue = fixture.Create<TestStructure>();
+            var defaultStructureValue = fixture.Create<Structure>();
             var emptyFlagOptions = new FlagEvaluationOptions(new List<Hook>(), new Dictionary<string, object>());
 
             OpenFeature.Instance.SetProvider(new NoOpFeatureProvider());
@@ -114,7 +114,7 @@ namespace OpenFeature.SDK.Tests
             var defaultStringValue = fixture.Create<string>();
             var defaultIntegerValue = fixture.Create<int>();
             var defaultDoubleValue = fixture.Create<double>();
-            var defaultStructureValue = fixture.Create<TestStructure>();
+            var defaultStructureValue = fixture.Create<Structure>();
             var emptyFlagOptions = new FlagEvaluationOptions(new List<Hook>(), new Dictionary<string, object>());
 
             OpenFeature.Instance.SetProvider(new NoOpFeatureProvider());
@@ -140,7 +140,7 @@ namespace OpenFeature.SDK.Tests
             (await client.GetStringDetails(flagName, defaultStringValue, new EvaluationContext())).Should().BeEquivalentTo(stringFlagEvaluationDetails);
             (await client.GetStringDetails(flagName, defaultStringValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
 
-            var structureFlagEvaluationDetails = new FlagEvaluationDetails<TestStructure>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            var structureFlagEvaluationDetails = new FlagEvaluationDetails<Structure>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await client.GetObjectDetails(flagName, defaultStructureValue)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
             (await client.GetObjectDetails(flagName, defaultStructureValue, new EvaluationContext())).Should().BeEquivalentTo(structureFlagEvaluationDetails);
             (await client.GetObjectDetails(flagName, defaultStructureValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
@@ -159,14 +159,14 @@ namespace OpenFeature.SDK.Tests
             var clientName = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
-            var defaultValue = fixture.Create<TestStructure>();
+            var defaultValue = fixture.Create<Structure>();
             var mockedFeatureProvider = new Mock<FeatureProvider>(MockBehavior.Strict);
             var mockedLogger = new Mock<ILogger<OpenFeature>>(MockBehavior.Default);
 
             // This will fail to case a String to TestStructure
             mockedFeatureProvider
-                .Setup(x => x.ResolveStructureValue<object>(flagName, defaultValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<object>(flagName, "Mismatch"));
+                .Setup(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>()))
+                .Throws<InvalidCastException>();
             mockedFeatureProvider.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
             mockedFeatureProvider.Setup(x => x.GetProviderHooks())
@@ -179,7 +179,7 @@ namespace OpenFeature.SDK.Tests
             evaluationDetails.ErrorType.Should().Be(ErrorType.TypeMismatch.GetDescription());
 
             mockedFeatureProvider
-                .Verify(x => x.ResolveStructureValue<object>(flagName, defaultValue, It.IsAny<EvaluationContext>()), Times.Once);
+                .Verify(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>()), Times.Once);
 
             mockedLogger.Verify(
                 x => x.Log(
@@ -302,12 +302,12 @@ namespace OpenFeature.SDK.Tests
             var clientName = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
-            var defaultValue = fixture.Create<TestStructure>();
+            var defaultValue = fixture.Create<Structure>();
 
             var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
                 .Setup(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<TestStructure>(flagName, defaultValue));
+                .ReturnsAsync(new ResolutionDetails<Structure>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.Setup(x => x.GetProviderHooks())
@@ -316,7 +316,7 @@ namespace OpenFeature.SDK.Tests
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetObjectValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetObjectValue(flagName, defaultValue)).Should().Equal(defaultValue);
 
             featureProviderMock.Verify(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>()), Times.Once);
         }
@@ -328,7 +328,7 @@ namespace OpenFeature.SDK.Tests
             var clientName = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
-            var defaultValue = fixture.Create<TestStructure>();
+            var defaultValue = fixture.Create<Structure>();
 
             var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock

--- a/test/OpenFeature.SDK.Tests/OpenFeatureEvaluationContextTests.cs
+++ b/test/OpenFeature.SDK.Tests/OpenFeatureEvaluationContextTests.cs
@@ -67,7 +67,7 @@ namespace OpenFeature.SDK.Tests
             value1.AsString().Should().Be("value");
 
             var value2 = context.GetValue("key2");
-            value2.IsInteger().Should().BeTrue();
+            value2.IsNumber().Should().BeTrue();
             value2.AsInteger().Should().Be(1);
 
             var value3 = context.GetValue("key3");
@@ -83,7 +83,7 @@ namespace OpenFeature.SDK.Tests
             value5.AsStructure().Should().Equal(structure);
 
             var value6 = context.GetValue("key6");
-            value6.IsDouble().Should().BeTrue();
+            value6.IsNumber().Should().BeTrue();
             value6.AsDouble().Should().Be(1.0);
         }
 

--- a/test/OpenFeature.SDK.Tests/StructureTests.cs
+++ b/test/OpenFeature.SDK.Tests/StructureTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using OpenFeature.SDK.Model;
+using Xunit;
+
+namespace OpenFeature.SDK.Tests
+{
+    public class StructureTests
+    {
+        [Fact]
+        public void No_Arg_Should_Contain_Empty_Attributes()
+        {
+            Structure structure = new Structure();
+            Assert.Equal(0, structure.Count);
+            Assert.Equal(0, structure.AsDictionary().Keys.Count);
+        }
+
+        [Fact]
+        public void Dictionary_Arg_Should_Contain_New_Dictionary()
+        {
+            string KEY = "key";
+            IDictionary<string, Value> dictionary = new Dictionary<string, Value>(){
+                { KEY, new Value(KEY) }
+            };
+            Structure structure = new Structure(dictionary);
+            Assert.Equal(KEY, structure.AsDictionary()[KEY].AsString());
+            Assert.NotSame(structure.AsDictionary(), dictionary); // should be a copy
+        }
+
+        [Fact]
+        public void Add_And_Get_Add_And_Return_Values()
+        {
+            String BOOL_KEY = "bool";
+            String STRING_KEY = "string";
+            String INT_KEY = "int";
+            String DOUBLE_KEY = "double";
+            String DATE_KEY = "date";
+            String STRUCT_KEY = "struct";
+            String LIST_KEY = "list";
+            String VALUE_KEY = "value";
+
+            bool BOOL_VAL = true;
+            String STRING_VAL = "val";
+            int INT_VAL = 13;
+            double DOUBLE_VAL = .5;
+            DateTime DATE_VAL = DateTime.Now;
+            Structure STRUCT_VAL = new Structure();
+            IList<Value> LIST_VAL = new List<Value>();
+            Value VALUE_VAL = new Value();
+
+            Structure structure = new Structure();
+            structure.Add(BOOL_KEY, BOOL_VAL);
+            structure.Add(STRING_KEY, STRING_VAL);
+            structure.Add(INT_KEY, INT_VAL);
+            structure.Add(DOUBLE_KEY, DOUBLE_VAL);
+            structure.Add(DATE_KEY, DATE_VAL);
+            structure.Add(STRUCT_KEY, STRUCT_VAL);
+            structure.Add(LIST_KEY, LIST_VAL);
+            structure.Add(VALUE_KEY, VALUE_VAL);
+
+            Assert.Equal(BOOL_VAL, structure.GetValue(BOOL_KEY).AsBoolean());
+            Assert.Equal(STRING_VAL, structure.GetValue(STRING_KEY).AsString());
+            Assert.Equal(INT_VAL, structure.GetValue(INT_KEY).AsInteger());
+            Assert.Equal(DOUBLE_VAL, structure.GetValue(DOUBLE_KEY).AsDouble());
+            Assert.Equal(DATE_VAL, structure.GetValue(DATE_KEY).AsDateTime());
+            Assert.Equal(STRUCT_VAL, structure.GetValue(STRUCT_KEY).AsStructure());
+            Assert.Equal(LIST_VAL, structure.GetValue(LIST_KEY).AsList());
+            Assert.True(structure.GetValue(VALUE_KEY).IsNull());
+        }
+
+        [Fact]
+        public void Remove_Should_Remove_Value()
+        {
+            String KEY = "key";
+            bool VAL = true;
+
+            Structure structure = new Structure();
+            structure.Add(KEY, VAL);
+            Assert.Equal(1, structure.Count);
+            structure.Remove(KEY);
+            Assert.Equal(0, structure.Count);
+        }
+
+        [Fact]
+        public void TryGetValue_Should_Return_Value()
+        {
+            String KEY = "key";
+            String VAL = "val";
+
+            Structure structure = new Structure();
+            structure.Add(KEY, VAL);
+            Value value;
+            Assert.True(structure.TryGetValue(KEY, out value));
+            Assert.Equal(VAL, value.AsString());
+        }
+
+        [Fact]
+        public void Values_Should_Return_Values()
+        {
+            String KEY = "key";
+            Value VAL = new Value("val");
+
+            Structure structure = new Structure();
+            structure.Add(KEY, VAL);
+            Assert.Equal(1, structure.Values.Count);
+        }
+
+        [Fact]
+        public void Keys_Should_Return_Keys()
+        {
+            String KEY = "key";
+            Value VAL = new Value("val");
+
+            Structure structure = new Structure();
+            structure.Add(KEY, VAL);
+            Assert.Equal(1, structure.Keys.Count);
+            Assert.True(structure.Keys.Contains(KEY));
+        }
+
+        [Fact]
+        public void GetEnumerator_Should_Return_Enumerator()
+        {
+            string KEY = "key";
+            string VAL = "val";
+
+            Structure structure = new Structure();
+            structure.Add(KEY, VAL);
+            IEnumerator<KeyValuePair<string, Value>> enumerator = structure.GetEnumerator();
+            enumerator.MoveNext();
+            Assert.Equal(VAL, enumerator.Current.Value.AsString());
+        }
+    }
+}

--- a/test/OpenFeature.SDK.Tests/TestImplementations.cs
+++ b/test/OpenFeature.SDK.Tests/TestImplementations.cs
@@ -5,12 +5,6 @@ using OpenFeature.SDK.Model;
 
 namespace OpenFeature.SDK.Tests
 {
-    public class TestStructure
-    {
-        public string Name { get; set; }
-        public string Value { get; set; }
-    }
-
     public class TestHookNoOverride : Hook { }
 
     public class TestHook : Hook
@@ -76,10 +70,10 @@ namespace OpenFeature.SDK.Tests
             return Task.FromResult(new ResolutionDetails<double>(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue,
+        public override Task<ResolutionDetails<Structure>> ResolveStructureValue(string flagKey, Structure defaultValue,
             EvaluationContext context = null)
         {
-            return Task.FromResult(new ResolutionDetails<T>(flagKey, defaultValue));
+            return Task.FromResult(new ResolutionDetails<Structure>(flagKey, defaultValue));
         }
     }
 }

--- a/test/OpenFeature.SDK.Tests/ValueTests.cs
+++ b/test/OpenFeature.SDK.Tests/ValueTests.cs
@@ -24,21 +24,19 @@ namespace OpenFeature.SDK.Tests
         }
 
         [Fact]
-        public void Int_Arg_Should_Contain_Int()
+        public void Numeric_Arg_Should_Return_Double_Or_Int()
         {
-            int innerValue = 99;
-            Value value = new Value(innerValue);
-            Assert.True(value.IsInteger());
-            Assert.Equal(innerValue, value.AsInteger());
-        }
+            double innerDoubleValue = .75;
+            Value doubleValue = new Value(innerDoubleValue);
+            Assert.True(doubleValue.IsNumber());
+            Assert.Equal(1, doubleValue.AsInteger());     // should be rounded
+            Assert.Equal(.75, doubleValue.AsDouble());
 
-        [Fact]
-        public void Double_Arg_Should_Contain_Double()
-        {
-            double innerValue = .5;
-            Value value = new Value(innerValue);
-            Assert.True(value.IsDouble());
-            Assert.Equal(innerValue, value.AsDouble());
+            int innerIntValue = 100;
+            Value intValue = new Value(innerIntValue);
+            Assert.True(intValue.IsNumber());
+            Assert.Equal(innerIntValue, intValue.AsInteger());
+            Assert.Equal(innerIntValue, intValue.AsDouble());
         }
 
         [Fact]
@@ -72,7 +70,7 @@ namespace OpenFeature.SDK.Tests
         }
 
         [Fact]
-        public void List_Arg_Should_Contain_List()
+        public void LIst_Arg_Should_Contain_LIst()
         {
             string ITEM_VALUE = "val";
             IList<Value> innerValue = new List<Value>()

--- a/test/OpenFeature.SDK.Tests/ValueTests.cs
+++ b/test/OpenFeature.SDK.Tests/ValueTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using OpenFeature.SDK.Model;
+using Xunit;
+
+namespace OpenFeature.SDK.Tests
+{
+    public class ValueTests
+    {
+        [Fact]
+        public void No_Arg_Should_Contain_Null()
+        {
+            Value value = new Value();
+            Assert.True(value.IsNull());
+        }
+
+        [Fact]
+        public void Bool_Arg_Should_Contain_Bool()
+        {
+            bool innerValue = true;
+            Value value = new Value(innerValue);
+            Assert.True(value.IsBoolean());
+            Assert.Equal(innerValue, value.AsBoolean());
+        }
+
+        [Fact]
+        public void Int_Arg_Should_Contain_Int()
+        {
+            int innerValue = 99;
+            Value value = new Value(innerValue);
+            Assert.True(value.IsInteger());
+            Assert.Equal(innerValue, value.AsInteger());
+        }
+
+        [Fact]
+        public void Double_Arg_Should_Contain_Double()
+        {
+            double innerValue = .5;
+            Value value = new Value(innerValue);
+            Assert.True(value.IsDouble());
+            Assert.Equal(innerValue, value.AsDouble());
+        }
+
+        [Fact]
+        public void String_Arg_Should_Contain_String()
+        {
+            string innerValue = "hi!";
+            Value value = new Value(innerValue);
+            Assert.True(value.IsString());
+            Assert.Equal(innerValue, value.AsString());
+        }
+
+
+        [Fact]
+        public void DateTime_Arg_Should_Contain_DateTime()
+        {
+            DateTime innerValue = new DateTime();
+            Value value = new Value(innerValue);
+            Assert.True(value.IsDateTime());
+            Assert.Equal(innerValue, value.AsDateTime());
+        }
+
+        [Fact]
+        public void Structure_Arg_Should_Contain_Structure()
+        {
+            string INNER_KEY = "key";
+            string INNER_VALUE = "val";
+            Structure innerValue = new Structure().Add(INNER_KEY, INNER_VALUE);
+            Value value = new Value(innerValue);
+            Assert.True(value.IsStructure());
+            Assert.Equal(INNER_VALUE, value.AsStructure().GetValue(INNER_KEY).AsString());
+        }
+
+        [Fact]
+        public void List_Arg_Should_Contain_List()
+        {
+            string ITEM_VALUE = "val";
+            IList<Value> innerValue = new List<Value>()
+            {
+                new Value(ITEM_VALUE)
+            };
+            Value value = new Value(innerValue);
+            Assert.True(value.IsList());
+            Assert.Equal(ITEM_VALUE, value.AsList()[0].AsString());
+        }
+    }
+}


### PR DESCRIPTION
Born from the discussions in #25 and https://github.com/open-feature/java-sdk/issues/50

- Adds `Structure` type which represents JSON data
- Adds `Value` wrapper class that houses the supported types (Structure, List, bool, int, double, Value - note ints are stored and doubles, and rounded when returned)
- `EvaluationContext` exposes methods to interact with its underlying keyvalue pairs of string, `Value`
- Update interfaces to use `Structure` instead of generics
