### PR TITLE
fix: substitute version number into filename when pushing package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,5 +39,6 @@ jobs:
       - name: Publish to Nuget
         if: ${{ steps.release.outputs.releases_created }}
         run: |
-          VERSION=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
-          dotnet nuget push OpenFeature.{VERSION}.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push OpenFeature.${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}.nupkg `
+            --api-key ${{secrets.NUGET_API_KEY}} `
+            --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Fix build publish

![image](https://user-images.githubusercontent.com/2031163/191866594-9877d6bd-8be3-4f3e-88c8-109d5bef588c.png)
