### PR TITLE
feat!: ErrorType as enum, add ErrorMessage string

### DIFF
--- a/src/OpenFeatureSDK/Constant/ErrorType.cs
+++ b/src/OpenFeatureSDK/Constant/ErrorType.cs
@@ -46,6 +46,6 @@ namespace OpenFeatureSDK.Constant
         /// <summary>
         /// Context does not contain a targeting key and the provider requires one.
         /// </summary>
-        [Description("TARGETING_KEY_MISSING")]TargetingKeyMissing,
+        [Description("TARGETING_KEY_MISSING")] TargetingKeyMissing,
     }
 }

--- a/src/OpenFeatureSDK/Constant/ErrorType.cs
+++ b/src/OpenFeatureSDK/Constant/ErrorType.cs
@@ -36,6 +36,16 @@ namespace OpenFeatureSDK.Constant
         /// <summary>
         /// Abnormal execution of the provider
         /// </summary>
-        [Description("GENERAL")] General
+        [Description("GENERAL")] General,
+
+        /// <summary>
+        /// Context does not satisfy provider requirements.
+        /// </summary>
+        [Description("INVALID_CONTEXT")] InvalidContext,
+
+        /// <summary>
+        /// Context does not contain a targeting key and the provider requires one.
+        /// </summary>
+        [Description("TARGETING_KEY_MISSING")]TargetingKeyMissing,
     }
 }

--- a/src/OpenFeatureSDK/Error/FeatureProviderException.cs
+++ b/src/OpenFeatureSDK/Error/FeatureProviderException.cs
@@ -1,6 +1,5 @@
 using System;
 using OpenFeatureSDK.Constant;
-using OpenFeatureSDK.Extension;
 
 namespace OpenFeatureSDK.Error
 {
@@ -11,9 +10,9 @@ namespace OpenFeatureSDK.Error
     public class FeatureProviderException : Exception
     {
         /// <summary>
-        /// Description of error that occured when evaluating a flag
+        /// Error that occurred during evaluation
         /// </summary>
-        public string ErrorDescription { get; }
+        public ErrorType ErrorType { get; }
 
         /// <summary>
         /// Initialize a new instance of the <see cref="FeatureProviderException"/> class
@@ -24,19 +23,7 @@ namespace OpenFeatureSDK.Error
         public FeatureProviderException(ErrorType errorType, string message = null, Exception innerException = null)
             : base(message, innerException)
         {
-            this.ErrorDescription = errorType.GetDescription();
-        }
-
-        /// <summary>
-        /// Initialize a new instance of the <see cref="FeatureProviderException"/> class
-        /// </summary>
-        /// <param name="errorCode">A string representation describing the error that occured</param>
-        /// <param name="message">Exception message</param>
-        /// <param name="innerException">Optional inner exception</param>
-        public FeatureProviderException(string errorCode, string message = null, Exception innerException = null)
-            : base(message, innerException)
-        {
-            this.ErrorDescription = errorCode;
+            this.ErrorType = errorType;
         }
     }
 }

--- a/src/OpenFeatureSDK/Extension/ResolutionDetailsExtensions.cs
+++ b/src/OpenFeatureSDK/Extension/ResolutionDetailsExtensions.cs
@@ -6,7 +6,8 @@ namespace OpenFeatureSDK.Extension
     {
         public static FlagEvaluationDetails<T> ToFlagEvaluationDetails<T>(this ResolutionDetails<T> details)
         {
-            return new FlagEvaluationDetails<T>(details.FlagKey, details.Value, details.ErrorType, details.Reason, details.Variant);
+            return new FlagEvaluationDetails<T>(details.FlagKey, details.Value, details.ErrorType, details.Reason,
+                details.Variant, details.ErrorMessage);
         }
     }
 }

--- a/src/OpenFeatureSDK/Model/FlagEvaluationDetails.cs
+++ b/src/OpenFeatureSDK/Model/FlagEvaluationDetails.cs
@@ -1,5 +1,4 @@
 using OpenFeatureSDK.Constant;
