### PR TITLE
BREAKING: add structure->value, object value constructor

### DIFF
--- a/src/OpenFeature.SDK/FeatureProvider.cs
+++ b/src/OpenFeature.SDK/FeatureProvider.cs
@@ -72,13 +72,13 @@ namespace OpenFeature.SDK
             EvaluationContext context = null);
 
         /// <summary>
-        /// Resolves a structure feature flag
+        /// Resolves a structured feature flag
         /// </summary>
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<Structure>> ResolveStructureValue(string flagKey, Structure defaultValue,
+        public abstract Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue,
             EvaluationContext context = null);
     }
 }

--- a/src/OpenFeature.SDK/IFeatureClient.cs
+++ b/src/OpenFeature.SDK/IFeatureClient.cs
@@ -21,7 +21,7 @@ namespace OpenFeature.SDK
         Task<double> GetDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
         Task<FlagEvaluationDetails<double>> GetDoubleDetails(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
 
-        Task<Structure> GetObjectValue(string flagKey, Structure defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
-        Task<FlagEvaluationDetails<Structure>> GetObjectDetails(string flagKey, Structure defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<Value> GetObjectValue(string flagKey, Value defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<FlagEvaluationDetails<Value>> GetObjectDetails(string flagKey, Value defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
     }
 }

--- a/src/OpenFeature.SDK/Model/Value.cs
+++ b/src/OpenFeature.SDK/Model/Value.cs
@@ -25,13 +25,13 @@ namespace OpenFeature.SDK.Model
         {
             // integer is a special case, convert those.
             this._innerValue = value is int ? Convert.ToDouble(value) : value;
-            if (!(this.IsNull()
-                || this.IsBoolean()
-                || this.IsString()
-                || this.IsNumber()
-                || this.IsStructure()
-                || this.IsList()
-                || this.IsDateTime()))
+            if (!(this.IsNull
+                || this.IsBoolean
+                || this.IsString
+                || this.IsNumber
+                || this.IsStructure
+                || this.IsList
+                || this.IsDateTime))
             {
                 throw new ArgumentException("Invalid value type: " + value.GetType());
             }
@@ -90,97 +90,97 @@ namespace OpenFeature.SDK.Model
         /// Determines if inner value is null
         /// </summary>
         /// <returns><see cref="bool">True if value is null</see></returns>
-        public bool IsNull() => this._innerValue is null;
+        public bool IsNull => this._innerValue is null;
 
         /// <summary>
         /// Determines if inner value is bool
         /// </summary>
         /// <returns><see cref="bool">True if value is bool</see></returns>
-        public bool IsBoolean() => this._innerValue is bool;
+        public bool IsBoolean => this._innerValue is bool;
 
         /// <summary>
         /// Determines if inner value is numeric
         /// </summary>
         /// <returns><see cref="bool">True if value is double</see></returns>
-        public bool IsNumber() => this._innerValue is double;
+        public bool IsNumber => this._innerValue is double;
 
         /// <summary>
         /// Determines if inner value is string
         /// </summary>
         /// <returns><see cref="bool">True if value is string</see></returns>
-        public bool IsString() => this._innerValue is string;
+        public bool IsString => this._innerValue is string;
 
         /// <summary>
         /// Determines if inner value is <see cref="Structure">Structure</see>
         /// </summary>
         /// <returns><see cref="bool">True if value is <see cref="Structure">Structure</see></see></returns>
-        public bool IsStructure() => this._innerValue is Structure;
+        public bool IsStructure => this._innerValue is Structure;
 
         /// <summary>
         /// Determines if inner value is list
         /// </summary>
         /// <returns><see cref="bool">True if value is list</see></returns>
-        public bool IsList() => this._innerValue is IList;
+        public bool IsList => this._innerValue is IList;
 
         /// <summary>
         /// Determines if inner value is DateTime
         /// </summary>
         /// <returns><see cref="bool">True if value is DateTime</see></returns>
-        public bool IsDateTime() => this._innerValue is DateTime;
+        public bool IsDateTime => this._innerValue is DateTime;
 
         /// <summary>
         /// Returns the underlying inner value as an object. Returns null if the inner value is null.
         /// </summary>
         /// <returns>Value as object</returns>
-        public object AsObject() => this._innerValue;
+        public object AsObject => this._innerValue;
 
         /// <summary>
         /// Returns the underlying int value
         /// Value will be null if it isn't a integer
         /// </summary>
         /// <returns>Value as int</returns>
-        public int? AsInteger() => this.IsNumber() ? (int?)Convert.ToInt32((double?)this._innerValue) : null;
+        public int? AsInteger => this.IsNumber ? (int?)Convert.ToInt32((double?)this._innerValue) : null;
 
         /// <summary>
         /// Returns the underlying bool value
         /// Value will be null if it isn't a bool
         /// </summary>
         /// <returns>Value as bool</returns>
-        public bool? AsBoolean() => this.IsBoolean() ? (bool?)this._innerValue : null;
+        public bool? AsBoolean => this.IsBoolean ? (bool?)this._innerValue : null;
 
         /// <summary>
         /// Returns the underlying double value
         /// Value will be null if it isn't a double
         /// </summary>
         /// <returns>Value as int</returns>
-        public double? AsDouble() => this.IsNumber() ? (double?)this._innerValue : null;
+        public double? AsDouble => this.IsNumber ? (double?)this._innerValue : null;
 
         /// <summary>
         /// Returns the underlying string value
         /// Value will be null if it isn't a string
         /// </summary>
         /// <returns>Value as string</returns>
-        public string AsString() => this.IsString() ? (string)this._innerValue : null;
+        public string AsString => this.IsString ? (string)this._innerValue : null;
 
         /// <summary>
         /// Returns the underlying Structure value
         /// Value will be null if it isn't a Structure
         /// </summary>
         /// <returns>Value as Structure</returns>
-        public Structure AsStructure() => this.IsStructure() ? (Structure)this._innerValue : null;
+        public Structure AsStructure => this.IsStructure ? (Structure)this._innerValue : null;
 
         /// <summary>
         /// Returns the underlying List value
         /// Value will be null if it isn't a List
         /// </summary>
         /// <returns>Value as List</returns>
-        public IList<Value> AsList() => this.IsList() ? (IList<Value>)this._innerValue : null;
+        public IList<Value> AsList => this.IsList ? (IList<Value>)this._innerValue : null;
 
         /// <summary>
         /// Returns the underlying DateTime value
         /// Value will be null if it isn't a DateTime
         /// </summary>
         /// <returns>Value as DateTime</returns>
-        public DateTime? AsDateTime() => this.IsDateTime() ? (DateTime?)this._innerValue : null;
+        public DateTime? AsDateTime => this.IsDateTime ? (DateTime?)this._innerValue : null;
     }
 }

--- a/src/OpenFeature.SDK/Model/Value.cs
+++ b/src/OpenFeature.SDK/Model/Value.cs
@@ -18,6 +18,27 @@ namespace OpenFeature.SDK.Model
         public Value() => this._innerValue = null;
 
         /// <summary>
+        /// Creates a Value with the inner set to the object
+        /// </summary>
+        /// <param name="value"><see cref="Object">The object to set as the inner value</see></param>
+        public Value(Object value)
+        {
+            // integer is a special case, convert those.
+            this._innerValue = value is int ? Convert.ToDouble(value) : value;
+            if (!(this.IsNull()
+                || this.IsBoolean()
+                || this.IsString()
+                || this.IsNumber()
+                || this.IsStructure()
+                || this.IsList()
+                || this.IsDateTime()))
+            {
+                throw new ArgumentException("Invalid value type: " + value.GetType());
+            }
+        }
+
+
+        /// <summary>
         /// Creates a Value with the inner value to the inner value of the value param
         /// </summary>
         /// <param name="value"><see cref="Value">Value type</see></param>
@@ -106,6 +127,12 @@ namespace OpenFeature.SDK.Model
         /// </summary>
         /// <returns><see cref="bool">True if value is DateTime</see></returns>
         public bool IsDateTime() => this._innerValue is DateTime;
+
+        /// <summary>
+        /// Returns the underlying inner value as an object. Returns null if the inner value is null.
+        /// </summary>
+        /// <returns>Value as object</returns>
+        public object AsObject() => this._innerValue;
 
         /// <summary>
         /// Returns the underlying int value

--- a/src/OpenFeature.SDK/NoOpProvider.cs
+++ b/src/OpenFeature.SDK/NoOpProvider.cs
@@ -33,7 +33,7 @@ namespace OpenFeature.SDK
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<Structure>> ResolveStructureValue(string flagKey, Structure defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext context = null)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }

--- a/src/OpenFeature.SDK/OpenFeatureClient.cs
+++ b/src/OpenFeature.SDK/OpenFeatureClient.cs
@@ -188,7 +188,7 @@ namespace OpenFeature.SDK
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        public async Task<Structure> GetObjectValue(string flagKey, Structure defaultValue, EvaluationContext context = null,
+        public async Task<Value> GetObjectValue(string flagKey, Value defaultValue, EvaluationContext context = null,
             FlagEvaluationOptions config = null) =>
             (await this.GetObjectDetails(flagKey, defaultValue, context, config)).Value;
 
@@ -200,7 +200,7 @@ namespace OpenFeature.SDK
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        public async Task<FlagEvaluationDetails<Structure>> GetObjectDetails(string flagKey, Structure defaultValue,
+        public async Task<FlagEvaluationDetails<Value>> GetObjectDetails(string flagKey, Value defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
             await this.EvaluateFlag(this._featureProvider.ResolveStructureValue, FlagValueType.Object, flagKey,
                 defaultValue, context, config);

--- a/test/OpenFeature.SDK.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.SDK.Tests/FeatureProviderTests.cs
@@ -36,7 +36,7 @@ namespace OpenFeature.SDK.Tests
             var defaultStringValue = fixture.Create<string>();
             var defaultIntegerValue = fixture.Create<int>();
             var defaultDoubleValue = fixture.Create<double>();
-            var defaultStructureValue = fixture.Create<Structure>();
+            var defaultStructureValue = fixture.Create<Value>();
             var provider = new NoOpFeatureProvider();
 
             var boolResolutionDetails = new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
@@ -51,7 +51,7 @@ namespace OpenFeature.SDK.Tests
             var stringResolutionDetails = new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await provider.ResolveStringValue(flagName, defaultStringValue)).Should().BeEquivalentTo(stringResolutionDetails);
 
-            var structureResolutionDetails = new ResolutionDetails<Structure>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            var structureResolutionDetails = new ResolutionDetails<Value>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await provider.ResolveStructureValue(flagName, defaultStructureValue)).Should().BeEquivalentTo(structureResolutionDetails);
         }
 
@@ -66,7 +66,7 @@ namespace OpenFeature.SDK.Tests
             var defaultStringValue = fixture.Create<string>();
             var defaultIntegerValue = fixture.Create<int>();
             var defaultDoubleValue = fixture.Create<double>();
-            var defaultStructureValue = fixture.Create<Structure>();
+            var defaultStructureValue = fixture.Create<Value>();
             var providerMock = new Mock<FeatureProvider>(MockBehavior.Strict);
 
             providerMock.Setup(x => x.ResolveBooleanValue(flagName, defaultBoolValue, It.IsAny<EvaluationContext>()))
@@ -82,10 +82,10 @@ namespace OpenFeature.SDK.Tests
                 .ReturnsAsync(new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.TypeMismatch, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
             providerMock.Setup(x => x.ResolveStructureValue(flagName, defaultStructureValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<Structure>(flagName, defaultStructureValue, ErrorType.FlagNotFound, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+                .ReturnsAsync(new ResolutionDetails<Value>(flagName, defaultStructureValue, ErrorType.FlagNotFound, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
             providerMock.Setup(x => x.ResolveStructureValue(flagName2, defaultStructureValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<Structure>(flagName, defaultStructureValue, ErrorType.ProviderNotReady, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+                .ReturnsAsync(new ResolutionDetails<Value>(flagName, defaultStructureValue, ErrorType.ProviderNotReady, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
             var provider = providerMock.Object;
 

--- a/test/OpenFeature.SDK.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.SDK.Tests/OpenFeatureClientTests.cs
@@ -68,7 +68,7 @@ namespace OpenFeature.SDK.Tests
             var defaultStringValue = fixture.Create<string>();
             var defaultIntegerValue = fixture.Create<int>();
             var defaultDoubleValue = fixture.Create<double>();
-            var defaultStructureValue = fixture.Create<Structure>();
+            var defaultStructureValue = fixture.Create<Value>();
             var emptyFlagOptions = new FlagEvaluationOptions(new List<Hook>(), new Dictionary<string, object>());
 
             OpenFeature.Instance.SetProvider(new NoOpFeatureProvider());
@@ -114,7 +114,7 @@ namespace OpenFeature.SDK.Tests
             var defaultStringValue = fixture.Create<string>();
             var defaultIntegerValue = fixture.Create<int>();
             var defaultDoubleValue = fixture.Create<double>();
-            var defaultStructureValue = fixture.Create<Structure>();
+            var defaultStructureValue = fixture.Create<Value>();
             var emptyFlagOptions = new FlagEvaluationOptions(new List<Hook>(), new Dictionary<string, object>());
 
             OpenFeature.Instance.SetProvider(new NoOpFeatureProvider());
@@ -140,7 +140,7 @@ namespace OpenFeature.SDK.Tests
             (await client.GetStringDetails(flagName, defaultStringValue, new EvaluationContext())).Should().BeEquivalentTo(stringFlagEvaluationDetails);
             (await client.GetStringDetails(flagName, defaultStringValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
 
-            var structureFlagEvaluationDetails = new FlagEvaluationDetails<Structure>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            var structureFlagEvaluationDetails = new FlagEvaluationDetails<Value>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await client.GetObjectDetails(flagName, defaultStructureValue)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
             (await client.GetObjectDetails(flagName, defaultStructureValue, new EvaluationContext())).Should().BeEquivalentTo(structureFlagEvaluationDetails);
             (await client.GetObjectDetails(flagName, defaultStructureValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
@@ -159,7 +159,7 @@ namespace OpenFeature.SDK.Tests
             var clientName = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
-            var defaultValue = fixture.Create<Structure>();
+            var defaultValue = fixture.Create<Value>();
             var mockedFeatureProvider = new Mock<FeatureProvider>(MockBehavior.Strict);
             var mockedLogger = new Mock<ILogger<OpenFeature>>(MockBehavior.Default);
 
@@ -302,12 +302,12 @@ namespace OpenFeature.SDK.Tests
             var clientName = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
-            var defaultValue = fixture.Create<Structure>();
+            var defaultValue = fixture.Create<Value>();
 
             var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock
                 .Setup(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<Structure>(flagName, defaultValue));
+                .ReturnsAsync(new ResolutionDetails<Value>(flagName, defaultValue));
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.Setup(x => x.GetProviderHooks())
@@ -316,7 +316,7 @@ namespace OpenFeature.SDK.Tests
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetObjectValue(flagName, defaultValue)).Should().Equal(defaultValue);
+            (await client.GetObjectValue(flagName, defaultValue)).Should().Be(defaultValue);
 
             featureProviderMock.Verify(x => x.ResolveStructureValue(flagName, defaultValue, It.IsAny<EvaluationContext>()), Times.Once);
         }
@@ -328,7 +328,7 @@ namespace OpenFeature.SDK.Tests
             var clientName = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
-            var defaultValue = fixture.Create<Structure>();
+            var defaultValue = fixture.Create<Value>();
 
             var featureProviderMock = new Mock<FeatureProvider>(MockBehavior.Strict);
             featureProviderMock

--- a/test/OpenFeature.SDK.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.SDK.Tests/OpenFeatureClientTests.cs
@@ -362,7 +362,7 @@ namespace OpenFeature.SDK.Tests
             var VAL = 1;
             FeatureClient client = OpenFeature.Instance.GetClient();
             client.SetContext(new EvaluationContext().Add(KEY, VAL));
-            Assert.Equal(VAL, client.GetContext().GetValue(KEY).AsInteger());
+            Assert.Equal(VAL, client.GetContext().GetValue(KEY).AsInteger);
         }
     }
 }

--- a/test/OpenFeature.SDK.Tests/OpenFeatureEvaluationContextTests.cs
+++ b/test/OpenFeature.SDK.Tests/OpenFeatureEvaluationContextTests.cs
@@ -21,8 +21,8 @@ namespace OpenFeature.SDK.Tests
             context1.Merge(context2);
 
             Assert.Equal(2, context1.Count);
-            Assert.Equal("value1", context1.GetValue("key1").AsString());
-            Assert.Equal("value2", context1.GetValue("key2").AsString());
+            Assert.Equal("value1", context1.GetValue("key1").AsString);
+            Assert.Equal("value2", context1.GetValue("key2").AsString);
         }
 
         [Fact]
@@ -39,8 +39,8 @@ namespace OpenFeature.SDK.Tests
             context1.Merge(context2);
 
             Assert.Equal(2, context1.Count);
-            Assert.Equal("overriden_value", context1.GetValue("key1").AsString());
-            Assert.Equal("value2", context1.GetValue("key2").AsString());
+            Assert.Equal("overriden_value", context1.GetValue("key1").AsString);
+            Assert.Equal("value2", context1.GetValue("key2").AsString);
 
             context1.Remove("key1");
             Assert.Throws<KeyNotFoundException>(() => context1.GetValue("key1"));
@@ -63,28 +63,28 @@ namespace OpenFeature.SDK.Tests
                 .Add("key6", 1.0);
 
             var value1 = context.GetValue("key1");
-            value1.IsString().Should().BeTrue();
-            value1.AsString().Should().Be("value");
+            value1.IsString.Should().BeTrue();
+            value1.AsString.Should().Be("value");
 
             var value2 = context.GetValue("key2");
-            value2.IsNumber().Should().BeTrue();
-            value2.AsInteger().Should().Be(1);
+            value2.IsNumber.Should().BeTrue();
+            value2.AsInteger.Should().Be(1);
 
             var value3 = context.GetValue("key3");
-            value3.IsBoolean().Should().Be(true);
-            value3.AsBoolean().Should().Be(true);
+            value3.IsBoolean.Should().Be(true);
+            value3.AsBoolean.Should().Be(true);
 
             var value4 = context.GetValue("key4");
-            value4.IsDateTime().Should().BeTrue();
-            value4.AsDateTime().Should().Be(now);
+            value4.IsDateTime.Should().BeTrue();
+            value4.AsDateTime.Should().Be(now);
 
             var value5 = context.GetValue("key5");
-            value5.IsStructure().Should().BeTrue();
-            value5.AsStructure().Should().Equal(structure);
+            value5.IsStructure.Should().BeTrue();
+            value5.AsStructure.Should().Equal(structure);
 
             var value6 = context.GetValue("key6");
-            value6.IsNumber().Should().BeTrue();
-            value6.AsDouble().Should().Be(1.0);
+            value6.IsNumber.Should().BeTrue();
+            value6.AsDouble.Should().Be(1.0);
         }
 
         [Fact]
@@ -112,7 +112,7 @@ namespace OpenFeature.SDK.Tests
             var count = 0;
             foreach (var keyValue in context)
             {
-                context.GetValue(keyValue.Key).AsString().Should().Be(keyValue.Value.AsString());
+                context.GetValue(keyValue.Key).AsString.Should().Be(keyValue.Value.AsString);
                 count++;
             }
 

--- a/test/OpenFeature.SDK.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.SDK.Tests/OpenFeatureHookTests.cs
@@ -185,7 +185,7 @@ namespace OpenFeature.SDK.Tests
                 new FlagEvaluationOptions(new[] { hook1.Object, hook2.Object }, new Dictionary<string, object>()));
 
             hook1.Verify(x => x.Before(It.IsAny<HookContext<It.IsAnyType>>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
-            hook2.Verify(x => x.Before(It.Is<HookContext<bool>>(a => a.EvaluationContext.GetValue("test").AsString() == "test"), It.IsAny<Dictionary<string, object>>()), Times.Once);
+            hook2.Verify(x => x.Before(It.Is<HookContext<bool>>(a => a.EvaluationContext.GetValue("test").AsString == "test"), It.IsAny<Dictionary<string, object>>()), Times.Once);
         }
 
         [Fact]
@@ -245,13 +245,13 @@ namespace OpenFeature.SDK.Tests
 
             // after proper merging, all properties should equal true
             provider.Verify(x => x.ResolveBooleanValue(It.IsAny<string>(), It.IsAny<bool>(), It.Is<EvaluationContext>(y =>
-                (y.GetValue(propGlobal).AsBoolean() ?? false)
-                && (y.GetValue(propClient).AsBoolean() ?? false)
-                && (y.GetValue(propGlobalToOverwrite).AsBoolean() ?? false)
-                && (y.GetValue(propInvocation).AsBoolean() ?? false)
-                && (y.GetValue(propClientToOverwrite).AsBoolean() ?? false)
-                && (y.GetValue(propHook).AsBoolean() ?? false)
-                && (y.GetValue(propInvocationToOverwrite).AsBoolean() ?? false)
+                (y.GetValue(propGlobal).AsBoolean ?? false)
+                && (y.GetValue(propClient).AsBoolean ?? false)
+                && (y.GetValue(propGlobalToOverwrite).AsBoolean ?? false)
+                && (y.GetValue(propInvocation).AsBoolean ?? false)
+                && (y.GetValue(propClientToOverwrite).AsBoolean ?? false)
+                && (y.GetValue(propHook).AsBoolean ?? false)
+                && (y.GetValue(propInvocationToOverwrite).AsBoolean ?? false)
             )), Times.Once);
         }
 

--- a/test/OpenFeature.SDK.Tests/StructureTests.cs
+++ b/test/OpenFeature.SDK.Tests/StructureTests.cs
@@ -23,7 +23,7 @@ namespace OpenFeature.SDK.Tests
                 { KEY, new Value(KEY) }
             };
             Structure structure = new Structure(dictionary);
-            Assert.Equal(KEY, structure.AsDictionary()[KEY].AsString());
+            Assert.Equal(KEY, structure.AsDictionary()[KEY].AsString);
             Assert.NotSame(structure.AsDictionary(), dictionary); // should be a copy
         }
 
@@ -58,14 +58,14 @@ namespace OpenFeature.SDK.Tests
             structure.Add(LIST_KEY, LIST_VAL);
             structure.Add(VALUE_KEY, VALUE_VAL);
 
-            Assert.Equal(BOOL_VAL, structure.GetValue(BOOL_KEY).AsBoolean());
-            Assert.Equal(STRING_VAL, structure.GetValue(STRING_KEY).AsString());
-            Assert.Equal(INT_VAL, structure.GetValue(INT_KEY).AsInteger());
-            Assert.Equal(DOUBLE_VAL, structure.GetValue(DOUBLE_KEY).AsDouble());
-            Assert.Equal(DATE_VAL, structure.GetValue(DATE_KEY).AsDateTime());
-            Assert.Equal(STRUCT_VAL, structure.GetValue(STRUCT_KEY).AsStructure());
-            Assert.Equal(LIST_VAL, structure.GetValue(LIST_KEY).AsList());
-            Assert.True(structure.GetValue(VALUE_KEY).IsNull());
+            Assert.Equal(BOOL_VAL, structure.GetValue(BOOL_KEY).AsBoolean);
+            Assert.Equal(STRING_VAL, structure.GetValue(STRING_KEY).AsString);
+            Assert.Equal(INT_VAL, structure.GetValue(INT_KEY).AsInteger);
+            Assert.Equal(DOUBLE_VAL, structure.GetValue(DOUBLE_KEY).AsDouble);
+            Assert.Equal(DATE_VAL, structure.GetValue(DATE_KEY).AsDateTime);
+            Assert.Equal(STRUCT_VAL, structure.GetValue(STRUCT_KEY).AsStructure);
+            Assert.Equal(LIST_VAL, structure.GetValue(LIST_KEY).AsList);
+            Assert.True(structure.GetValue(VALUE_KEY).IsNull);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace OpenFeature.SDK.Tests
             structure.Add(KEY, VAL);
             Value value;
             Assert.True(structure.TryGetValue(KEY, out value));
-            Assert.Equal(VAL, value.AsString());
+            Assert.Equal(VAL, value.AsString);
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace OpenFeature.SDK.Tests
             structure.Add(KEY, VAL);
             IEnumerator<KeyValuePair<string, Value>> enumerator = structure.GetEnumerator();
             enumerator.MoveNext();
-            Assert.Equal(VAL, enumerator.Current.Value.AsString());
+            Assert.Equal(VAL, enumerator.Current.Value.AsString);
         }
     }
 }

--- a/test/OpenFeature.SDK.Tests/TestImplementations.cs
+++ b/test/OpenFeature.SDK.Tests/TestImplementations.cs
@@ -70,10 +70,10 @@ namespace OpenFeature.SDK.Tests
             return Task.FromResult(new ResolutionDetails<double>(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<Structure>> ResolveStructureValue(string flagKey, Structure defaultValue,
+        public override Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue,
             EvaluationContext context = null)
         {
-            return Task.FromResult(new ResolutionDetails<Structure>(flagKey, defaultValue));
+            return Task.FromResult(new ResolutionDetails<Value>(flagKey, defaultValue));
         }
     }
 }

--- a/test/OpenFeature.SDK.Tests/ValueTests.cs
+++ b/test/OpenFeature.SDK.Tests/ValueTests.cs
@@ -13,7 +13,7 @@ namespace OpenFeature.SDK.Tests
         public void No_Arg_Should_Contain_Null()
         {
             Value value = new Value();
-            Assert.True(value.IsNull());
+            Assert.True(value.IsNull);
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace OpenFeature.SDK.Tests
                 foreach (Object l in list)
                 {
                     Value value = new Value(l);
-                    Assert.Equal(list[i], value.AsObject());
+                    Assert.Equal(list[i], value.AsObject);
                     i++;
                 }
             }
@@ -47,8 +47,8 @@ namespace OpenFeature.SDK.Tests
             {
                 int innerValue = 1;
                 Value value = new Value(innerValue);
-                Assert.True(value.IsNumber());
-                Assert.Equal(innerValue, value.AsInteger());
+                Assert.True(value.IsNumber);
+                Assert.Equal(innerValue, value.AsInteger);
             }
             catch (Exception)
             {
@@ -70,8 +70,8 @@ namespace OpenFeature.SDK.Tests
         {
             bool innerValue = true;
             Value value = new Value(innerValue);
-            Assert.True(value.IsBoolean());
-            Assert.Equal(innerValue, value.AsBoolean());
+            Assert.True(value.IsBoolean);
+            Assert.Equal(innerValue, value.AsBoolean);
         }
 
         [Fact]
@@ -79,15 +79,15 @@ namespace OpenFeature.SDK.Tests
         {
             double innerDoubleValue = .75;
             Value doubleValue = new Value(innerDoubleValue);
-            Assert.True(doubleValue.IsNumber());
-            Assert.Equal(1, doubleValue.AsInteger());     // should be rounded
-            Assert.Equal(.75, doubleValue.AsDouble());
+            Assert.True(doubleValue.IsNumber);
+            Assert.Equal(1, doubleValue.AsInteger);     // should be rounded
+            Assert.Equal(.75, doubleValue.AsDouble);
 
             int innerIntValue = 100;
             Value intValue = new Value(innerIntValue);
-            Assert.True(intValue.IsNumber());
-            Assert.Equal(innerIntValue, intValue.AsInteger());
-            Assert.Equal(innerIntValue, intValue.AsDouble());
+            Assert.True(intValue.IsNumber);
+            Assert.Equal(innerIntValue, intValue.AsInteger);
+            Assert.Equal(innerIntValue, intValue.AsDouble);
         }
 
         [Fact]
@@ -95,8 +95,8 @@ namespace OpenFeature.SDK.Tests
         {
             string innerValue = "hi!";
             Value value = new Value(innerValue);
-            Assert.True(value.IsString());
-            Assert.Equal(innerValue, value.AsString());
+            Assert.True(value.IsString);
+            Assert.Equal(innerValue, value.AsString);
         }
 
         [Fact]
@@ -104,8 +104,8 @@ namespace OpenFeature.SDK.Tests
         {
             DateTime innerValue = new DateTime();
             Value value = new Value(innerValue);
-            Assert.True(value.IsDateTime());
-            Assert.Equal(innerValue, value.AsDateTime());
+            Assert.True(value.IsDateTime);
+            Assert.Equal(innerValue, value.AsDateTime);
         }
 
         [Fact]
@@ -115,8 +115,8 @@ namespace OpenFeature.SDK.Tests
             string INNER_VALUE = "val";
             Structure innerValue = new Structure().Add(INNER_KEY, INNER_VALUE);
             Value value = new Value(innerValue);
-            Assert.True(value.IsStructure());
-            Assert.Equal(INNER_VALUE, value.AsStructure().GetValue(INNER_KEY).AsString());
+            Assert.True(value.IsStructure);
+            Assert.Equal(INNER_VALUE, value.AsStructure.GetValue(INNER_KEY).AsString);
         }
 
         [Fact]
@@ -128,8 +128,8 @@ namespace OpenFeature.SDK.Tests
                 new Value(ITEM_VALUE)
             };
             Value value = new Value(innerValue);
-            Assert.True(value.IsList());
-            Assert.Equal(ITEM_VALUE, value.AsList()[0].AsString());
+            Assert.True(value.IsList);
+            Assert.Equal(ITEM_VALUE, value.AsList[0].AsString);
         }
     }
 }

