### PR TITLE
chore: poc, Implement builders and immutable contexts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ OpenFeature.Instance.SetProvider(new NoOpProvider());
 var client = OpenFeature.Instance.GetClient();
 // Evaluation the `my-feature` feature flag
 var isEnabled = await client.GetBooleanValue("my-feature", false);
+
+// Evaluating with a context.
+var evaluationContext = EvaluationContext.Builder()
+    .Set("my-key", "my-value")
+    .Build();
+
+// Evaluation the `my-conditional` feature flag
+var isEnabled = await client.GetBooleanValue("my-conditional", false, evaluationContext);
 ```
 
 ### Provider

--- a/src/OpenFeatureSDK/Hook.cs
+++ b/src/OpenFeatureSDK/Hook.cs
@@ -31,7 +31,7 @@ namespace OpenFeatureSDK
         public virtual Task<EvaluationContext> Before<T>(HookContext<T> context,
             IReadOnlyDictionary<string, object> hints = null)
         {
-            return Task.FromResult(new EvaluationContext());
+            return Task.FromResult(EvaluationContext.Empty);
         }
 
         /// <summary>

--- a/src/OpenFeatureSDK/Model/EvaluationContext.cs
+++ b/src/OpenFeatureSDK/Model/EvaluationContext.cs
@@ -12,11 +12,18 @@ namespace OpenFeatureSDK.Model
     {
         private readonly Structure _structure;
 
+        /// <summary>
+        /// Internal constructor used by the builder.
+        /// </summary>
+        /// <param name="content">The content of the context.</param>
         internal EvaluationContext(Structure content)
         {
             this._structure = content;
         }
 
+        /// <summary>
+        /// Private constructor for making an empty <see cref="EvaluationContext"/>.
+        /// </summary>
         private EvaluationContext()
         {
             this._structure = Structure.Empty;
@@ -82,6 +89,15 @@ namespace OpenFeatureSDK.Model
         public IEnumerator<KeyValuePair<string, Value>> GetEnumerator()
         {
             return this._structure.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Get a builder which can build an <see cref="EvaluationContext"/>.
+        /// </summary>
+        /// <returns>The builder</returns>
+        public static EvaluationContextBuilder Builder()
+        {
+            return new EvaluationContextBuilder();
         }
     }
 }

--- a/src/OpenFeatureSDK/Model/EvaluationContext.cs
+++ b/src/OpenFeatureSDK/Model/EvaluationContext.cs
@@ -22,9 +22,10 @@ namespace OpenFeatureSDK.Model
             this._structure = Structure.Empty;
         }
 
-        private static EvaluationContext _empty = new EvaluationContext();
-
-        public static EvaluationContext Empty => _empty;
+        /// <summary>
+        /// An empty evaluation context.
+        /// </summary>
+        public static readonly EvaluationContext Empty = new EvaluationContext();
 
         /// <summary>
         /// Gets the Value at the specified key

--- a/src/OpenFeatureSDK/Model/EvaluationContext.cs
+++ b/src/OpenFeatureSDK/Model/EvaluationContext.cs
@@ -8,9 +8,23 @@ namespace OpenFeatureSDK.Model
     /// to the feature flag evaluation context.
     /// </summary>
     /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/evaluation-context.md">Evaluation context</seealso>
-    public class EvaluationContext
+    public sealed class EvaluationContext
     {
-        private readonly Structure _structure = new Structure();
+        private readonly Structure _structure;
+
+        internal EvaluationContext(Structure content)
+        {
+            this._structure = content;
+        }
+
+        private EvaluationContext()
+        {
+            this._structure = Structure.Empty;
+        }
+
+        private static EvaluationContext _empty = new EvaluationContext();
+
+        public static EvaluationContext Empty => _empty;
 
         /// <summary>
         /// Gets the Value at the specified key
@@ -36,15 +50,6 @@ namespace OpenFeatureSDK.Model
         public bool ContainsKey(string key) => this._structure.ContainsKey(key);
 
         /// <summary>
-        /// Removes the Value at the specified key
-        /// </summary>
-        /// <param name="key">The key of the value to be removed</param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the key is <see langword="null" />
-        /// </exception>
-        public void Remove(string key) => this._structure.Remove(key);
-
-        /// <summary>
         /// Gets the value associated with the specified key
         /// </summary>
         /// <param name="value">The <see cref="Value"/> or <see langword="null" /> if the key was not present</param>
@@ -65,173 +70,9 @@ namespace OpenFeatureSDK.Model
         }
 
         /// <summary>
-        /// Add a new bool Value to the evaluation context
-        /// </summary>
-        /// <param name="key">The key of the value to be added</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="EvaluationContext"/></returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the key is <see langword="null" />
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown when an element with the same key is already contained in the context
-        /// </exception>
-        public EvaluationContext Add(string key, bool value)
-        {
-            this._structure.Add(key, value);
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new string Value to the evaluation context
-        /// </summary>
-        /// <param name="key">The key of the value to be added</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="EvaluationContext"/></returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the key is <see langword="null" />
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown when an element with the same key is already contained in the context
-        /// </exception>
-        public EvaluationContext Add(string key, string value)
-        {
-            this._structure.Add(key, value);
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new int Value to the evaluation context
-        /// </summary>
-        /// <param name="key">The key of the value to be added</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="EvaluationContext"/></returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the key is <see langword="null" />
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown when an element with the same key is already contained in the context
-        /// </exception>
-        public EvaluationContext Add(string key, int value)
-        {
-            this._structure.Add(key, value);
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new double Value to the evaluation context
-        /// </summary>
-        /// <param name="key">The key of the value to be added</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="EvaluationContext"/></returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the key is <see langword="null" />
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown when an element with the same key is already contained in the context
-        /// </exception>
-        public EvaluationContext Add(string key, double value)
-        {
-            this._structure.Add(key, value);
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new DateTime Value to the evaluation context
-        /// </summary>
-        /// <param name="key">The key of the value to be added</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="EvaluationContext"/></returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the key is <see langword="null" />
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown when an element with the same key is already contained in the context
-        /// </exception>
-        public EvaluationContext Add(string key, DateTime value)
-        {
-            this._structure.Add(key, value);
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new Structure Value to the evaluation context
-        /// </summary>
-        /// <param name="key">The key of the value to be added</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="EvaluationContext"/></returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the key is <see langword="null" />
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown when an element with the same key is already contained in the context
-        /// </exception>
-        public EvaluationContext Add(string key, Structure value)
-        {
-            this._structure.Add(key, value);
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new List Value to the evaluation context
-        /// </summary>
-        /// <param name="key">The key of the value to be added</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="EvaluationContext"/></returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the key is <see langword="null" />
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown when an element with the same key is already contained in the context
-        /// </exception>
-        public EvaluationContext Add(string key, List<Value> value)
-        {
-            this._structure.Add(key, value);
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new Value to the evaluation context
-        /// </summary>
-        /// <param name="key">The key of the value to be added</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="EvaluationContext"/></returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the key is <see langword="null" />
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown when an element with the same key is already contained in the context
-        /// </exception>
-        public EvaluationContext Add(string key, Value value)
-        {
-            this._structure.Add(key, value);
-            return this;
-        }
-
-        /// <summary>
         /// Return a count of all values
         /// </summary>
         public int Count => this._structure.Count;
-
-        /// <summary>
-        /// Merges provided evaluation context into this one.
-        /// Any duplicate keys will be overwritten.
-        /// </summary>
-        /// <param name="other"><see cref="EvaluationContext"/></param>
-        public void Merge(EvaluationContext other)
-        {
-            foreach (var key in other._structure.Keys)
-            {
-                if (this._structure.ContainsKey(key))
-                {
-                    this._structure[key] = other._structure[key];
-                }
-                else
-                {
-                    this._structure.Add(key, other._structure[key]);
-                }
-            }
-        }
 
         /// <summary>
         /// Return an enumerator for all values

--- a/src/OpenFeatureSDK/Model/EvaluationContextBuilder.cs
+++ b/src/OpenFeatureSDK/Model/EvaluationContextBuilder.cs
@@ -12,7 +12,12 @@ namespace OpenFeatureSDK.Model
     /// </summary>
     public sealed class EvaluationContextBuilder
     {
-        private readonly StructureBuilder _attributes = new StructureBuilder();
+        private readonly StructureBuilder _attributes = Structure.Builder();
+
+        /// <summary>
+        /// Internal to only allow direct creation by <see cref="EvaluationContext.Builder()"/>.
+        /// </summary>
+        internal EvaluationContextBuilder() {}
 
         /// <summary>
         /// Set the key to the given <see cref="Value"/>.

--- a/src/OpenFeatureSDK/Model/EvaluationContextBuilder.cs
+++ b/src/OpenFeatureSDK/Model/EvaluationContextBuilder.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Immutable;
+
+namespace OpenFeatureSDK.Model
+{
+    public sealed class EvaluationContextBuilder
+    {
+        private readonly StructureBuilder _attributes = new StructureBuilder();
+
+        public EvaluationContextBuilder Set(string key, Value value)
+        {
+            this._attributes.Set(key, value);
+            return this;
+        }
+
+        public EvaluationContextBuilder Set(string key, string value)
+        {
+            this._attributes.Set(key, value);
+            return this;
+        }
+
+        public EvaluationContextBuilder Set(string key, int value)
+        {
+            this._attributes.Set(key, value);
+            return this;
+        }
+
+        public EvaluationContextBuilder Set(string key, double value)
+        {
+            this._attributes.Set(key, value);
+            return this;
+        }
+
+        public EvaluationContextBuilder Set(string key, long value)
+        {
+            this._attributes.Set(key, value);
+            return this;
+        }
+
+        public EvaluationContextBuilder Set(string key, bool value)
+        {
+            this._attributes.Set(key, value);
+            return this;
+        }
+
+        public EvaluationContextBuilder Set(string key, Structure value)
+        {
+            this._attributes.Set(key, value);
+            return this;
+        }
+
+        public EvaluationContextBuilder Set(string key, DateTime time)
+        {
+            this._attributes.Set(key, time);
+            return this;
+        }
+
+        public EvaluationContextBuilder Set(string key, IImmutableList<Value> value)
+        {
+            this._attributes.Set(key, value);
+            return this;
+        }
+
+        public EvaluationContextBuilder Remove(string key)
+        {
+            this._attributes.Remove(key);
+            return this;
+        }
+
+        public EvaluationContextBuilder Merge(EvaluationContext context)
+        {
+            foreach (var kvp in context)
+            {
+                this.Set(kvp.Key, kvp.Value);
+            }
+
+            return this;
+        }
+
+        public EvaluationContext Build()
+        {
+            return new EvaluationContext(this._attributes.Build());
+        }
+    }
+}

--- a/src/OpenFeatureSDK/Model/EvaluationContextBuilder.cs
+++ b/src/OpenFeatureSDK/Model/EvaluationContextBuilder.cs
@@ -17,7 +17,7 @@ namespace OpenFeatureSDK.Model
         /// <summary>
         /// Internal to only allow direct creation by <see cref="EvaluationContext.Builder()"/>.
         /// </summary>
-        internal EvaluationContextBuilder() {}
+        internal EvaluationContextBuilder() { }
 
         /// <summary>
         /// Set the key to the given <see cref="Value"/>.

--- a/src/OpenFeatureSDK/Model/EvaluationContextBuilder.cs
+++ b/src/OpenFeatureSDK/Model/EvaluationContextBuilder.cs
@@ -1,72 +1,134 @@
 using System;
-using System.Collections.Immutable;
 
 namespace OpenFeatureSDK.Model
 {
+    /// <summary>
+    /// A builder which allows the specification of attributes for an <see cref="EvaluationContext"/>.
+    /// <para>
+    /// A <see cref="EvaluationContextBuilder"/> object is intended for use by a single thread and should not be used
+    /// from multiple threads. Once an <see cref="EvaluationContext"/> has been created it is immutable and safe for use
+    /// from multiple threads.
+    /// </para>
+    /// </summary>
     public sealed class EvaluationContextBuilder
     {
         private readonly StructureBuilder _attributes = new StructureBuilder();
 
+        /// <summary>
+        /// Set the key to the given <see cref="Value"/>.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public EvaluationContextBuilder Set(string key, Value value)
         {
             this._attributes.Set(key, value);
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given string.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public EvaluationContextBuilder Set(string key, string value)
         {
             this._attributes.Set(key, value);
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given int.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public EvaluationContextBuilder Set(string key, int value)
         {
             this._attributes.Set(key, value);
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given double.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public EvaluationContextBuilder Set(string key, double value)
         {
             this._attributes.Set(key, value);
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given long.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public EvaluationContextBuilder Set(string key, long value)
         {
             this._attributes.Set(key, value);
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given bool.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public EvaluationContextBuilder Set(string key, bool value)
         {
             this._attributes.Set(key, value);
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given <see cref="Structure"/>.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public EvaluationContextBuilder Set(string key, Structure value)
         {
             this._attributes.Set(key, value);
             return this;
         }
 
-        public EvaluationContextBuilder Set(string key, DateTime time)
-        {
-            this._attributes.Set(key, time);
-            return this;
-        }
-
-        public EvaluationContextBuilder Set(string key, IImmutableList<Value> value)
+        /// <summary>
+        /// Set the key to the given DateTime.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
+        public EvaluationContextBuilder Set(string key, DateTime value)
         {
             this._attributes.Set(key, value);
             return this;
         }
 
+        /// <summary>
+        /// Remove the given key from the context.
+        /// </summary>
+        /// <param name="key">The key to remove</param>
+        /// <returns>This builder</returns>
         public EvaluationContextBuilder Remove(string key)
         {
             this._attributes.Remove(key);
             return this;
         }
 
+        /// <summary>
+        /// Incorporate an existing context into the builder.
+        /// <para>
+        /// Any existing keys in the builder will be replaced by keys in the context.
+        /// </para>
+        /// </summary>
+        /// <param name="context">The context to add merge</param>
+        /// <returns>This builder</returns>
         public EvaluationContextBuilder Merge(EvaluationContext context)
         {
             foreach (var kvp in context)
@@ -77,6 +139,10 @@ namespace OpenFeatureSDK.Model
             return this;
         }
 
+        /// <summary>
+        /// Build an immutable <see cref="EvaluationContext"/>.
+        /// </summary>
+        /// <returns>An immutable <see cref="EvaluationContext"/></returns>
         public EvaluationContext Build()
         {
             return new EvaluationContext(this._attributes.Build());

--- a/src/OpenFeatureSDK/Model/HookContext.cs
+++ b/src/OpenFeatureSDK/Model/HookContext.cs
@@ -65,5 +65,17 @@ namespace OpenFeatureSDK.Model
             this.ProviderMetadata = providerMetadata ?? throw new ArgumentNullException(nameof(providerMetadata));
             this.EvaluationContext = evaluationContext ?? throw new ArgumentNullException(nameof(evaluationContext));
         }
+
+        internal HookContext<T> WithNewEvalContext(EvaluationContext context)
+        {
+            return new HookContext<T>(
+                this.FlagKey,
+                this.DefaultValue,
+                this.FlagValueType,
+                this.ClientMetadata,
+                this.ProviderMetadata,
+                context
+            );
+        }
     }
 }

--- a/src/OpenFeatureSDK/Model/Structure.cs
+++ b/src/OpenFeatureSDK/Model/Structure.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace OpenFeatureSDK.Model
 {
@@ -21,13 +20,18 @@ namespace OpenFeatureSDK.Model
             this._attributes = attributes;
         }
 
+        /// <summary>
+        /// Private constructor for creating an empty <see cref="Structure"/>.
+        /// </summary>
         private Structure()
         {
             this._attributes = ImmutableDictionary<string, Value>.Empty;;
         }
 
-        private static Structure _empty = new Structure();
-        public static Structure Empty => _empty;
+        /// <summary>
+        /// An empty structure.
+        /// </summary>
+        public static readonly Structure Empty = new Structure();
 
         /// <summary>
         /// Creates a new structure with the supplied attributes

--- a/src/OpenFeatureSDK/Model/Structure.cs
+++ b/src/OpenFeatureSDK/Model/Structure.cs
@@ -25,7 +25,7 @@ namespace OpenFeatureSDK.Model
         /// </summary>
         private Structure()
         {
-            this._attributes = ImmutableDictionary<string, Value>.Empty;;
+            this._attributes = ImmutableDictionary<string, Value>.Empty; ;
         }
 
         /// <summary>

--- a/src/OpenFeatureSDK/Model/Structure.cs
+++ b/src/OpenFeatureSDK/Model/Structure.cs
@@ -1,24 +1,33 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace OpenFeatureSDK.Model
 {
     /// <summary>
     /// Structure represents a map of Values
     /// </summary>
-    public class Structure : IEnumerable<KeyValuePair<string, Value>>
+    public sealed class Structure : IEnumerable<KeyValuePair<string, Value>>
     {
-        private readonly Dictionary<string, Value> _attributes;
+        private readonly ImmutableDictionary<string, Value> _attributes;
 
         /// <summary>
-        /// Creates a new structure with an empty set of attributes
+        /// Creates a new structure with the specified attributes.
         /// </summary>
-        public Structure()
+        internal Structure(ImmutableDictionary<string, Value> attributes)
         {
-            this._attributes = new Dictionary<string, Value>();
+            this._attributes = attributes;
         }
+
+        private Structure()
+        {
+            this._attributes = ImmutableDictionary<string, Value>.Empty;;
+        }
+
+        private static Structure _empty = new Structure();
+        public static Structure Empty => _empty;
 
         /// <summary>
         /// Creates a new structure with the supplied attributes
@@ -26,7 +35,7 @@ namespace OpenFeatureSDK.Model
         /// <param name="attributes"></param>
         public Structure(IDictionary<string, Value> attributes)
         {
-            this._attributes = new Dictionary<string, Value>(attributes);
+            this._attributes = ImmutableDictionary.CreateRange(attributes);
         }
 
         /// <summary>
@@ -42,13 +51,6 @@ namespace OpenFeatureSDK.Model
         /// <param name="key">The key of the value to be retrieved</param>
         /// <returns><see cref="bool"/>indicating the presence of the key.</returns>
         public bool ContainsKey(string key) => this._attributes.ContainsKey(key);
-
-        /// <summary>
-        /// Removes the Value at the specified key
-        /// </summary>
-        /// <param name="key">The key of the value to be retrieved</param>
-        /// <returns><see cref="bool"/> indicating the presence of the key.</returns>
-        public bool Remove(string key) => this._attributes.Remove(key);
 
         /// <summary>
         /// Gets the value associated with the specified key by mutating the supplied value.
@@ -74,114 +76,17 @@ namespace OpenFeatureSDK.Model
         public Value this[string key]
         {
             get => this._attributes[key];
-            set => this._attributes[key] = value;
         }
 
         /// <summary>
-        /// Return a collection containing all the keys in this structure
+        /// Return a list containing all the keys in this structure
         /// </summary>
-        public ICollection<string> Keys => this._attributes.Keys;
+        public IImmutableList<string> Keys => this._attributes.Keys.ToImmutableList();
 
         /// <summary>
-        /// Return a collection containing all the values in this structure
+        /// Return an enumerable containing all the values in this structure
         /// </summary>
-        public ICollection<Value> Values => this._attributes.Values;
-
-        /// <summary>
-        /// Add a new bool Value to the structure
-        /// </summary>
-        /// <param name="key">The key of the value to be retrieved</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="Structure"/></returns>
-        public Structure Add(string key, bool value)
-        {
-            this._attributes.Add(key, new Value(value));
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new string Value to the structure
-        /// </summary>
-        /// <param name="key">The key of the value to be retrieved</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="Structure"/></returns>
-        public Structure Add(string key, string value)
-        {
-            this._attributes.Add(key, new Value(value));
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new int Value to the structure
-        /// </summary>
-        /// <param name="key">The key of the value to be retrieved</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="Structure"/></returns>
-        public Structure Add(string key, int value)
-        {
-            this._attributes.Add(key, new Value(value));
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new double Value to the structure
-        /// </summary>
-        /// <param name="key">The key of the value to be retrieved</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="Structure"/></returns>
-        public Structure Add(string key, double value)
-        {
-            this._attributes.Add(key, new Value(value));
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new DateTime Value to the structure
-        /// </summary>
-        /// <param name="key">The key of the value to be retrieved</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="Structure"/></returns>
-        public Structure Add(string key, DateTime value)
-        {
-            this._attributes.Add(key, new Value(value));
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new Structure Value to the structure
-        /// </summary>
-        /// <param name="key">The key of the value to be retrieved</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="Structure"/></returns>
-        public Structure Add(string key, Structure value)
-        {
-            this._attributes.Add(key, new Value(value));
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new List Value to the structure
-        /// </summary>
-        /// <param name="key">The key of the value to be retrieved</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="Structure"/></returns>
-        public Structure Add(string key, IList<Value> value)
-        {
-            this._attributes.Add(key, new Value(value));
-            return this;
-        }
-
-        /// <summary>
-        /// Add a new Value to the structure
-        /// </summary>
-        /// <param name="key">The key of the value to be retrieved</param>
-        /// <param name="value">The value to be added</param>
-        /// <returns>This <see cref="Structure"/></returns>
-        public Structure Add(string key, Value value)
-        {
-            this._attributes.Add(key, new Value(value));
-            return this;
-        }
+        public IImmutableList<Value> Values => this._attributes.Values.ToImmutableList();
 
         /// <summary>
         /// Return a count of all values

--- a/src/OpenFeatureSDK/Model/Structure.cs
+++ b/src/OpenFeatureSDK/Model/Structure.cs
@@ -13,7 +13,7 @@ namespace OpenFeatureSDK.Model
         private readonly ImmutableDictionary<string, Value> _attributes;
 
         /// <summary>
-        /// Creates a new structure with the specified attributes.
+        /// Internal constructor for use by the builder.
         /// </summary>
         internal Structure(ImmutableDictionary<string, Value> attributes)
         {
@@ -104,6 +104,15 @@ namespace OpenFeatureSDK.Model
         public IEnumerator<KeyValuePair<string, Value>> GetEnumerator()
         {
             return this._attributes.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Get a builder which can build a <see cref="Structure"/>.
+        /// </summary>
+        /// <returns>The builder</returns>
+        public static StructureBuilder Builder()
+        {
+            return new StructureBuilder();
         }
 
         [ExcludeFromCodeCoverage]

--- a/src/OpenFeatureSDK/Model/StructureBuilder.cs
+++ b/src/OpenFeatureSDK/Model/StructureBuilder.cs
@@ -20,7 +20,7 @@ namespace OpenFeatureSDK.Model
         /// <summary>
         /// Internal to only allow direct creation by <see cref="Structure.Builder()"/>.
         /// </summary>
-        internal StructureBuilder() {}
+        internal StructureBuilder() { }
 
         /// <summary>
         /// Set the key to the given <see cref="Value"/>.

--- a/src/OpenFeatureSDK/Model/StructureBuilder.cs
+++ b/src/OpenFeatureSDK/Model/StructureBuilder.cs
@@ -18,6 +18,11 @@ namespace OpenFeatureSDK.Model
             ImmutableDictionary.CreateBuilder<string, Value>();
 
         /// <summary>
+        /// Internal to only allow direct creation by <see cref="Structure.Builder()"/>.
+        /// </summary>
+        internal StructureBuilder() {}
+
+        /// <summary>
         /// Set the key to the given <see cref="Value"/>.
         /// </summary>
         /// <param name="key">The key for the value</param>

--- a/src/OpenFeatureSDK/Model/StructureBuilder.cs
+++ b/src/OpenFeatureSDK/Model/StructureBuilder.cs
@@ -1,13 +1,28 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace OpenFeatureSDK.Model
 {
+    /// <summary>
+    /// A builder which allows the specification of attributes for a <see cref="Structure"/>.
+    /// <para>
+    /// A <see cref="StructureBuilder"/> object is intended for use by a single thread and should not be used from
+    /// multiple threads. Once a <see cref="Structure"/> has been created it is immutable and safe for use from
+    /// multiple threads.
+    /// </para>
+    /// </summary>
     public sealed class StructureBuilder
     {
         private readonly ImmutableDictionary<string, Value>.Builder _attributes =
             ImmutableDictionary.CreateBuilder<string, Value>();
 
+        /// <summary>
+        /// Set the key to the given <see cref="Value"/>.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public StructureBuilder Set(string key, Value value)
         {
             // Remove the attribute. Will not throw an exception if not present.
@@ -16,61 +31,118 @@ namespace OpenFeatureSDK.Model
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given string.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public StructureBuilder Set(string key, string value)
         {
             this.Set(key, new Value(value));
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given int.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public StructureBuilder Set(string key, int value)
         {
             this.Set(key, new Value(value));
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given double.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public StructureBuilder Set(string key, double value)
         {
             this.Set(key, new Value(value));
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given long.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public StructureBuilder Set(string key, long value)
         {
             this.Set(key, new Value(value));
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given bool.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public StructureBuilder Set(string key, bool value)
         {
             this.Set(key, new Value(value));
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given <see cref="Structure"/>.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public StructureBuilder Set(string key, Structure value)
         {
             this.Set(key, new Value(value));
             return this;
         }
 
+        /// <summary>
+        /// Set the key to the given DateTime.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
         public StructureBuilder Set(string key, DateTime value)
         {
             this.Set(key, new Value(value));
             return this;
         }
 
-        public StructureBuilder Set(string key, IImmutableList<Value> value)
+        /// <summary>
+        /// Set the key to the given list.
+        /// </summary>
+        /// <param name="key">The key for the value</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>This builder</returns>
+        public StructureBuilder Set(string key, IList<Value> value)
         {
             this.Set(key, new Value(value));
             return this;
         }
 
+
+        /// <summary>
+        /// Remove the specified key.
+        /// </summary>
+        /// <param name="key">The key to remove</param>
+        /// <returns>This builder</returns>
         public StructureBuilder Remove(string key)
         {
             this._attributes.Remove(key);
             return this;
         }
 
-
+        /// <summary>
+        /// Build an immutable <see cref="Structure"/>/
+        /// </summary>
+        /// <returns>The built <see cref="Structure"/></returns>
         public Structure Build()
         {
             return new Structure(this._attributes.ToImmutable());

--- a/src/OpenFeatureSDK/Model/StructureBuilder.cs
+++ b/src/OpenFeatureSDK/Model/StructureBuilder.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Immutable;
+
+namespace OpenFeatureSDK.Model
+{
+    public sealed class StructureBuilder
+    {
+        private readonly ImmutableDictionary<string, Value>.Builder _attributes =
+            ImmutableDictionary.CreateBuilder<string, Value>();
+
+        public StructureBuilder Set(string key, Value value)
+        {
+            // Remove the attribute. Will not throw an exception if not present.
+            this._attributes.Remove(key);
+            this._attributes.Add(key, value);
+            return this;
+        }
+
+        public StructureBuilder Set(string key, string value)
+        {
+            this.Set(key, new Value(value));
+            return this;
+        }
+
+        public StructureBuilder Set(string key, int value)
+        {
+            this.Set(key, new Value(value));
+            return this;
+        }
+
+        public StructureBuilder Set(string key, double value)
+        {
+            this.Set(key, new Value(value));
+            return this;
+        }
+
+        public StructureBuilder Set(string key, long value)
+        {
+            this.Set(key, new Value(value));
+            return this;
+        }
+
+        public StructureBuilder Set(string key, bool value)
+        {
+            this.Set(key, new Value(value));
+            return this;
+        }
+
+        public StructureBuilder Set(string key, Structure value)
+        {
+            this.Set(key, new Value(value));
+            return this;
+        }
+
+        public StructureBuilder Set(string key, DateTime value)
+        {
+            this.Set(key, new Value(value));
+            return this;
+        }
+
+        public StructureBuilder Set(string key, IImmutableList<Value> value)
+        {
+            this.Set(key, new Value(value));
+            return this;
+        }
+
+        public StructureBuilder Remove(string key)
+        {
+            this._attributes.Remove(key);
+            return this;
+        }
+
+
+        public Structure Build()
+        {
+            return new Structure(this._attributes.ToImmutable());
+        }
+    }
+}

--- a/src/OpenFeatureSDK/Model/Value.cs
+++ b/src/OpenFeatureSDK/Model/Value.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -78,12 +77,6 @@ namespace OpenFeatureSDK.Model
         /// </summary>
         /// <param name="value"><see cref="Structure">Structure type</see></param>
         public Value(Structure value) => this._innerValue = value;
-
-        /// <summary>
-        /// Creates a Value with the inner set to list type
-        /// </summary>
-        /// <param name="value"><see cref="IImmutableList{T}">List type</see></param>
-        public Value(IImmutableList<Value> value) => this._innerValue = value;
 
         /// <summary>
         /// Creates a Value with the inner set to list type

--- a/src/OpenFeatureSDK/Model/Value.cs
+++ b/src/OpenFeatureSDK/Model/Value.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace OpenFeatureSDK.Model
 {
@@ -23,6 +24,10 @@ namespace OpenFeatureSDK.Model
         /// <param name="value"><see cref="Object">The object to set as the inner value</see></param>
         public Value(Object value)
         {
+            if (value is IList<Value> list)
+            {
+                value = list.ToImmutableList();
+            }
             // integer is a special case, convert those.
             this._innerValue = value is int ? Convert.ToDouble(value) : value;
             if (!(this.IsNull
@@ -77,8 +82,14 @@ namespace OpenFeatureSDK.Model
         /// <summary>
         /// Creates a Value with the inner set to list type
         /// </summary>
-        /// <param name="value"><see cref="List{T}">List type</see></param>
-        public Value(IList<Value> value) => this._innerValue = value;
+        /// <param name="value"><see cref="IImmutableList{T}">List type</see></param>
+        public Value(IImmutableList<Value> value) => this._innerValue = value;
+
+        /// <summary>
+        /// Creates a Value with the inner set to list type
+        /// </summary>
+        /// <param name="value"><see cref="IImmutableList{T}">List type</see></param>
+        public Value(IList<Value> value) => this._innerValue = value.ToImmutableList();
 
         /// <summary>
         /// Creates a Value with the inner set to DateTime type
@@ -120,7 +131,7 @@ namespace OpenFeatureSDK.Model
         /// Determines if inner value is list
         /// </summary>
         /// <returns><see cref="bool">True if value is list</see></returns>
-        public bool IsList => this._innerValue is IList;
+        public bool IsList => this._innerValue is IImmutableList<Value>;
 
         /// <summary>
         /// Determines if inner value is DateTime
@@ -174,7 +185,7 @@ namespace OpenFeatureSDK.Model
         /// Value will be null if it isn't a List
         /// </summary>
         /// <returns>Value as List</returns>
-        public IList<Value> AsList => this.IsList ? (IList<Value>)this._innerValue : null;
+        public IImmutableList<Value> AsList => this.IsList ? (IImmutableList<Value>)this._innerValue : null;
 
         /// <summary>
         /// Returns the underlying DateTime value

--- a/src/OpenFeatureSDK/OpenFeature.cs
+++ b/src/OpenFeatureSDK/OpenFeature.cs
@@ -11,7 +11,7 @@ namespace OpenFeatureSDK
     /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/flag-evaluation.md#flag-evaluation-api"/>
     public sealed class OpenFeature
     {
-        private EvaluationContext _evaluationContext = new EvaluationContext();
+        private EvaluationContext _evaluationContext = EvaluationContext.Empty;
         private FeatureProvider _featureProvider = new NoOpFeatureProvider();
         private readonly List<Hook> _hooks = new List<Hook>();
 
@@ -82,7 +82,7 @@ namespace OpenFeatureSDK
         /// Sets the global <see cref="EvaluationContext"/>
         /// </summary>
         /// <param name="context"></param>
-        public void SetContext(EvaluationContext context) => this._evaluationContext = context ?? new EvaluationContext();
+        public void SetContext(EvaluationContext context) => this._evaluationContext = context ?? EvaluationContext.Empty;
 
         /// <summary>
         /// Gets the global <see cref="EvaluationContext"/>

--- a/src/OpenFeatureSDK/OpenFeatureClient.cs
+++ b/src/OpenFeatureSDK/OpenFeatureClient.cs
@@ -218,7 +218,7 @@ namespace OpenFeatureSDK
 
             // merge api, client, and invocation context.
             var evaluationContext = OpenFeature.Instance.GetContext();
-            var evaluationContextBuilder = new EvaluationContextBuilder();
+            var evaluationContextBuilder = EvaluationContext.Builder();
             evaluationContextBuilder.Merge(evaluationContext);
             evaluationContextBuilder.Merge(this.GetContext());
             evaluationContextBuilder.Merge(context);
@@ -282,7 +282,7 @@ namespace OpenFeatureSDK
         private async Task<HookContext<T>> TriggerBeforeHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
             FlagEvaluationOptions options)
         {
-            var evalContextBuilder = new EvaluationContextBuilder();
+            var evalContextBuilder = EvaluationContext.Builder();
             evalContextBuilder.Merge(context.EvaluationContext);
 
             foreach (var hook in hooks)

--- a/src/OpenFeatureSDK/OpenFeatureSDK.csproj
+++ b/src/OpenFeatureSDK/OpenFeatureSDK.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggerVer)" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
@@ -75,24 +75,24 @@ namespace OpenFeatureSDK.Tests
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
 
             (await client.GetBooleanValue(flagName, defaultBoolValue)).Should().Be(defaultBoolValue);
-            (await client.GetBooleanValue(flagName, defaultBoolValue, new EvaluationContext())).Should().Be(defaultBoolValue);
-            (await client.GetBooleanValue(flagName, defaultBoolValue, new EvaluationContext(), emptyFlagOptions)).Should().Be(defaultBoolValue);
+            (await client.GetBooleanValue(flagName, defaultBoolValue, EvaluationContext.Empty)).Should().Be(defaultBoolValue);
+            (await client.GetBooleanValue(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultBoolValue);
 
             (await client.GetIntegerValue(flagName, defaultIntegerValue)).Should().Be(defaultIntegerValue);
-            (await client.GetIntegerValue(flagName, defaultIntegerValue, new EvaluationContext())).Should().Be(defaultIntegerValue);
-            (await client.GetIntegerValue(flagName, defaultIntegerValue, new EvaluationContext(), emptyFlagOptions)).Should().Be(defaultIntegerValue);
+            (await client.GetIntegerValue(flagName, defaultIntegerValue, EvaluationContext.Empty)).Should().Be(defaultIntegerValue);
+            (await client.GetIntegerValue(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultIntegerValue);
 
             (await client.GetDoubleValue(flagName, defaultDoubleValue)).Should().Be(defaultDoubleValue);
-            (await client.GetDoubleValue(flagName, defaultDoubleValue, new EvaluationContext())).Should().Be(defaultDoubleValue);
-            (await client.GetDoubleValue(flagName, defaultDoubleValue, new EvaluationContext(), emptyFlagOptions)).Should().Be(defaultDoubleValue);
+            (await client.GetDoubleValue(flagName, defaultDoubleValue, EvaluationContext.Empty)).Should().Be(defaultDoubleValue);
+            (await client.GetDoubleValue(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultDoubleValue);
 
             (await client.GetStringValue(flagName, defaultStringValue)).Should().Be(defaultStringValue);
-            (await client.GetStringValue(flagName, defaultStringValue, new EvaluationContext())).Should().Be(defaultStringValue);
-            (await client.GetStringValue(flagName, defaultStringValue, new EvaluationContext(), emptyFlagOptions)).Should().Be(defaultStringValue);
+            (await client.GetStringValue(flagName, defaultStringValue, EvaluationContext.Empty)).Should().Be(defaultStringValue);
+            (await client.GetStringValue(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultStringValue);
 
             (await client.GetObjectValue(flagName, defaultStructureValue)).Should().BeEquivalentTo(defaultStructureValue);
-            (await client.GetObjectValue(flagName, defaultStructureValue, new EvaluationContext())).Should().BeEquivalentTo(defaultStructureValue);
-            (await client.GetObjectValue(flagName, defaultStructureValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(defaultStructureValue);
+            (await client.GetObjectValue(flagName, defaultStructureValue, EvaluationContext.Empty)).Should().BeEquivalentTo(defaultStructureValue);
+            (await client.GetObjectValue(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(defaultStructureValue);
         }
 
         [Fact]
@@ -122,28 +122,28 @@ namespace OpenFeatureSDK.Tests
 
             var boolFlagEvaluationDetails = new FlagEvaluationDetails<bool>(flagName, defaultBoolValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await client.GetBooleanDetails(flagName, defaultBoolValue)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
-            (await client.GetBooleanDetails(flagName, defaultBoolValue, new EvaluationContext())).Should().BeEquivalentTo(boolFlagEvaluationDetails);
-            (await client.GetBooleanDetails(flagName, defaultBoolValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
+            (await client.GetBooleanDetails(flagName, defaultBoolValue, EvaluationContext.Empty)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
+            (await client.GetBooleanDetails(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
 
             var integerFlagEvaluationDetails = new FlagEvaluationDetails<int>(flagName, defaultIntegerValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await client.GetIntegerDetails(flagName, defaultIntegerValue)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
-            (await client.GetIntegerDetails(flagName, defaultIntegerValue, new EvaluationContext())).Should().BeEquivalentTo(integerFlagEvaluationDetails);
-            (await client.GetIntegerDetails(flagName, defaultIntegerValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
+            (await client.GetIntegerDetails(flagName, defaultIntegerValue, EvaluationContext.Empty)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
+            (await client.GetIntegerDetails(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
 
             var doubleFlagEvaluationDetails = new FlagEvaluationDetails<double>(flagName, defaultDoubleValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await client.GetDoubleDetails(flagName, defaultDoubleValue)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
-            (await client.GetDoubleDetails(flagName, defaultDoubleValue, new EvaluationContext())).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
-            (await client.GetDoubleDetails(flagName, defaultDoubleValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
+            (await client.GetDoubleDetails(flagName, defaultDoubleValue, EvaluationContext.Empty)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
+            (await client.GetDoubleDetails(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
 
             var stringFlagEvaluationDetails = new FlagEvaluationDetails<string>(flagName, defaultStringValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await client.GetStringDetails(flagName, defaultStringValue)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
-            (await client.GetStringDetails(flagName, defaultStringValue, new EvaluationContext())).Should().BeEquivalentTo(stringFlagEvaluationDetails);
-            (await client.GetStringDetails(flagName, defaultStringValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
+            (await client.GetStringDetails(flagName, defaultStringValue, EvaluationContext.Empty)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
+            (await client.GetStringDetails(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
 
             var structureFlagEvaluationDetails = new FlagEvaluationDetails<Value>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await client.GetObjectDetails(flagName, defaultStructureValue)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
-            (await client.GetObjectDetails(flagName, defaultStructureValue, new EvaluationContext())).Should().BeEquivalentTo(structureFlagEvaluationDetails);
-            (await client.GetObjectDetails(flagName, defaultStructureValue, new EvaluationContext(), emptyFlagOptions)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
+            (await client.GetObjectDetails(flagName, defaultStructureValue, EvaluationContext.Empty)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
+            (await client.GetObjectDetails(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
         }
 
         [Fact]
@@ -393,7 +393,7 @@ namespace OpenFeatureSDK.Tests
             var KEY = "key";
             var VAL = 1;
             FeatureClient client = OpenFeature.Instance.GetClient();
-            client.SetContext(new EvaluationContext().Add(KEY, VAL));
+            client.SetContext(new EvaluationContextBuilder().Set(KEY, VAL).Build());
             Assert.Equal(VAL, client.GetContext().GetValue(KEY).AsInteger);
         }
     }

--- a/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using OpenFeatureSDK.Constant;
 using OpenFeatureSDK.Error;
-using OpenFeatureSDK.Extension;
 using OpenFeatureSDK.Model;
 using OpenFeatureSDK.Tests.Internal;
 using Xunit;

--- a/test/OpenFeatureSDK.Tests/OpenFeatureEvaluationContextTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureEvaluationContextTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using AutoFixture;
 using FluentAssertions;
 using OpenFeatureSDK.Model;

--- a/test/OpenFeatureSDK.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureTests.cs
@@ -1,4 +1,3 @@
-using AutoFixture;
 using FluentAssertions;
 using Moq;
 using OpenFeatureSDK.Constant;

--- a/test/OpenFeatureSDK.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureTests.cs
@@ -79,8 +79,13 @@ namespace OpenFeatureSDK.Tests
         [Fact]
         public void Should_Set_Given_Context()
         {
-            var fixture = new Fixture();
-            var context = fixture.Create<EvaluationContext>();
+            var context = EvaluationContext.Empty;
+
+            OpenFeature.Instance.SetContext(context);
+
+            OpenFeature.Instance.GetContext().Should().BeSameAs(context);
+
+            context = EvaluationContext.Builder().Build();
 
             OpenFeature.Instance.SetContext(context);
 

--- a/test/OpenFeatureSDK.Tests/StructureTests.cs
+++ b/test/OpenFeatureSDK.Tests/StructureTests.cs
@@ -20,7 +20,7 @@ namespace OpenFeatureSDK.Tests
         public void Dictionary_Arg_Should_Contain_New_Dictionary()
         {
             string KEY = "key";
-            IDictionary<string, Value> dictionary = new Dictionary<string, Value>() {{KEY, new Value(KEY)}};
+            IDictionary<string, Value> dictionary = new Dictionary<string, Value>() { { KEY, new Value(KEY) } };
             Structure structure = new Structure(dictionary);
             Assert.Equal(KEY, structure.AsDictionary()[KEY].AsString);
             Assert.NotSame(structure.AsDictionary(), dictionary); // should be a copy

--- a/test/OpenFeatureSDK.Tests/StructureTests.cs
+++ b/test/OpenFeatureSDK.Tests/StructureTests.cs
@@ -47,7 +47,7 @@ namespace OpenFeatureSDK.Tests
             IList<Value> LIST_VAL = new List<Value>();
             Value VALUE_VAL = new Value();
 
-            var structureBuilder = new StructureBuilder();
+            var structureBuilder = Structure.Builder();
             structureBuilder.Set(BOOL_KEY, BOOL_VAL);
             structureBuilder.Set(STRING_KEY, STRING_VAL);
             structureBuilder.Set(INT_KEY, INT_VAL);
@@ -74,7 +74,7 @@ namespace OpenFeatureSDK.Tests
             String KEY = "key";
             bool VAL = true;
 
-            var structureBuilder = new StructureBuilder()
+            var structureBuilder = Structure.Builder()
                 .Set(KEY, VAL);
             Assert.Equal(1, structureBuilder.Build().Count);
             structureBuilder.Remove(KEY);
@@ -87,7 +87,7 @@ namespace OpenFeatureSDK.Tests
             String KEY = "key";
             String VAL = "val";
 
-            var structure = new StructureBuilder()
+            var structure = Structure.Builder()
                 .Set(KEY, VAL).Build();
             Value value;
             Assert.True(structure.TryGetValue(KEY, out value));
@@ -100,7 +100,7 @@ namespace OpenFeatureSDK.Tests
             String KEY = "key";
             Value VAL = new Value("val");
 
-            var structure = new StructureBuilder()
+            var structure = Structure.Builder()
                 .Set(KEY, VAL).Build();
             Assert.Equal(1, structure.Values.Count);
         }
@@ -111,7 +111,7 @@ namespace OpenFeatureSDK.Tests
             String KEY = "key";
             Value VAL = new Value("val");
 
-            var structure = new StructureBuilder()
+            var structure = Structure.Builder()
                 .Set(KEY, VAL).Build();
             Assert.Equal(1, structure.Keys.Count);
             Assert.Equal(0, structure.Keys.IndexOf(KEY));
@@ -123,7 +123,7 @@ namespace OpenFeatureSDK.Tests
             string KEY = "key";
             string VAL = "val";
 
-            var structure = new StructureBuilder()
+            var structure = Structure.Builder()
                 .Set(KEY, VAL).Build();
             IEnumerator<KeyValuePair<string, Value>> enumerator = structure.GetEnumerator();
             enumerator.MoveNext();

--- a/test/OpenFeatureSDK.Tests/TestImplementations.cs
+++ b/test/OpenFeatureSDK.Tests/TestImplementations.cs
@@ -11,7 +11,7 @@ namespace OpenFeatureSDK.Tests
     {
         public override Task<EvaluationContext> Before<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null)
         {
-            return Task.FromResult(new EvaluationContext());
+            return Task.FromResult(EvaluationContext.Empty);
         }
 
         public override Task After<T>(HookContext<T> context, FlagEvaluationDetails<T> details,

--- a/test/OpenFeatureSDK.Tests/ValueTests.cs
+++ b/test/OpenFeatureSDK.Tests/ValueTests.cs
@@ -124,7 +124,7 @@ namespace OpenFeatureSDK.Tests
         public void List_Arg_Should_Contain_List()
         {
             string ITEM_VALUE = "val";
-            IList<Value> innerValue = new List<Value>() {new Value(ITEM_VALUE)};
+            IList<Value> innerValue = new List<Value>() { new Value(ITEM_VALUE) };
             Value value = new Value(innerValue);
             Assert.True(value.IsList);
             Assert.Equal(ITEM_VALUE, value.AsList[0].AsString);

--- a/test/OpenFeatureSDK.Tests/ValueTests.cs
+++ b/test/OpenFeatureSDK.Tests/ValueTests.cs
@@ -114,7 +114,7 @@ namespace OpenFeatureSDK.Tests
         {
             string INNER_KEY = "key";
             string INNER_VALUE = "val";
-            Structure innerValue = new StructureBuilder().Set(INNER_KEY, INNER_VALUE).Build();
+            Structure innerValue = Structure.Builder().Set(INNER_KEY, INNER_VALUE).Build();
             Value value = new Value(innerValue);
             Assert.True(value.IsStructure);
             Assert.Equal(INNER_VALUE, value.AsStructure.GetValue(INNER_KEY).AsString);

--- a/test/OpenFeatureSDK.Tests/ValueTests.cs
+++ b/test/OpenFeatureSDK.Tests/ValueTests.cs
@@ -7,7 +7,9 @@ namespace OpenFeatureSDK.Tests
 {
     public class ValueTests
     {
-        class Foo { }
+        class Foo
+        {
+        }
 
         [Fact]
         public void No_Arg_Should_Contain_Null()
@@ -19,24 +21,23 @@ namespace OpenFeatureSDK.Tests
         [Fact]
         public void Object_Arg_Should_Contain_Object()
         {
-            try
+            // int is a special case, see Int_Object_Arg_Should_Contain_Object()
+            IList<Object> list = new List<Object>()
             {
-                // int is a special case, see Int_Object_Arg_Should_Contain_Object()
-                IList<Object> list = new List<Object>(){
-                    true, "val", .5, new Structure(), new List<Value>(), DateTime.Now
-                };
+                true,
+                "val",
+                .5,
+                Structure.Empty,
+                new List<Value>(),
+                DateTime.Now
+            };
 
-                int i = 0;
-                foreach (Object l in list)
-                {
-                    Value value = new Value(l);
-                    Assert.Equal(list[i], value.AsObject);
-                    i++;
-                }
-            }
-            catch (Exception)
+            int i = 0;
+            foreach (Object l in list)
             {
-                Assert.True(false, "Expected no exception.");
+                Value value = new Value(l);
+                Assert.Equal(list[i], value.AsObject);
+                i++;
             }
         }
 
@@ -80,7 +81,7 @@ namespace OpenFeatureSDK.Tests
             double innerDoubleValue = .75;
             Value doubleValue = new Value(innerDoubleValue);
             Assert.True(doubleValue.IsNumber);
-            Assert.Equal(1, doubleValue.AsInteger);     // should be rounded
+            Assert.Equal(1, doubleValue.AsInteger); // should be rounded
             Assert.Equal(.75, doubleValue.AsDouble);
 
             int innerIntValue = 100;
@@ -113,20 +114,17 @@ namespace OpenFeatureSDK.Tests
         {
             string INNER_KEY = "key";
             string INNER_VALUE = "val";
-            Structure innerValue = new Structure().Add(INNER_KEY, INNER_VALUE);
+            Structure innerValue = new StructureBuilder().Set(INNER_KEY, INNER_VALUE).Build();
             Value value = new Value(innerValue);
             Assert.True(value.IsStructure);
             Assert.Equal(INNER_VALUE, value.AsStructure.GetValue(INNER_KEY).AsString);
         }
 
         [Fact]
-        public void LIst_Arg_Should_Contain_LIst()
+        public void List_Arg_Should_Contain_List()
         {
             string ITEM_VALUE = "val";
-            IList<Value> innerValue = new List<Value>()
-            {
-                new Value(ITEM_VALUE)
-            };
+            IList<Value> innerValue = new List<Value>() {new Value(ITEM_VALUE)};
             Value value = new Value(innerValue);
             Assert.True(value.IsList);
             Assert.Equal(ITEM_VALUE, value.AsList[0].AsString);


### PR DESCRIPTION
Proof of concept implementing builders for `EvaluationContext` and `Structure` types to address context threading concerns.

```
var sample = Structure.Builder().Set("key", "val").Build();
var context = EvalContext.Builder().Set("my-struct", sample).Build();

```

This allows for the context provided to the client to be immutable, and for immutability for the duration of a hook.