### PR TITLE
test: add initial api benchmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,9 @@ only and does not affect the actual build of the project.
 ## Benchmarking
 
 We use [BenchmarkDotNet](https://benchmarkdotnet.org/articles/overview.html) NuGet package to benchmark a code.
-To run pipelines locally, you can procede with a following command in a root project directory.
+
+To run pipelines locally, you can follow these commands from a root project directory.
+
 ```
 dotnet restore
 dotnet build --configuration Release --output "./release" --no-restore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,3 +119,13 @@ As with other OpenFeature SDKs, dotnet-sdk follows the
 This project includes a [`.editorconfig`](./.editorconfig) file which is
 supported by all the IDEs/editor mentioned above. It works with the IDE/editor
 only and does not affect the actual build of the project.
+
+## Benchmarking
+
+We use [BenchmarkDotNet](https://benchmarkdotnet.org/articles/overview.html) NuGet package to benchmark a code.
+To run pipelines locally, you can procede with a following command in a root project directory.
+```
+dotnet restore
+dotnet build --configuration Release --output "./release" --no-restore
+dotnet release\OpenFeature.Benchmarks.dll
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,5 +129,5 @@ To run pipelines locally, you can follow these commands from a root project dire
 ```
 dotnet restore
 dotnet build --configuration Release --output "./release" --no-restore
-dotnet release\OpenFeature.Benchmarks.dll
+dotnet release/OpenFeature.Benchmarks.dll
 ```

--- a/OpenFeature.sln
+++ b/OpenFeature.sln
@@ -1,21 +1,24 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenFeature", "src\OpenFeature\OpenFeature.csproj", "{07A6E6BD-FB7E-4B3B-9CBE-65AE9D0EB223}"
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33213.308
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenFeature", "src\OpenFeature\OpenFeature.csproj", "{07A6E6BD-FB7E-4B3B-9CBE-65AE9D0EB223}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{72005F60-C2E8-40BF-AE95-893635134D7D}"
 	ProjectSection(SolutionItems) = preProject
-		build\Common.props = build\Common.props
-		build\Common.tests.props = build\Common.tests.props
-		build\Common.prod.props = build\Common.prod.props
 		.github\workflows\code-coverage.yml = .github\workflows\code-coverage.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
+		build\Common.prod.props = build\Common.prod.props
+		build\Common.props = build\Common.props
+		build\Common.tests.props = build\Common.tests.props
+		CONTRIBUTING.md = CONTRIBUTING.md
 		.github\workflows\dotnet-format.yml = .github\workflows\dotnet-format.yml
+		.github\workflows\lint-pr.yml = .github\workflows\lint-pr.yml
 		.github\workflows\linux-ci.yml = .github\workflows\linux-ci.yml
+		README.md = README.md
 		.github\workflows\release.yml = .github\workflows\release.yml
 		.github\workflows\windows-ci.yml = .github\workflows\windows-ci.yml
-		README.md = README.md
-		CONTRIBUTING.md = CONTRIBUTING.md
-		.github\workflows\lint-pr.yml = .github\workflows\lint-pr.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C97E9975-E10A-4817-AE2C-4DD69C3C02D4}"
@@ -29,7 +32,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{65FBA159-2
 		test\Directory.Build.props = test\Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenFeature.Tests", "test\OpenFeature.Tests\OpenFeature.Tests.csproj", "{49BB42BA-10A6-4DA3-A7D5-38C968D57837}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenFeature.Tests", "test\OpenFeature.Tests\OpenFeature.Tests.csproj", "{49BB42BA-10A6-4DA3-A7D5-38C968D57837}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenFeature.Benchmarks", "test\OpenFeature.Benchmarks\OpenFeature.Benchmarks.csproj", "{90E7EAD3-251E-4490-AF78-E758E33518E5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,9 +50,20 @@ Global
 		{49BB42BA-10A6-4DA3-A7D5-38C968D57837}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{49BB42BA-10A6-4DA3-A7D5-38C968D57837}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{49BB42BA-10A6-4DA3-A7D5-38C968D57837}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90E7EAD3-251E-4490-AF78-E758E33518E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90E7EAD3-251E-4490-AF78-E758E33518E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90E7EAD3-251E-4490-AF78-E758E33518E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90E7EAD3-251E-4490-AF78-E758E33518E5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{07A6E6BD-FB7E-4B3B-9CBE-65AE9D0EB223} = {C97E9975-E10A-4817-AE2C-4DD69C3C02D4}
 		{49BB42BA-10A6-4DA3-A7D5-38C968D57837} = {65FBA159-23E0-4CF9-881B-F78DBFF198E9}
+		{90E7EAD3-251E-4490-AF78-E758E33518E5} = {65FBA159-23E0-4CF9-881B-F78DBFF198E9}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {41F01B78-FB06-404F-8AD0-6ED6973F948F}
 	EndGlobalSection
 EndGlobal

--- a/build/Common.tests.props
+++ b/build/Common.tests.props
@@ -21,6 +21,7 @@
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
     <AutoFixtureVer>[4.17.0]</AutoFixtureVer>
+    <BenchmarkDotNetVer>[0.13.1]</BenchmarkDotNetVer>
     <CoverletCollectorVer>[3.1.2]</CoverletCollectorVer>
     <FluentAssertionsVer>[6.7.0]</FluentAssertionsVer>
     <MicrosoftNETTestSdkPkgVer>[17.2.0]</MicrosoftNETTestSdkPkgVer>

--- a/src/OpenFeature/OpenFeature.csproj
+++ b/src/OpenFeature/OpenFeature.csproj
@@ -11,6 +11,9 @@
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>OpenFeature.Benchmarks</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>OpenFeature.Tests</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>

--- a/test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj
+++ b/test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>OpenFeature.Benchmark</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="$(AutoFixtureVer)" />
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVer)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenFeature\OpenFeature.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
+++ b/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
@@ -10,7 +10,8 @@ namespace OpenFeature.Benchmark
 {
     [MemoryDiagnoser]
     [SimpleJob(RuntimeMoniker.Net60, baseline: true)]
-    [RPlotExporter]
+    [JsonExporterAttribute.Full]
+    [JsonExporterAttribute.FullCompressed]
     public class OpenFeatureClientBenchmarks
     {
         private readonly string _clientName;
@@ -22,6 +23,7 @@ namespace OpenFeature.Benchmark
         private readonly double _defaultDoubleValue;
         private readonly Value _defaultStructureValue;
         private readonly FlagEvaluationOptions _emptyFlagOptions;
+        private readonly FeatureClient _client;
 
         public OpenFeatureClientBenchmarks()
         {
@@ -35,141 +37,69 @@ namespace OpenFeature.Benchmark
             _defaultDoubleValue = fixture.Create<double>();
             _defaultStructureValue = fixture.Create<Value>();
             _emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
+
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            _client = Api.Instance.GetClient(_clientName, _clientVersion);
         }
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetBooleanValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetBooleanValue(_flagName, _defaultBoolValue);
-        }
+        public async Task OpenFeatureClient_GetBooleanValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
+            await _client.GetBooleanValue(_flagName, _defaultBoolValue);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetBooleanValue(_flagName, _defaultBoolValue, EvaluationContext.Empty);
-        }
+        public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
+            await _client.GetBooleanValue(_flagName, _defaultBoolValue, EvaluationContext.Empty);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetBooleanValue(_flagName, _defaultBoolValue, EvaluationContext.Empty, _emptyFlagOptions);
-        }
+        public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
+            await _client.GetBooleanValue(_flagName, _defaultBoolValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetStringValue(_flagName, _defaultStringValue);
-        }
+        public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
+            await _client.GetStringValue(_flagName, _defaultStringValue);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetStringValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetStringValue(_flagName, _defaultStringValue, EvaluationContext.Empty);
-        }
+        public async Task OpenFeatureClient_GetStringValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
+            await _client.GetStringValue(_flagName, _defaultStringValue, EvaluationContext.Empty);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithEmptyFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetStringValue(_flagName, _defaultStringValue, EvaluationContext.Empty, _emptyFlagOptions);
-        }
+        public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithEmptyFlagEvaluationOptions() =>
+            await _client.GetStringValue(_flagName, _defaultStringValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetIntegerValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetIntegerValue(_flagName, _defaultIntegerValue);
-        }
+        public async Task OpenFeatureClient_GetIntegerValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
+            await _client.GetIntegerValue(_flagName, _defaultIntegerValue);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetIntegerValue(_flagName, _defaultIntegerValue, EvaluationContext.Empty);
-        }
+        public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
+            await _client.GetIntegerValue(_flagName, _defaultIntegerValue, EvaluationContext.Empty);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetIntegerValue(_flagName, _defaultIntegerValue, EvaluationContext.Empty, _emptyFlagOptions);
-        }
+        public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
+            await _client.GetIntegerValue(_flagName, _defaultIntegerValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetDoubleValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetDoubleValue(_flagName, _defaultDoubleValue);
-        }
+        public async Task OpenFeatureClient_GetDoubleValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
+            await _client.GetDoubleValue(_flagName, _defaultDoubleValue);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetDoubleValue(_flagName, _defaultDoubleValue, EvaluationContext.Empty);
-        }
+        public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
+            await _client.GetDoubleValue(_flagName, _defaultDoubleValue, EvaluationContext.Empty);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetDoubleValue(_flagName, _defaultDoubleValue, EvaluationContext.Empty, _emptyFlagOptions);
-        }
+        public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
+            await _client.GetDoubleValue(_flagName, _defaultDoubleValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetObjectValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetObjectValue(_flagName, _defaultStructureValue);
-        }
+        public async Task OpenFeatureClient_GetObjectValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
+            await _client.GetObjectValue(_flagName, _defaultStructureValue);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetObjectValue(_flagName, _defaultStructureValue, EvaluationContext.Empty);
-        }
+        public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
+            await _client.GetObjectValue(_flagName, _defaultStructureValue, EvaluationContext.Empty);
 
         [Benchmark]