-using OpenFeatureSDK.Extension;
 
 namespace OpenFeatureSDK.Model
 {
@@ -23,7 +22,15 @@ namespace OpenFeatureSDK.Model
         /// <summary>
         /// Error that occurred during evaluation
         /// </summary>
-        public string ErrorType { get; }
+        public ErrorType ErrorType { get; }
+
+        /// <summary>
+        /// Message containing additional details about an error.
+        ///
+        /// Will be <see langword="null" /> if there is no error or if the provider didn't provide any additional error
+        /// details.
+        /// </summary>
+        public string ErrorMessage { get; }
 
         /// <summary>
         /// Describes the reason for the outcome of the evaluation process
@@ -45,30 +52,16 @@ namespace OpenFeatureSDK.Model
         /// <param name="errorType">Error</param>
         /// <param name="reason">Reason</param>
         /// <param name="variant">Variant</param>
-        public FlagEvaluationDetails(string flagKey, T value, ErrorType errorType, string reason, string variant)
-        {
-            this.Value = value;
-            this.FlagKey = flagKey;
-            this.ErrorType = errorType.GetDescription();
-            this.Reason = reason;
-            this.Variant = variant;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FlagEvaluationDetails{T}"/> class.
-        /// </summary>
-        /// <param name="flagKey">Feature flag key</param>
-        /// <param name="value">Evaluated value</param>
-        /// <param name="errorType">Error</param>
-        /// <param name="reason">Reason</param>
-        /// <param name="variant">Variant</param>
-        public FlagEvaluationDetails(string flagKey, T value, string errorType, string reason, string variant)
+        /// <param name="errorMessage">Error message</param>
+        public FlagEvaluationDetails(string flagKey, T value, ErrorType errorType, string reason, string variant,
+            string errorMessage = null)
         {
             this.Value = value;
             this.FlagKey = flagKey;
             this.ErrorType = errorType;
             this.Reason = reason;
             this.Variant = variant;
+            this.ErrorMessage = errorMessage;
         }
     }
 }

--- a/src/OpenFeatureSDK/Model/FlagEvaluationDetails.cs
+++ b/src/OpenFeatureSDK/Model/FlagEvaluationDetails.cs
@@ -26,9 +26,10 @@ namespace OpenFeatureSDK.Model
 
         /// <summary>
         /// Message containing additional details about an error.
-        ///
+        /// <para>
         /// Will be <see langword="null" /> if there is no error or if the provider didn't provide any additional error
         /// details.
+        /// </para>
         /// </summary>
         public string ErrorMessage { get; }
 

--- a/src/OpenFeatureSDK/Model/ResolutionDetails.cs
+++ b/src/OpenFeatureSDK/Model/ResolutionDetails.cs
@@ -27,6 +27,11 @@ namespace OpenFeatureSDK.Model
         public ErrorType ErrorType { get; }
 
         /// <summary>
+        /// Message containing additional details about an error.
+        /// </summary>
+        public string ErrorMessage { get; }
+
+        /// <summary>
         /// Describes the reason for the outcome of the evaluation process
         /// <see cref="Reason"/>
         /// </summary>
@@ -47,14 +52,16 @@ namespace OpenFeatureSDK.Model
         /// <param name="errorType">Error</param>
         /// <param name="reason">Reason</param>
         /// <param name="variant">Variant</param>
+        /// <param name="errorMessage">Error message</param>
         public ResolutionDetails(string flagKey, T value, ErrorType errorType = ErrorType.None, string reason = null,
-            string variant = null)
+            string variant = null, string errorMessage = null)
         {
             this.Value = value;
             this.FlagKey = flagKey;
             this.ErrorType = errorType;
             this.Reason = reason;
             this.Variant = variant;
+            this.ErrorMessage = errorMessage;
         }
     }
 }

--- a/src/OpenFeatureSDK/OpenFeatureClient.cs
+++ b/src/OpenFeatureSDK/OpenFeatureClient.cs
@@ -257,9 +257,9 @@ namespace OpenFeatureSDK
             catch (FeatureProviderException ex)
             {
                 this._logger.LogError(ex, "Error while evaluating flag {FlagKey}. Error {ErrorType}", flagKey,
-                    ex.ErrorDescription);
-                evaluation = new FlagEvaluationDetails<T>(flagKey, defaultValue, ex.ErrorDescription, Reason.Error,
-                    string.Empty);
+                    ex.ErrorType.GetDescription());
+                evaluation = new FlagEvaluationDetails<T>(flagKey, defaultValue, ex.ErrorType, Reason.Error,
+                    string.Empty, ex.Message);
                 await this.TriggerErrorHooks(allHooksReversed, hookContext, ex, options);
             }
             catch (Exception ex)

--- a/test/OpenFeatureSDK.Tests/FeatureProviderExceptionTests.cs
+++ b/test/OpenFeatureSDK.Tests/FeatureProviderExceptionTests.cs
@@ -2,6 +2,7 @@ using System;
 using FluentAssertions;
 using OpenFeatureSDK.Constant;
 using OpenFeatureSDK.Error;
