### PR TITLE
feat!: Thread safe hooks, provider, and context

### DIFF
--- a/src/OpenFeatureSDK/FeatureProvider.cs
+++ b/src/OpenFeatureSDK/FeatureProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using OpenFeatureSDK.Model;
 
@@ -22,8 +23,8 @@ namespace OpenFeatureSDK
         /// error (if applicable): Provider, Invocation, Client, API
         /// finally: Provider, Invocation, Client, API
         /// </summary>
-        /// <returns></returns>
-        public virtual IReadOnlyList<Hook> GetProviderHooks() => Array.Empty<Hook>();
+        /// <returns>Immutable list of hooks</returns>
+        public virtual IImmutableList<Hook> GetProviderHooks() => ImmutableList<Hook>.Empty;
 
         /// <summary>
         /// Metadata describing the provider.

--- a/src/OpenFeatureSDK/FeatureProvider.cs
+++ b/src/OpenFeatureSDK/FeatureProvider.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using OpenFeatureSDK.Model;

--- a/src/OpenFeatureSDK/Model/FlagEvaluationOptions.cs
+++ b/src/OpenFeatureSDK/Model/FlagEvaluationOptions.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace OpenFeatureSDK.Model

--- a/src/OpenFeatureSDK/Model/FlagEvaluationOptions.cs
+++ b/src/OpenFeatureSDK/Model/FlagEvaluationOptions.cs
@@ -22,7 +22,7 @@ namespace OpenFeatureSDK.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FlagEvaluationOptions"/> class.
         /// </summary>
