### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenFeature SDK for .NET
 
 [![a](https://img.shields.io/badge/slack-%40cncf%2Fopenfeature-brightgreen?style=flat&logo=slack)](https://cloud-native.slack.com/archives/C0344AANLA1)
-[![spec version badge](https://img.shields.io/badge/Specification-v0.5.0-yellow)](https://github.com/open-feature/spec/tree/v0.5.0?rgh-link-date=2022-09-27T17%3A53%3A52Z)
+[![spec version badge](https://img.shields.io/badge/Specification-v0.5.2-yellow)](https://github.com/open-feature/spec/tree/v0.5.2?rgh-link-date=2023-01-20T21%3A37%3A52Z)
 [![codecov](https://codecov.io/gh/open-feature/dotnet-sdk/branch/main/graph/badge.svg?token=MONAVJBXUJ)](https://codecov.io/gh/open-feature/dotnet-sdk)
 [![nuget](https://img.shields.io/nuget/vpre/OpenFeature)](https://www.nuget.org/packages/OpenFeature)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6250/badge)](https://bestpractices.coreinfrastructure.org/projects/6250)

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -11,7 +11,7 @@ namespace OpenFeature
     /// The evaluation API allows for the evaluation of feature flag values, independent of any flag control plane or vendor.
     /// In the absence of a provider the evaluation API uses the "No-op provider", which simply returns the supplied default flag value.
     /// </summary>
-    /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/flag-evaluation.md#flag-evaluation-api"/>
+    /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/sections/01-flag-evaluation.md#1-flag-evaluation-api"/>
     public sealed class Api
     {
         private EvaluationContext _evaluationContext = EvaluationContext.Empty;

--- a/src/OpenFeature/Constant/ErrorType.cs
+++ b/src/OpenFeature/Constant/ErrorType.cs
@@ -5,7 +5,7 @@ namespace OpenFeature.Constant
     /// <summary>
     /// These errors are used to indicate abnormal execution when evaluation a flag
     /// </summary>
-    /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/providers.md#requirement-28"/>
+    /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/sections/02-providers.md#requirement-227"/>
     public enum ErrorType
     {
         /// <summary>

--- a/src/OpenFeature/Constant/Reason.cs
+++ b/src/OpenFeature/Constant/Reason.cs
@@ -3,7 +3,7 @@ namespace OpenFeature.Constant
     /// <summary>
     /// Common reasons used during flag resolution
     /// </summary>
-    /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/providers.md#requirement-26">Reason Specification</seealso>
+    /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/sections/02-providers.md#requirement-225">Reason Specification</seealso>
     public static class Reason
     {
         /// <summary>

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -8,7 +8,7 @@ namespace OpenFeature
     /// The provider interface describes the abstraction layer for a feature flag provider.
     /// A provider acts as the translates layer between the generic feature flag structure to a target feature flag system.
     /// </summary>
-    /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/providers.md">Provider specification</seealso>
+    /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/sections/02-providers.md">Provider specification</seealso>
     public abstract class FeatureProvider
     {
         /// <summary>

--- a/src/OpenFeature/Hook.cs
+++ b/src/OpenFeature/Hook.cs
@@ -18,7 +18,7 @@ namespace OpenFeature
     /// Hooks can be configured to run globally (impacting all flag evaluations), per client, or per flag evaluation invocation.
     ///
     /// </summary>
-    /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/hooks.md">Hook Specification</seealso>
+    /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/sections/04-hooks.md">Hook Specification</seealso>
     public abstract class Hook
     {
         /// <summary>

--- a/src/OpenFeature/Model/EvaluationContext.cs
+++ b/src/OpenFeature/Model/EvaluationContext.cs
@@ -8,7 +8,7 @@ namespace OpenFeature.Model
     /// A KeyValuePair with a string key and object value that is used to apply user defined properties
     /// to the feature flag evaluation context.
     /// </summary>
-    /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/evaluation-context.md">Evaluation context</seealso>
+    /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/sections/03-evaluation-context.md">Evaluation context</seealso>
     public sealed class EvaluationContext
     {
         private readonly Structure _structure;

--- a/src/OpenFeature/Model/FlagEvaluationDetails.cs
+++ b/src/OpenFeature/Model/FlagEvaluationDetails.cs
@@ -6,7 +6,7 @@ namespace OpenFeature.Model
     /// The contract returned to the caller that describes the result of the flag evaluation process.
     /// </summary>
     /// <typeparam name="T">Flag value type</typeparam>
-    /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/types.md#resolution-details"/>
+    /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/types.md#evaluation-details"/>
     public class FlagEvaluationDetails<T>
     {
         /// <summary>

--- a/src/OpenFeature/Model/FlagEvaluationOptions.cs
+++ b/src/OpenFeature/Model/FlagEvaluationOptions.cs
@@ -6,7 +6,7 @@ namespace OpenFeature.Model
     /// A structure containing the one or more hooks and hook hints
     /// The hook and hook hints are added to the list of hooks called during the evaluation process
     /// </summary>
-    /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/types.md#evaluation-options">Flag Evaluation Options</seealso>
+    /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/types.md#evaluation-options">Flag Evaluation Options</seealso>
     public class FlagEvaluationOptions
     {
         /// <summary>

--- a/src/OpenFeature/Model/HookContext.cs
+++ b/src/OpenFeature/Model/HookContext.cs
@@ -7,7 +7,7 @@ namespace OpenFeature.Model
     /// Context provided to hook execution
     /// </summary>
     /// <typeparam name="T">Flag value type</typeparam>
-    /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/hooks.md#hook-context"/>
+    /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/sections/04-hooks.md#41-hook-context"/>
     public class HookContext<T>
     {
         /// <summary>

--- a/src/OpenFeature/Model/ResolutionDetails.cs
+++ b/src/OpenFeature/Model/ResolutionDetails.cs
@@ -7,7 +7,7 @@ namespace OpenFeature.Model
     /// Describes the details of the feature flag being evaluated
     /// </summary>
     /// <typeparam name="T">Flag value type</typeparam>
-    /// <seealso href="https://github.com/open-feature/spec/blob/main/specification/types.md#resolution-details"/>
+    /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/types.md#resolution-details"/>
     public class ResolutionDetails<T>
     {
         /// <summary>

--- a/test/OpenFeature.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderTests.cs
@@ -12,8 +12,7 @@ namespace OpenFeature.Tests
     public class FeatureProviderTests : ClearOpenFeatureInstanceFixture
     {
         [Fact]
-        [Specification("2.1",
-            "The provider interface MUST define a `metadata` member or accessor, containing a `name` field or accessor of type string, which identifies the provider implementation.")]
+        [Specification("2.1.1", "The provider interface MUST define a `metadata` member or accessor, containing a `name` field or accessor of type string, which identifies the provider implementation.")]
         public void Provider_Must_Have_Metadata()
         {
             var provider = new TestProvider();
@@ -22,22 +21,14 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        [Specification("2.2",
-            "The `feature provider` interface MUST define methods to resolve flag values, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required) and `evaluation context` (optional), which returns a `flag resolution` structure.")]
-        [Specification("2.3.1",
-            "The `feature provider` interface MUST define methods for typed flag resolution, including boolean, numeric, string, and structure.")]
-        [Specification("2.4",
-            "In cases of normal execution, the `provider` MUST populate the `flag resolution` structure's `value` field with the resolved flag value.")]
-        [Specification("2.5",
-            "In cases of normal execution, the `provider` SHOULD populate the `flag resolution` structure's `variant` field with a string identifier corresponding to the returned flag value.")]
-        [Specification("2.6",
-            "The `provider` SHOULD populate the `flag resolution` structure's `reason` field with a string indicating the semantic reason for the returned flag value.")]
-        [Specification("2.7",
-            "In cases of normal execution, the `provider` MUST NOT populate the `flag resolution` structure's `error code` field, or otherwise must populate it with a null or falsy value.")]
-        [Specification("2.9.1",
-            "The `flag resolution` structure SHOULD accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.")]
-        [Specification("2.11",
-            "In cases of normal execution, the `provider` MUST NOT populate the `flag resolution` structure's `error message` field, or otherwise must populate it with a null or falsy value.")]
+        [Specification("2.2.1", "The `feature provider` interface MUST define methods to resolve flag values, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required) and `evaluation context` (optional), which returns a `resolution details` structure.")]
+        [Specification("2.2.2.1", "The `feature provider` interface MUST define methods for typed flag resolution, including boolean, numeric, string, and structure.")]
+        [Specification("2.2.3", "In cases of normal execution, the `provider` MUST populate the `resolution details` structure's `value` field with the resolved flag value.")]
+        [Specification("2.2.4", "In cases of normal execution, the `provider` SHOULD populate the `resolution details` structure's `variant` field with a string identifier corresponding to the returned flag value.")]
+        [Specification("2.2.5", "The `provider` SHOULD populate the `resolution details` structure's `reason` field with `\"STATIC\"`, `\"DEFAULT\",` `\"TARGETING_MATCH\"`, `\"SPLIT\"`, `\"CACHED\"`, `\"DISABLED\"`, `\"UNKNOWN\"`, `\"ERROR\"` or some other string indicating the semantic reason for the returned flag value.")]
+        [Specification("2.2.6", "In cases of normal execution, the `provider` MUST NOT populate the `resolution details` structure's `error code` field, or otherwise must populate it with a null or falsy value.")]
+        [Specification("2.2.8.1", "The `resolution details` structure SHOULD accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.")]
+        [Specification("2.3.2", "In cases of normal execution, the `provider` MUST NOT populate the `resolution details` structure's `error message` field, or otherwise must populate it with a null or falsy value.")]
         public async Task Provider_Must_Resolve_Flag_Values()
         {
             var fixture = new Fixture();
@@ -76,10 +67,8 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        [Specification("2.8",
-            "In cases of abnormal execution, the `provider` MUST indicate an error using the idioms of the implementation language, with an associated `error code` and optional associated `error message`.")]
-        [Specification("2.12",
-            "In cases of abnormal execution, the `evaluation details` structure's `error message` field MAY contain a string containing additional detail about the nature of the error.")]
+        [Specification("2.2.7", "In cases of abnormal execution, the `provider` MUST indicate an error using the idioms of the implementation language, with an associated `error code` and optional associated `error message`.")]
+        [Specification("2.3.3", "In cases of abnormal execution, the `resolution details` structure's `error message` field MAY contain a string containing additional detail about the nature of the error.")]
         public async Task Provider_Must_ErrorType()
         {
             var fixture = new Fixture();

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -56,7 +56,7 @@ namespace OpenFeature.Tests
 
         [Fact]
         [Specification("1.3.1", "The `client` MUST provide methods for typed flag evaluation, including boolean, numeric, string, and structure, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns the flag value.")]
-        [Specification("1.3.2.1", "he client SHOULD provide functions for floating-point numbers and integers, consistent with language idioms.")]
+        [Specification("1.3.2.1", "The client SHOULD provide functions for floating-point numbers and integers, consistent with language idioms.")]
         [Specification("1.3.3", "The `client` SHOULD guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied `default value` should be returned.")]
         public async Task OpenFeatureClient_Should_Allow_Flag_Evaluation()
         {
@@ -103,7 +103,7 @@ namespace OpenFeature.Tests
         [Specification("1.4.5", "In cases of normal execution, the `evaluation details` structure's `variant` field MUST contain the value of the `variant` field in the `flag resolution` structure returned by the configured `provider`, if the field is set.")]
         [Specification("1.4.6", "In cases of normal execution, the `evaluation details` structure's `reason` field MUST contain the value of the `reason` field in the `flag resolution` structure returned by the configured `provider`, if the field is set.")]
         [Specification("1.4.11", "The `client` SHOULD provide asynchronous or non-blocking mechanisms for flag evaluation.")]
-        [Specification("2.9", "The `flag resolution` structure SHOULD accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.")]
+        [Specification("2.2.8.1", "The `resolution details` structure SHOULD accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.")]
         public async Task OpenFeatureClient_Should_Allow_Details_Flag_Evaluation()
         {
             var fixture = new Fixture();
@@ -147,9 +147,9 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        [Specification("1.1.2", "The API MUST provide a function to set the global provider singleton, which accepts an API-conformant provider implementation.")]
+        [Specification("1.1.2", "The `API` MUST provide a function to set the global `provider` singleton, which accepts an API-conformant `provider` implementation.")]
         [Specification("1.3.3", "The `client` SHOULD guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied `default value` should be returned.")]
-        [Specification("1.4.7", "In cases of abnormal execution, the `evaluation details` structure's `error code` field MUST contain a string identifying an error occurred during flag evaluation and the nature of the error.")]
+        [Specification("1.4.7", "In cases of abnormal execution, the `evaluation details` structure's `error code` field MUST contain an `error code`.")]
         [Specification("1.4.8", "In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field in the `evaluation details` SHOULD indicate an error.")]
         [Specification("1.4.9", "Methods, functions, or operations on the client MUST NOT throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup.")]
         [Specification("1.4.10", "In the case of abnormal execution, the client SHOULD log an informative error message.")]

--- a/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
@@ -25,7 +25,7 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        [Specification("3.2.2", "Duplicate values being overwritten.")]
+        [Specification("3.2.2", "Evaluation context MUST be merged in the order: API (global; lowest precedence) - client - invocation - before hooks (highest precedence), with duplicate values being overwritten.")]
         public void Should_Merge_TwoContexts_And_Override_Duplicates_With_RightHand_Context()
         {
             var contextBuilder1 = new EvaluationContextBuilder();
@@ -43,8 +43,8 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        [Specification("3.1", "The `evaluation context` structure MUST define an optional `targeting key` field of type string, identifying the subject of the flag evaluation.")]
-        [Specification("3.2", "The evaluation context MUST support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | datetime | structure`.")]
+        [Specification("3.1.1", "The `evaluation context` structure MUST define an optional `targeting key` field of type string, identifying the subject of the flag evaluation.")]
+        [Specification("3.1.2", "The evaluation context MUST support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | datetime | structure`.")]
         public void EvaluationContext_Should_All_Types()
         {
             var fixture = new Fixture();

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -17,7 +17,7 @@ namespace OpenFeature.Tests
     {
         [Fact]
         [Specification("1.5.1", "The `evaluation options` structure's `hooks` field denotes an ordered collection of hooks that the client MUST execute for the respective flag evaluation, in addition to those already configured.")]
-        [Specification("2.10", "The provider interface MUST define a provider hook mechanism which can be optionally implemented in order to add hook instances to the evaluation life-cycle.")]
+        [Specification("2.3.1", "The provider interface MUST define a `provider hook` mechanism which can be optionally implemented in order to add `hook` instances to the evaluation life-cycle.")]
         [Specification("4.4.2", "Hooks MUST be evaluated in the following order: - before: API, Client, Invocation, Provider - after: Provider, Invocation, Client, API - error (if applicable): Provider, Invocation, Client, API - finally: Provider, Invocation, Client, API")]
         public async Task Hooks_Should_Be_Called_In_Order()
         {
@@ -191,7 +191,8 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        [Specification("4.3.4", "When before hooks have finished executing, any resulting evaluation context MUST be merged with the existing evaluation context in the following order: before-hook (highest precedence), invocation, client, api (lowest precedence).")]
+        [Specification("3.2.2", "Evaluation context MUST be merged in the order: API (global; lowest precedence) - client - invocation - before hooks (highest precedence), with duplicate values being overwritten.")]
+        [Specification("4.3.4", "When `before` hooks have finished executing, any resulting `evaluation context` MUST be merged with the existing `evaluation context`.")]
         public async Task Evaluation_Context_Must_Be_Merged_In_Correct_Order()
         {
             var propGlobal = "4.3.4global";
@@ -265,7 +266,7 @@ namespace OpenFeature.Tests
         [Specification("4.2.1", "`hook hints` MUST be a structure supports definition of arbitrary properties, with keys of type `string`, and values of type `boolean | string | number | datetime | structure`..")]
         [Specification("4.2.2.1", "Condition: `Hook hints` MUST be immutable.")]
         [Specification("4.2.2.2", "Condition: The client `metadata` field in the `hook context` MUST be immutable.")]
-        [Specification("4.2.2.3", "Condition: The provider `metadata` field in the `hook context` MUST be immutable")]
+        [Specification("4.2.2.3", "Condition: The provider `metadata` field in the `hook context` MUST be immutable.")]
         [Specification("4.3.1", "Hooks MUST specify at least one stage.")]
         public async Task Hook_Should_Return_No_Errors()
         {

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -11,7 +11,7 @@ namespace OpenFeature.Tests
     public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
     {
         [Fact]
-        [Specification("1.1.1", "The API, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the API are present at runtime.")]
+        [Specification("1.1.1", "The `API`, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the `API` are present at runtime.")]
         public void OpenFeature_Should_Be_Singleton()
         {
             var openFeature = Api.Instance;
@@ -21,7 +21,7 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        [Specification("1.1.3", "The API MUST provide a function to add hooks which accepts one or more API-conformant hooks, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.")]
+        [Specification("1.1.3", "The `API` MUST provide a function to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.")]
         public void OpenFeature_Should_Add_Hooks()
         {
             var openFeature = Api.Instance;


### PR DESCRIPTION
Signed-off-by: Chris Donnelly [cdonnellytx@users.noreply.github.com](mailto:cdonnellytx@users.noreply.github.com)

## This PR

- Fixes broken spec links in the XML documentation
- Fixes spec references in the tests (both code and description)
- Adds one additional test to cover 4.4.5 "after" phase

### Related Issues

Partial fix for #84 (skips v0.5.1, goes to v0.5.2).

### Notes

I started this because I found the `see` links were broken.  Then I realized I should probably fix the specification attribute numbers.  Then I added one test.  Stopping there :)

### Follow-up Tasks

These are the remaining spec items that I saw that do not have tests labeled:

- **1.1.6** The client creation function MUST NOT throw, or otherwise abnormally terminate.
- **1.4.12** In cases of abnormal execution, the `evaluation details` structure's `error message` field MAY contain a string containing additional details about the nature of the error.
- **3.2.1** The API, Client and invocation MUST have a method for supplying `evaluation context`.
- **4.3.2** The `before` stage MUST run before flag resolution occurs. It accepts a `hook context` (required) and `hook hints` (optional) as parameters and returns either an `evaluation context` or nothing.

Additionally there is no "after" equivalent for 4.4.7, which may or may not be a concern.  (It currently returns the default value, instead of the evaluated value.)

