### PR TITLE
chore: exclude component in git tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "monorepo-tags": false,
+      "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default",


### PR DESCRIPTION
This change prevents Release Please from adding the component name in the release tag. It looks like currently that's not a problem but this will prevent it from happening if the component name detection changes in the future.

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>