-        /// <param name="hooks"></param>
+        /// <param name="hooks">An immutable list of hooks to use during evaluation</param>
         /// <param name="hookHints">Optional - a list of hints that are passed through the hook lifecycle</param>
         public FlagEvaluationOptions(IImmutableList<Hook> hooks, IImmutableDictionary<string, object> hookHints = null)
         {
@@ -33,7 +33,7 @@ namespace OpenFeatureSDK.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FlagEvaluationOptions"/> class.
         /// </summary>
-        /// <param name="hook"></param>
+        /// <param name="hook">A hook to use during the evaluation</param>
         /// <param name="hookHints">Optional - a list of hints that are passed through the hook lifecycle</param>
         public FlagEvaluationOptions(Hook hook, ImmutableDictionary<string, object> hookHints = null)
         {

--- a/src/OpenFeatureSDK/Model/FlagEvaluationOptions.cs
+++ b/src/OpenFeatureSDK/Model/FlagEvaluationOptions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace OpenFeatureSDK.Model
 {
@@ -12,22 +13,22 @@ namespace OpenFeatureSDK.Model
         /// <summary>
         /// A immutable list of <see cref="Hook"/>
         /// </summary>
-        public IReadOnlyList<Hook> Hooks { get; }
+        public IImmutableList<Hook> Hooks { get; }
 
         /// <summary>
         /// A immutable dictionary of hook hints
         /// </summary>
-        public IReadOnlyDictionary<string, object> HookHints { get; }
+        public IImmutableDictionary<string, object> HookHints { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FlagEvaluationOptions"/> class.
         /// </summary>
         /// <param name="hooks"></param>
         /// <param name="hookHints">Optional - a list of hints that are passed through the hook lifecycle</param>
-        public FlagEvaluationOptions(IReadOnlyList<Hook> hooks, IReadOnlyDictionary<string, object> hookHints = null)
+        public FlagEvaluationOptions(IImmutableList<Hook> hooks, IImmutableDictionary<string, object> hookHints = null)
         {
             this.Hooks = hooks;
-            this.HookHints = hookHints ?? new Dictionary<string, object>();
+            this.HookHints = hookHints ?? ImmutableDictionary<string, object>.Empty;
         }
 
         /// <summary>
@@ -35,10 +36,10 @@ namespace OpenFeatureSDK.Model
         /// </summary>
         /// <param name="hook"></param>
         /// <param name="hookHints">Optional - a list of hints that are passed through the hook lifecycle</param>
-        public FlagEvaluationOptions(Hook hook, IReadOnlyDictionary<string, object> hookHints = null)
+        public FlagEvaluationOptions(Hook hook, ImmutableDictionary<string, object> hookHints = null)
         {
-            this.Hooks = new[] { hook };
-            this.HookHints = hookHints ?? new Dictionary<string, object>();
+            this.Hooks = ImmutableList.Create(hook);
+            this.HookHints = hookHints ?? ImmutableDictionary<string, object>.Empty;
         }
     }
 }

--- a/src/OpenFeatureSDK/OpenFeature.cs
+++ b/src/OpenFeatureSDK/OpenFeature.cs
@@ -51,6 +51,13 @@ namespace OpenFeatureSDK
 
         /// <summary>
         /// Gets the feature provider
+        /// <para>
+        /// The feature provider may be set from multiple threads, when accessing the global feature provider
+        /// it should be accessed once for an operation, and then that reference should be used for all dependent
+        /// operations. For instance, during an evaluation the flag resolution method, and the provider hooks
+        /// should be accessed from the same reference, not two independent calls to
+        /// <see cref="OpenFeature.GetProvider"/>.
+        /// </para>
         /// </summary>
         /// <returns><see cref="FeatureProvider"/></returns>
         public FeatureProvider GetProvider()
@@ -68,6 +75,11 @@ namespace OpenFeatureSDK
 
         /// <summary>
         /// Gets providers metadata
+        /// <para>
+        /// This method is not guaranteed to return the same provider instance that may be used during an evaluation
+        /// in the case where the provider may be changed from another thread.
+        /// For multiple dependent provider operations see <see cref="OpenFeature.GetProvider"/>.
+        /// </para>
         /// </summary>
         /// <returns><see cref="ClientMetadata"/></returns>
         public Metadata GetProviderMetadata() => this.GetProvider().GetMetadata();
@@ -131,6 +143,12 @@ namespace OpenFeatureSDK
 
         /// <summary>
         /// Gets the global <see cref="EvaluationContext"/>
+        /// <para>
+        /// The evaluation context may be set from multiple threads, when accessing the global evaluation context
+        /// it should be accessed once for an operation, and then that reference should be used for all dependent
+        /// operations.
+        /// <see cref="OpenFeature.GetProvider"/>.
+        /// </para>
         /// </summary>
         /// <returns>An <see cref="EvaluationContext"/></returns>
         public EvaluationContext GetContext()

--- a/src/OpenFeatureSDK/OpenFeature.cs
+++ b/src/OpenFeatureSDK/OpenFeature.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/OpenFeatureSDK/OpenFeature.cs
+++ b/src/OpenFeatureSDK/OpenFeature.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using OpenFeatureSDK.Model;
 
@@ -13,7 +15,7 @@ namespace OpenFeatureSDK
     {
         private EvaluationContext _evaluationContext = EvaluationContext.Empty;
         private FeatureProvider _featureProvider = new NoOpFeatureProvider();
-        private readonly List<Hook> _hooks = new List<Hook>();
+        private readonly ConcurrentStack<Hook> _hooks = new ConcurrentStack<Hook>();
 
         /// <summary>
         /// Singleton instance of OpenFeature
@@ -59,19 +61,19 @@ namespace OpenFeatureSDK
         /// Appends list of hooks to global hooks list
         /// </summary>
         /// <param name="hooks">A list of <see cref="Hook"/></param>
-        public void AddHooks(IEnumerable<Hook> hooks) => this._hooks.AddRange(hooks);
+        public void AddHooks(IEnumerable<Hook> hooks) => this._hooks.PushRange(hooks.ToArray());
 
         /// <summary>
         /// Adds a hook to global hooks list
         /// </summary>
         /// <param name="hook">A list of <see cref="Hook"/></param>
-        public void AddHooks(Hook hook) => this._hooks.Add(hook);
+        public void AddHooks(Hook hook) => this._hooks.Push(hook);
 
         /// <summary>
         /// Returns the global immutable hooks list
         /// </summary>
         /// <returns>A immutable list of <see cref="Hook"/></returns>
-        public IReadOnlyList<Hook> GetHooks() => this._hooks.AsReadOnly();
+        public IEnumerable<Hook> GetHooks() => this._hooks;
 
         /// <summary>
         /// Removes all hooks from global hooks list

--- a/src/OpenFeatureSDK/OpenFeature.cs
+++ b/src/OpenFeatureSDK/OpenFeature.cs
@@ -79,7 +79,7 @@ namespace OpenFeatureSDK
         /// Returns the global immutable hooks list
         /// </summary>
         /// <returns>A immutable list of <see cref="Hook"/></returns>
-        public IEnumerable<Hook> GetHooks() => this._hooks;
+        public IEnumerable<Hook> GetHooks() => this._hooks.Reverse();
 
         /// <summary>
         /// Removes all hooks from global hooks list

--- a/src/OpenFeatureSDK/OpenFeature.cs
+++ b/src/OpenFeatureSDK/OpenFeature.cs
@@ -154,7 +154,6 @@ namespace OpenFeatureSDK
         /// The evaluation context may be set from multiple threads, when accessing the global evaluation context
         /// it should be accessed once for an operation, and then that reference should be used for all dependent
         /// operations.
-        /// <see cref="OpenFeature.GetProvider"/>.
         /// </para>
         /// </summary>
         /// <returns>An <see cref="EvaluationContext"/></returns>

--- a/src/OpenFeatureSDK/OpenFeature.cs
+++ b/src/OpenFeatureSDK/OpenFeature.cs
@@ -39,8 +39,14 @@ namespace OpenFeatureSDK
         public void SetProvider(FeatureProvider featureProvider)
         {
             this._featureProviderLock.EnterWriteLock();
-            this._featureProvider = featureProvider;
-            this._featureProviderLock.ExitWriteLock();
+            try
+            {
+                this._featureProvider = featureProvider;
+            }
+            finally
+            {
+                this._featureProviderLock.ExitWriteLock();
+            }
         }
 
         /// <summary>

--- a/src/OpenFeatureSDK/OpenFeature.cs
+++ b/src/OpenFeatureSDK/OpenFeature.cs
@@ -76,9 +76,14 @@ namespace OpenFeatureSDK
         public void AddHooks(Hook hook) => this._hooks.Push(hook);
 
         /// <summary>
-        /// Returns the global immutable hooks list
+        /// Enumerates the global hooks.
+        /// <para>
+        /// The items enumerated will reflect the registered hooks
+        /// at the start of enumeration. Hooks added during enumeration
+        /// will not be included.
+        /// </para>
         /// </summary>
-        /// <returns>A immutable list of <see cref="Hook"/></returns>
+        /// <returns>Enumeration of <see cref="Hook"/></returns>
         public IEnumerable<Hook> GetHooks() => this._hooks.Reverse();
 
         /// <summary>

--- a/src/OpenFeatureSDK/OpenFeature.cs
+++ b/src/OpenFeatureSDK/OpenFeature.cs
@@ -19,6 +19,7 @@ namespace OpenFeatureSDK
         private FeatureProvider _featureProvider = new NoOpFeatureProvider();
         private readonly ConcurrentStack<Hook> _hooks = new ConcurrentStack<Hook>();
 
+        /// The reader/writer locks are not disposed because the singleton instance should never be disposed.
         private readonly ReaderWriterLockSlim _evaluationContextLock = new ReaderWriterLockSlim();
         private readonly ReaderWriterLockSlim _featureProviderLock = new ReaderWriterLockSlim();
 

--- a/src/OpenFeatureSDK/OpenFeature.cs
+++ b/src/OpenFeatureSDK/OpenFeature.cs
@@ -98,14 +98,21 @@ namespace OpenFeatureSDK
 
         /// <summary>
         /// Appends list of hooks to global hooks list
+        /// <para>
+        /// The appending operation will be atomic.
+        /// </para>
         /// </summary>
         /// <param name="hooks">A list of <see cref="Hook"/></param>
         public void AddHooks(IEnumerable<Hook> hooks) => this._hooks.PushRange(hooks.ToArray());
 
         /// <summary>
         /// Adds a hook to global hooks list
+        /// <para>
+        /// Hooks which are dependent on each other should be provided in a collection
+        /// using the <see cref="AddHooks(System.Collections.Generic.IEnumerable{OpenFeatureSDK.Hook})"/>.
+        /// </para>
         /// </summary>
-        /// <param name="hook">A list of <see cref="Hook"/></param>
+        /// <param name="hook">Hook that implements the <see cref="Hook"/> interface</param>
         public void AddHooks(Hook hook) => this._hooks.Push(hook);
 
         /// <summary>

--- a/src/OpenFeatureSDK/OpenFeatureClient.cs
+++ b/src/OpenFeatureSDK/OpenFeatureClient.cs
@@ -67,9 +67,14 @@ namespace OpenFeatureSDK
         public void AddHooks(IEnumerable<Hook> hooks) => this._hooks.PushRange(hooks.ToArray());
 
         /// <summary>
-        /// Return a immutable list of hooks that are registered against the client
+        /// Enumerates the global hooks.
+        /// <para>
+        /// The items enumerated will reflect the registered hooks
+        /// at the start of enumeration. Hooks added during enumeration
+        /// will not be included.
+        /// </para>
         /// </summary>
-        /// <returns>A list of immutable hooks</returns>
+        /// <returns>Enumeration of <see cref="Hook"/></returns>
         public IEnumerable<Hook> GetHooks() => this._hooks.Reverse();
 
         /// <summary>

--- a/src/OpenFeatureSDK/OpenFeatureClient.cs
+++ b/src/OpenFeatureSDK/OpenFeatureClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -23,7 +22,7 @@ namespace OpenFeatureSDK
         private readonly ILogger _logger;
         private EvaluationContext _evaluationContext;
 
-        private readonly ReaderWriterLockSlim _evaluationContextLock = new ReaderWriterLockSlim();
+        private readonly object _evaluationContextLock = new object();
 
         /// <summary>
         /// Get a provider and an associated typed flag resolution method.
@@ -65,14 +64,9 @@ namespace OpenFeatureSDK
         /// <returns><see cref="EvaluationContext"/>of this client</returns>
         public EvaluationContext GetContext()
         {
-            this._evaluationContextLock.EnterReadLock();
-            try
+            lock (this._evaluationContextLock)
             {
                 return this._evaluationContext;
-            }
-            finally
-            {
-                this._evaluationContextLock.ExitReadLock();
             }
         }
 
@@ -82,14 +76,9 @@ namespace OpenFeatureSDK
         /// <param name="context">The <see cref="EvaluationContext"/> to set</param>
         public void SetContext(EvaluationContext context)
         {
-            this._evaluationContextLock.EnterWriteLock();
-            try
+            lock (this._evaluationContextLock)
             {
                 this._evaluationContext = context ?? EvaluationContext.Empty;
-            }
-            finally
-            {
-                this._evaluationContextLock.ExitWriteLock();
             }
         }
 

--- a/src/OpenFeatureSDK/OpenFeatureClient.cs
+++ b/src/OpenFeatureSDK/OpenFeatureClient.cs
@@ -41,6 +41,12 @@ namespace OpenFeatureSDK
             // Alias the provider reference so getting the method and returning the provider are
             // guaranteed to be the same object.
             var provider = OpenFeature.Instance.GetProvider();
+
+            if (provider == null)
+            {
+                provider = new NoOpFeatureProvider();
+                this._logger.LogDebug("No provider configured, using no-op provider");
+            }
             return (method(provider), provider);
         }
 
@@ -242,6 +248,7 @@ namespace OpenFeatureSDK
         {
             var resolveValueDelegate = providerInfo.Item1;
             var provider = providerInfo.Item2;
+
             // New up a evaluation context if one was not provided.
             if (context == null)
             {

--- a/src/OpenFeatureSDK/OpenFeatureClient.cs
+++ b/src/OpenFeatureSDK/OpenFeatureClient.cs
@@ -17,7 +17,6 @@ namespace OpenFeatureSDK
     public sealed class FeatureClient : IFeatureClient
     {
         private readonly ClientMetadata _metadata;
-        private readonly FeatureProvider _featureProvider;
         private readonly List<Hook> _hooks = new List<Hook>();
         private readonly ILogger _logger;
         private EvaluationContext _evaluationContext;
@@ -36,15 +35,13 @@ namespace OpenFeatureSDK
         /// <summary>
         /// Initializes a new instance of the <see cref="FeatureClient"/> class.
         /// </summary>
-        /// <param name="featureProvider">Feature provider used by client <see cref="FeatureProvider"/></param>
         /// <param name="name">Name of client <see cref="ClientMetadata"/></param>
         /// <param name="version">Version of client <see cref="ClientMetadata"/></param>
         /// <param name="logger">Logger used by client</param>
         /// <param name="context">Context given to this client</param>
         /// <exception cref="ArgumentNullException">Throws if any of the required parameters are null</exception>
-        public FeatureClient(FeatureProvider featureProvider, string name, string version, ILogger logger = null, EvaluationContext context = null)
+        public FeatureClient(string name, string version, ILogger logger = null, EvaluationContext context = null)
         {
-            this._featureProvider = featureProvider ?? throw new ArgumentNullException(nameof(featureProvider));
             this._metadata = new ClientMetadata(name, version);
             this._logger = logger ?? new Logger<OpenFeature>(new NullLoggerFactory());
             this._evaluationContext = context ?? EvaluationContext.Empty;
@@ -101,7 +98,7 @@ namespace OpenFeatureSDK
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         public async Task<FlagEvaluationDetails<bool>> GetBooleanDetails(string flagKey, bool defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
-            await this.EvaluateFlag(this._featureProvider.ResolveBooleanValue, FlagValueType.Boolean, flagKey,
+            await this.EvaluateFlag(OpenFeature.Instance.GetProvider().ResolveBooleanValue, FlagValueType.Boolean, flagKey,
                 defaultValue, context, config);
 
         /// <summary>
@@ -126,7 +123,7 @@ namespace OpenFeatureSDK
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         public async Task<FlagEvaluationDetails<string>> GetStringDetails(string flagKey, string defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
-            await this.EvaluateFlag(this._featureProvider.ResolveStringValue, FlagValueType.String, flagKey,
+            await this.EvaluateFlag(OpenFeature.Instance.GetProvider().ResolveStringValue, FlagValueType.String, flagKey,
                 defaultValue, context, config);
 
         /// <summary>
@@ -151,7 +148,7 @@ namespace OpenFeatureSDK
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         public async Task<FlagEvaluationDetails<int>> GetIntegerDetails(string flagKey, int defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
-            await this.EvaluateFlag(this._featureProvider.ResolveIntegerValue, FlagValueType.Number, flagKey,
+            await this.EvaluateFlag(OpenFeature.Instance.GetProvider().ResolveIntegerValue, FlagValueType.Number, flagKey,
                 defaultValue, context, config);
 
         /// <summary>
@@ -177,7 +174,7 @@ namespace OpenFeatureSDK
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         public async Task<FlagEvaluationDetails<double>> GetDoubleDetails(string flagKey, double defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
-            await this.EvaluateFlag(this._featureProvider.ResolveDoubleValue, FlagValueType.Number, flagKey,
+            await this.EvaluateFlag(OpenFeature.Instance.GetProvider().ResolveDoubleValue, FlagValueType.Number, flagKey,
                 defaultValue, context, config);
 
         /// <summary>
@@ -202,7 +199,7 @@ namespace OpenFeatureSDK
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         public async Task<FlagEvaluationDetails<Value>> GetObjectDetails(string flagKey, Value defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
-            await this.EvaluateFlag(this._featureProvider.ResolveStructureValue, FlagValueType.Object, flagKey,
+            await this.EvaluateFlag(OpenFeature.Instance.GetProvider().ResolveStructureValue, FlagValueType.Object, flagKey,
                 defaultValue, context, config);
 
         private async Task<FlagEvaluationDetails<T>> EvaluateFlag<T>(
@@ -227,7 +224,7 @@ namespace OpenFeatureSDK
                 .Concat(OpenFeature.Instance.GetHooks())
                 .Concat(this._hooks)
                 .Concat(options?.Hooks ?? Enumerable.Empty<Hook>())
-                .Concat(this._featureProvider.GetProviderHooks())
+                .Concat(OpenFeature.Instance.GetProvider().GetProviderHooks())
                 .ToList()
                 .AsReadOnly();
 

--- a/src/OpenFeatureSDK/OpenFeatureClient.cs
+++ b/src/OpenFeatureSDK/OpenFeatureClient.cs
@@ -47,6 +47,7 @@ namespace OpenFeatureSDK
                 provider = new NoOpFeatureProvider();
                 this._logger.LogDebug("No provider configured, using no-op provider");
             }
+
             return (method(provider), provider);
         }
 
@@ -84,12 +85,19 @@ namespace OpenFeatureSDK
 
         /// <summary>
         /// Add hook to client
+        /// <para>
+        /// Hooks which are dependent on each other should be provided in a collection
+        /// using the <see cref="AddHooks(System.Collections.Generic.IEnumerable{OpenFeatureSDK.Hook})"/>.
+        /// </para>
         /// </summary>
         /// <param name="hook">Hook that implements the <see cref="Hook"/> interface</param>
         public void AddHooks(Hook hook) => this._hooks.Push(hook);
 
         /// <summary>
         /// Appends hooks to client
+        /// <para>
+        /// The appending operation will be atomic.
+        /// </para>
         /// </summary>
         /// <param name="hooks">A list of Hooks that implement the <see cref="Hook"/> interface</param>
         public void AddHooks(IEnumerable<Hook> hooks) => this._hooks.PushRange(hooks.ToArray());

--- a/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture;
 using FluentAssertions;
@@ -31,14 +32,14 @@ namespace OpenFeatureSDK.Tests
             client.AddHooks(new[] { hook1, hook2 });
 
             client.GetHooks().Should().ContainInOrder(hook1, hook2);
-            client.GetHooks().Count.Should().Be(2);
+            client.GetHooks().Count().Should().Be(2);
 
             client.AddHooks(hook3);
             client.GetHooks().Should().ContainInOrder(hook1, hook2, hook3);
-            client.GetHooks().Count.Should().Be(3);
+            client.GetHooks().Count().Should().Be(3);
 
             client.ClearHooks();
-            client.GetHooks().Count.Should().Be(0);
+            Assert.Empty(client.GetHooks());
         }
 
         [Fact]

--- a/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using AutoFixture;
 using FluentAssertions;
@@ -68,7 +69,7 @@ namespace OpenFeatureSDK.Tests
             var defaultIntegerValue = fixture.Create<int>();
             var defaultDoubleValue = fixture.Create<double>();
             var defaultStructureValue = fixture.Create<Value>();
-            var emptyFlagOptions = new FlagEvaluationOptions(new List<Hook>(), new Dictionary<string, object>());
+            var emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
             OpenFeature.Instance.SetProvider(new NoOpFeatureProvider());
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -114,7 +115,7 @@ namespace OpenFeatureSDK.Tests
             var defaultIntegerValue = fixture.Create<int>();
             var defaultDoubleValue = fixture.Create<double>();
             var defaultStructureValue = fixture.Create<Value>();
-            var emptyFlagOptions = new FlagEvaluationOptions(new List<Hook>(), new Dictionary<string, object>());
+            var emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
             OpenFeature.Instance.SetProvider(new NoOpFeatureProvider());
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -169,7 +170,7 @@ namespace OpenFeatureSDK.Tests
             mockedFeatureProvider.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
             mockedFeatureProvider.Setup(x => x.GetProviderHooks())
-                .Returns(Array.Empty<Hook>());
+                .Returns(ImmutableList<Hook>.Empty);
 
             OpenFeature.Instance.SetProvider(mockedFeatureProvider.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion, mockedLogger.Object);
@@ -206,7 +207,7 @@ namespace OpenFeatureSDK.Tests
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.Setup(x => x.GetProviderHooks())
-                .Returns(Array.Empty<Hook>());
+                .Returns(ImmutableList<Hook>.Empty);
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -232,7 +233,7 @@ namespace OpenFeatureSDK.Tests
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.Setup(x => x.GetProviderHooks())
-                .Returns(Array.Empty<Hook>());
+                .Returns(ImmutableList<Hook>.Empty);
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -258,7 +259,7 @@ namespace OpenFeatureSDK.Tests
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.Setup(x => x.GetProviderHooks())
-                .Returns(Array.Empty<Hook>());
+                .Returns(ImmutableList<Hook>.Empty);
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -284,7 +285,7 @@ namespace OpenFeatureSDK.Tests
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.Setup(x => x.GetProviderHooks())
-                .Returns(Array.Empty<Hook>());
+                .Returns(ImmutableList<Hook>.Empty);
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -310,7 +311,7 @@ namespace OpenFeatureSDK.Tests
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.Setup(x => x.GetProviderHooks())
-                .Returns(Array.Empty<Hook>());
+                .Returns(ImmutableList<Hook>.Empty);
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -338,7 +339,7 @@ namespace OpenFeatureSDK.Tests
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.Setup(x => x.GetProviderHooks())
-                .Returns(Array.Empty<Hook>());
+                .Returns(ImmutableList<Hook>.Empty);
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);
@@ -367,7 +368,7 @@ namespace OpenFeatureSDK.Tests
             featureProviderMock.Setup(x => x.GetMetadata())
                 .Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.Setup(x => x.GetProviderHooks())
-                .Returns(Array.Empty<Hook>());
+                .Returns(ImmutableList<Hook>.Empty);
 
             OpenFeature.Instance.SetProvider(featureProviderMock.Object);
             var client = OpenFeature.Instance.GetClient(clientName, clientVersion);

--- a/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
@@ -381,13 +381,6 @@ namespace OpenFeatureSDK.Tests
         }
 
         [Fact]
-        public void Should_Throw_ArgumentNullException_When_Provider_Is_Null()
-        {
-            TestProvider provider = null;
-            Assert.Throws<ArgumentNullException>(() => new FeatureClient(provider, "test", "test"));
-        }
-
-        [Fact]
         public void Should_Get_And_Set_Context()
         {
             var KEY = "key";

--- a/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureClientTests.cs
@@ -382,6 +382,14 @@ namespace OpenFeatureSDK.Tests
         }
 
         [Fact]
+        public async Task Should_Use_No_Op_When_Provider_Is_Null()
+        {
+            OpenFeature.Instance.SetProvider(null);
+            var client = new FeatureClient("test", "test");
+            (await client.GetIntegerValue("some-key", 12)).Should().Be(12);
+        }
+
+        [Fact]
         public void Should_Get_And_Set_Context()
         {
             var KEY = "key";

--- a/test/OpenFeatureSDK.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureHookTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture;
 using FluentAssertions;
@@ -355,7 +356,7 @@ namespace OpenFeatureSDK.Tests
                 new FlagEvaluationOptions(hook3.Object, ImmutableDictionary<string, object>.Empty));
 
             Assert.Single(OpenFeature.Instance.GetHooks());
-            client.GetHooks().Count.Should().Be(1);
+            client.GetHooks().Count().Should().Be(1);
             testProvider.GetProviderHooks().Count.Should().Be(1);
         }
 
@@ -406,7 +407,7 @@ namespace OpenFeatureSDK.Tests
             OpenFeature.Instance.SetProvider(featureProvider.Object);
             var client = OpenFeature.Instance.GetClient();
             client.AddHooks(new[] { hook1.Object, hook2.Object });
-            client.GetHooks().Count.Should().Be(2);
+            client.GetHooks().Count().Should().Be(2);
 
             await client.GetBooleanValue("test", false);
 

--- a/test/OpenFeatureSDK.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FluentAssertions;
 using Moq;
 using OpenFeatureSDK.Constant;
@@ -34,18 +35,18 @@ namespace OpenFeatureSDK.Tests
             openFeature.AddHooks(hook1);
 
             openFeature.GetHooks().Should().Contain(hook1);
-            openFeature.GetHooks().Count.Should().Be(1);
+            Assert.Single(openFeature.GetHooks());
 
             openFeature.AddHooks(hook2);
-            openFeature.GetHooks().Should().ContainInOrder(hook1, hook2);
-            openFeature.GetHooks().Count.Should().Be(2);
+            openFeature.GetHooks().Should().ContainInOrder(hook2, hook1);
+            openFeature.GetHooks().Count().Should().Be(2);
 
             openFeature.AddHooks(new[] { hook3, hook4 });
-            openFeature.GetHooks().Should().ContainInOrder(hook1, hook2, hook3, hook4);
-            openFeature.GetHooks().Count.Should().Be(4);
+            openFeature.GetHooks().Should().ContainInOrder(hook4, hook3, hook2, hook1);
+            openFeature.GetHooks().Count().Should().Be(4);
 
             openFeature.ClearHooks();
-            openFeature.GetHooks().Count.Should().Be(0);
+            Assert.Empty(openFeature.GetHooks());
         }
 
         [Fact]

--- a/test/OpenFeatureSDK.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeatureSDK.Tests/OpenFeatureTests.cs
@@ -38,11 +38,11 @@ namespace OpenFeatureSDK.Tests
             Assert.Single(openFeature.GetHooks());
 
             openFeature.AddHooks(hook2);
-            openFeature.GetHooks().Should().ContainInOrder(hook2, hook1);
+            openFeature.GetHooks().Should().ContainInOrder(hook1, hook2);
             openFeature.GetHooks().Count().Should().Be(2);
 
             openFeature.AddHooks(new[] { hook3, hook4 });
-            openFeature.GetHooks().Should().ContainInOrder(hook4, hook3, hook2, hook1);
+            openFeature.GetHooks().Should().ContainInOrder(hook1, hook2, hook3, hook4);
             openFeature.GetHooks().Count().Should().Be(4);
 
             openFeature.ClearHooks();

--- a/test/OpenFeatureSDK.Tests/TestImplementations.cs
+++ b/test/OpenFeatureSDK.Tests/TestImplementations.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using OpenFeatureSDK.Model;
 
@@ -39,7 +40,7 @@ namespace OpenFeatureSDK.Tests
 
         public void AddHook(Hook hook) => this._hooks.Add(hook);
 
-        public override IReadOnlyList<Hook> GetProviderHooks() => this._hooks.AsReadOnly();
+        public override IImmutableList<Hook> GetProviderHooks() => this._hooks.ToImmutableList();
 
         public override Metadata GetMetadata()
         {


### PR DESCRIPTION
- Change storage type of global hooks to a concurrent stack.
    - Should be able to add and remove from this without locking,
- Protect references used from multiple threads with a Read/Write lock.
- Change read only collection types to immutable collection types.
    - Readonly collections are just views into existing mutable collections. So they are still subject to the same modification problems. Immutable collections are supposed to be fixed and unchanging. Considering they are an interface you could still violate this constraint, but it is less likely.

Related to: https://github.com/open-feature/dotnet-sdk/issues/56