--- a/test/OpenFeature.SDK.Tests/ValueTests.cs
+++ b/test/OpenFeature.SDK.Tests/ValueTests.cs
@@ -7,11 +7,62 @@ namespace OpenFeature.SDK.Tests
 {
     public class ValueTests
     {
+        class Foo { }
+
         [Fact]
         public void No_Arg_Should_Contain_Null()
         {
             Value value = new Value();
             Assert.True(value.IsNull());
+        }
+
+        [Fact]
+        public void Object_Arg_Should_Contain_Object()
+        {
+            try
+            {
+                // int is a special case, see Int_Object_Arg_Should_Contain_Object()
+                IList<Object> list = new List<Object>(){
+                    true, "val", .5, new Structure(), new List<Value>(), DateTime.Now
+                };
+
+                int i = 0;
+                foreach (Object l in list)
+                {
+                    Value value = new Value(l);
+                    Assert.Equal(list[i], value.AsObject());
+                    i++;
+                }
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Expected no exception.");
+            }
+        }
+
+        [Fact]
+        public void Int_Object_Arg_Should_Contain_Object()
+        {
+            try
+            {
+                int innerValue = 1;
+                Value value = new Value(innerValue);
+                Assert.True(value.IsNumber());
+                Assert.Equal(innerValue, value.AsInteger());
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Expected no exception.");
+            }
+        }
+
+        [Fact]
+        public void Invalid_Object_Should_Throw()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                return new Value(new Foo());
+            });
         }
 
         [Fact]
@@ -47,7 +98,6 @@ namespace OpenFeature.SDK.Tests
             Assert.True(value.IsString());
             Assert.Equal(innerValue, value.AsString());
         }
-
 
         [Fact]
         public void DateTime_Arg_Should_Contain_DateTime()


### PR DESCRIPTION
A c# flavored version of: https://github.com/open-feature/java-sdk/pull/65. I hope these are the last breaking changes before a 1.0rc.

- add object constructor and accessor to `Value`
- use `Value` instead of `Structure` in object resolver (https://github.com/open-feature/spec/issues/138#issuecomment-1241202093)