+using OpenFeatureSDK.Extension;
 using Xunit;
 
 namespace OpenFeatureSDK.Tests
@@ -17,16 +18,16 @@ namespace OpenFeatureSDK.Tests
         public void FeatureProviderException_Should_Resolve_Description(ErrorType errorType, string errorDescription)
         {
             var ex = new FeatureProviderException(errorType);
-            ex.ErrorDescription.Should().Be(errorDescription);
+            ex.ErrorType.GetDescription().Should().Be(errorDescription);
         }
 
         [Theory]
-        [InlineData("OUT_OF_CREDIT", "Subscription has expired, please renew your subscription.")]
-        [InlineData("Exceed quota", "User has exceeded the quota for this feature.")]
-        public void FeatureProviderException_Should_Allow_Custom_ErrorCode_Messages(string errorCode, string message)
+        [InlineData(ErrorType.General, "Subscription has expired, please renew your subscription.")]
+        [InlineData(ErrorType.ProviderNotReady, "User has exceeded the quota for this feature.")]
+        public void FeatureProviderException_Should_Allow_Custom_ErrorCode_Messages(ErrorType errorCode, string message)
         {
             var ex = new FeatureProviderException(errorCode, message, new ArgumentOutOfRangeException("flag"));
-            ex.ErrorDescription.Should().Be(errorCode);
+            ex.ErrorType.Should().Be(errorCode);
             ex.Message.Should().Be(message);
             ex.InnerException.Should().BeOfType<ArgumentOutOfRangeException>();
         }

--- a/test/OpenFeatureSDK.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeatureSDK.Tests/FeatureProviderTests.cs
@@ -12,7 +12,8 @@ namespace OpenFeatureSDK.Tests
     public class FeatureProviderTests : ClearOpenFeatureInstanceFixture
     {
         [Fact]
-        [Specification("2.1", "The provider interface MUST define a `metadata` member or accessor, containing a `name` field or accessor of type string, which identifies the provider implementation.")]
+        [Specification("2.1",
+            "The provider interface MUST define a `metadata` member or accessor, containing a `name` field or accessor of type string, which identifies the provider implementation.")]
         public void Provider_Must_Have_Metadata()
         {
             var provider = new TestProvider();
@@ -21,13 +22,22 @@ namespace OpenFeatureSDK.Tests
         }
 
         [Fact]
-        [Specification("2.2", "The `feature provider` interface MUST define methods to resolve flag values, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required) and `evaluation context` (optional), which returns a `flag resolution` structure.")]
-        [Specification("2.3.1", "The `feature provider` interface MUST define methods for typed flag resolution, including boolean, numeric, string, and structure.")]
-        [Specification("2.4", "In cases of normal execution, the `provider` MUST populate the `flag resolution` structure's `value` field with the resolved flag value.")]
-        [Specification("2.5", "In cases of normal execution, the `provider` SHOULD populate the `flag resolution` structure's `variant` field with a string identifier corresponding to the returned flag value.")]
-        [Specification("2.6", "The `provider` SHOULD populate the `flag resolution` structure's `reason` field with a string indicating the semantic reason for the returned flag value.")]
-        [Specification("2.7", "In cases of normal execution, the `provider` MUST NOT populate the `flag resolution` structure's `error code` field, or otherwise must populate it with a null or falsy value.")]
-        [Specification("2.9", "In cases of normal execution, the `provider` MUST NOT populate the `flag resolution` structure's `error code` field, or otherwise must populate it with a null or falsy value.")]
+        [Specification("2.2",
+            "The `feature provider` interface MUST define methods to resolve flag values, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required) and `evaluation context` (optional), which returns a `flag resolution` structure.")]
+        [Specification("2.3.1",
+            "The `feature provider` interface MUST define methods for typed flag resolution, including boolean, numeric, string, and structure.")]
+        [Specification("2.4",
+            "In cases of normal execution, the `provider` MUST populate the `flag resolution` structure's `value` field with the resolved flag value.")]
+        [Specification("2.5",
+            "In cases of normal execution, the `provider` SHOULD populate the `flag resolution` structure's `variant` field with a string identifier corresponding to the returned flag value.")]
+        [Specification("2.6",
+            "The `provider` SHOULD populate the `flag resolution` structure's `reason` field with a string indicating the semantic reason for the returned flag value.")]
+        [Specification("2.7",
+            "In cases of normal execution, the `provider` MUST NOT populate the `flag resolution` structure's `error code` field, or otherwise must populate it with a null or falsy value.")]
+        [Specification("2.9.1",
+            "The `flag resolution` structure SHOULD accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.")]
+        [Specification("2.11",
+            "In cases of normal execution, the `provider` MUST NOT populate the `flag resolution` structure's `error message` field, or otherwise must populate it with a null or falsy value.")]
         public async Task Provider_Must_Resolve_Flag_Values()
         {
             var fixture = new Fixture();
@@ -39,24 +49,37 @@ namespace OpenFeatureSDK.Tests
             var defaultStructureValue = fixture.Create<Value>();
             var provider = new NoOpFeatureProvider();
 
-            var boolResolutionDetails = new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveBooleanValue(flagName, defaultBoolValue)).Should().BeEquivalentTo(boolResolutionDetails);
+            var boolResolutionDetails = new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.None,
+                NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            (await provider.ResolveBooleanValue(flagName, defaultBoolValue)).Should()
+                .BeEquivalentTo(boolResolutionDetails);
 
-            var integerResolutionDetails = new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveIntegerValue(flagName, defaultIntegerValue)).Should().BeEquivalentTo(integerResolutionDetails);
+            var integerResolutionDetails = new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.None,
+                NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            (await provider.ResolveIntegerValue(flagName, defaultIntegerValue)).Should()
+                .BeEquivalentTo(integerResolutionDetails);
 