-        public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions()
-        {
-            Api.Instance.SetProvider(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(_clientName, _clientVersion);
-
-            await client.GetObjectValue(_flagName, _defaultStructureValue, EvaluationContext.Empty, _emptyFlagOptions);
-        }
+        public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
+            await _client.GetObjectValue(_flagName, _defaultStructureValue, EvaluationContext.Empty, _emptyFlagOptions);
     }
 }

--- a/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
+++ b/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
@@ -1,0 +1,175 @@
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using AutoFixture;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using OpenFeature.Model;
+
+namespace OpenFeature.Benchmark
+{
+    [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net60, baseline: true)]
+    [RPlotExporter]
+    public class OpenFeatureClientBenchmarks
+    {
+        private readonly string _clientName;
+        private readonly string _clientVersion;
+        private readonly string _flagName;
+        private readonly bool _defaultBoolValue;
+        private readonly string _defaultStringValue;
+        private readonly int _defaultIntegerValue;
+        private readonly double _defaultDoubleValue;
+        private readonly Value _defaultStructureValue;
+        private readonly FlagEvaluationOptions _emptyFlagOptions;
+
+        public OpenFeatureClientBenchmarks()
+        {
+            var fixture = new Fixture();
+            _clientName = fixture.Create<string>();
+            _clientVersion = fixture.Create<string>();
+            _flagName = fixture.Create<string>();
+            _defaultBoolValue = fixture.Create<bool>();
+            _defaultStringValue = fixture.Create<string>();
+            _defaultIntegerValue = fixture.Create<int>();
+            _defaultDoubleValue = fixture.Create<double>();
+            _defaultStructureValue = fixture.Create<Value>();
+            _emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetBooleanValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetBooleanValue(_flagName, _defaultBoolValue);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetBooleanValue(_flagName, _defaultBoolValue, EvaluationContext.Empty);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetBooleanValue(_flagName, _defaultBoolValue, EvaluationContext.Empty, _emptyFlagOptions);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetStringValue(_flagName, _defaultStringValue);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetStringValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetStringValue(_flagName, _defaultStringValue, EvaluationContext.Empty);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithEmptyFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetStringValue(_flagName, _defaultStringValue, EvaluationContext.Empty, _emptyFlagOptions);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetIntegerValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetIntegerValue(_flagName, _defaultIntegerValue);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetIntegerValue(_flagName, _defaultIntegerValue, EvaluationContext.Empty);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetIntegerValue(_flagName, _defaultIntegerValue, EvaluationContext.Empty, _emptyFlagOptions);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetDoubleValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetDoubleValue(_flagName, _defaultDoubleValue);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetDoubleValue(_flagName, _defaultDoubleValue, EvaluationContext.Empty);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetDoubleValue(_flagName, _defaultDoubleValue, EvaluationContext.Empty, _emptyFlagOptions);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetObjectValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetObjectValue(_flagName, _defaultStructureValue);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetObjectValue(_flagName, _defaultStructureValue, EvaluationContext.Empty);
+        }
+
+        [Benchmark]
+        public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions()
+        {
+            Api.Instance.SetProvider(new NoOpFeatureProvider());
+            var client = Api.Instance.GetClient(_clientName, _clientVersion);
+
+            await client.GetObjectValue(_flagName, _defaultStructureValue, EvaluationContext.Empty, _emptyFlagOptions);
+        }
+    }
+}

--- a/test/OpenFeature.Benchmarks/Program.cs
+++ b/test/OpenFeature.Benchmarks/Program.cs
@@ -1,0 +1,12 @@
+using BenchmarkDotNet.Running;
+
+namespace OpenFeature.Benchmark
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<OpenFeatureClientBenchmarks>();
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Valentinas <31697821+valentk777@users.noreply.github.com>

Added initial API benchmark (only for a few functions). Later we can increase the functions count by covering hooks as well. 

## This PR
Adds initial project to run benchmarks for API part.

Fixes #22

### Notes
I added the result table here. 

![image](https://user-images.githubusercontent.com/31697821/218009150-046a2089-6934-455d-af32-0640e13cda36.png)