-            var doubleResolutionDetails = new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveDoubleValue(flagName, defaultDoubleValue)).Should().BeEquivalentTo(doubleResolutionDetails);
+            var doubleResolutionDetails = new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.None,
+                NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            (await provider.ResolveDoubleValue(flagName, defaultDoubleValue)).Should()
+                .BeEquivalentTo(doubleResolutionDetails);
 
-            var stringResolutionDetails = new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveStringValue(flagName, defaultStringValue)).Should().BeEquivalentTo(stringResolutionDetails);
+            var stringResolutionDetails = new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.None,
+                NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            (await provider.ResolveStringValue(flagName, defaultStringValue)).Should()
+                .BeEquivalentTo(stringResolutionDetails);
 
-            var structureResolutionDetails = new ResolutionDetails<Value>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveStructureValue(flagName, defaultStructureValue)).Should().BeEquivalentTo(structureResolutionDetails);
+            var structureResolutionDetails = new ResolutionDetails<Value>(flagName, defaultStructureValue,
+                ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
+            (await provider.ResolveStructureValue(flagName, defaultStructureValue)).Should()
+                .BeEquivalentTo(structureResolutionDetails);
         }
 
         [Fact]
-        [Specification("2.8", "In cases of abnormal execution, the `provider` MUST indicate an error using the idioms of the implementation language, with an associated error code having possible values `PROVIDER_NOT_READY`, `FLAG_NOT_FOUND`, `PARSE_ERROR`, `TYPE_MISMATCH`, or `GENERAL`.")]
+        [Specification("2.8",
+            "In cases of abnormal execution, the `provider` MUST indicate an error using the idioms of the implementation language, with an associated `error code` and optional associated `error message`.")]
+        [Specification("2.12",
+            "In cases of abnormal execution, the `evaluation details` structure's `error message` field MAY contain a string containing additional detail about the nature of the error.")]
         public async Task Provider_Must_ErrorType()
         {
             var fixture = new Fixture();
@@ -68,33 +91,68 @@ namespace OpenFeatureSDK.Tests
             var defaultDoubleValue = fixture.Create<double>();
             var defaultStructureValue = fixture.Create<Value>();
             var providerMock = new Mock<FeatureProvider>(MockBehavior.Strict);
+            const string testMessage = "An error message";
 
             providerMock.Setup(x => x.ResolveBooleanValue(flagName, defaultBoolValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.General, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+                .ReturnsAsync(new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.General,
+                    NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
             providerMock.Setup(x => x.ResolveIntegerValue(flagName, defaultIntegerValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.ParseError, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+                .ReturnsAsync(new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.ParseError,
+                    NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
             providerMock.Setup(x => x.ResolveDoubleValue(flagName, defaultDoubleValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.ParseError, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+                .ReturnsAsync(new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.InvalidContext,
+                    NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
             providerMock.Setup(x => x.ResolveStringValue(flagName, defaultStringValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.TypeMismatch, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+                .ReturnsAsync(new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.TypeMismatch,
+                    NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.Setup(x => x.ResolveStructureValue(flagName, defaultStructureValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<Value>(flagName, defaultStructureValue, ErrorType.FlagNotFound, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+            providerMock.Setup(x =>
+                    x.ResolveStructureValue(flagName, defaultStructureValue, It.IsAny<EvaluationContext>()))
+                .ReturnsAsync(new ResolutionDetails<Value>(flagName, defaultStructureValue, ErrorType.FlagNotFound,
+                    NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.Setup(x => x.ResolveStructureValue(flagName2, defaultStructureValue, It.IsAny<EvaluationContext>()))
-                .ReturnsAsync(new ResolutionDetails<Value>(flagName, defaultStructureValue, ErrorType.ProviderNotReady, NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+            providerMock.Setup(x =>
+                    x.ResolveStructureValue(flagName2, defaultStructureValue, It.IsAny<EvaluationContext>()))
+                .ReturnsAsync(new ResolutionDetails<Value>(flagName2, defaultStructureValue, ErrorType.ProviderNotReady,
+                    NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
+
+            providerMock.Setup(x => x.ResolveBooleanValue(flagName2, defaultBoolValue, It.IsAny<EvaluationContext>()))
+                .ReturnsAsync(new ResolutionDetails<bool>(flagName2, defaultBoolValue, ErrorType.TargetingKeyMissing,
+                    NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
+
 
             var provider = providerMock.Object;
 
-            (await provider.ResolveBooleanValue(flagName, defaultBoolValue)).ErrorType.Should().Be(ErrorType.General);
-            (await provider.ResolveIntegerValue(flagName, defaultIntegerValue)).ErrorType.Should().Be(ErrorType.ParseError);
-            (await provider.ResolveDoubleValue(flagName, defaultDoubleValue)).ErrorType.Should().Be(ErrorType.ParseError);
-            (await provider.ResolveStringValue(flagName, defaultStringValue)).ErrorType.Should().Be(ErrorType.TypeMismatch);
-            (await provider.ResolveStructureValue(flagName, defaultStructureValue)).ErrorType.Should().Be(ErrorType.FlagNotFound);
-            (await provider.ResolveStructureValue(flagName2, defaultStructureValue)).ErrorType.Should().Be(ErrorType.ProviderNotReady);
+            var boolRes = await provider.ResolveBooleanValue(flagName, defaultBoolValue);
+            boolRes.ErrorType.Should().Be(ErrorType.General);
+            boolRes.ErrorMessage.Should().Be(testMessage);
+
+            var intRes = await provider.ResolveIntegerValue(flagName, defaultIntegerValue);
+            intRes.ErrorType.Should().Be(ErrorType.ParseError);
+            intRes.ErrorMessage.Should().Be(testMessage);
+
+            var doubleRes = await provider.ResolveDoubleValue(flagName, defaultDoubleValue);
+            doubleRes.ErrorType.Should().Be(ErrorType.InvalidContext);
+            doubleRes.ErrorMessage.Should().Be(testMessage);
+
+            var stringRes = await provider.ResolveStringValue(flagName, defaultStringValue);
+            stringRes.ErrorType.Should().Be(ErrorType.TypeMismatch);
+            stringRes.ErrorMessage.Should().Be(testMessage);
+
+            var structRes1 = await provider.ResolveStructureValue(flagName, defaultStructureValue);
+            structRes1.ErrorType.Should().Be(ErrorType.FlagNotFound);
+            structRes1.ErrorMessage.Should().Be(testMessage);
+
+            var structRes2 = await provider.ResolveStructureValue(flagName2, defaultStructureValue);
+            structRes2.ErrorType.Should().Be(ErrorType.ProviderNotReady);
+            structRes2.ErrorMessage.Should().Be(testMessage);
+
+            var boolRes2 = await provider.ResolveBooleanValue(flagName2, defaultBoolValue);
+            boolRes2.ErrorType.Should().Be(ErrorType.TargetingKeyMissing);
+            boolRes2.ErrorMessage.Should().BeNull();
         }
     }
 }


### PR DESCRIPTION
Addresses: https://github.com/open-feature/dotnet-sdk/issues/71

Extend the `ErrorType` to include `INVALID_CONTEXT` and `TARGETING_KEY_MISSING`.
Change the `ErrorType` in `FlagEvaluationDetails` to an enum.
Update the `FeatureProviderException` to have an enumerated code. Use `message` for the `error message`.
Update tests, and update specification references in tests.
