### PR TITLE
feat: Support for name client to given provider

### DIFF
--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -42,13 +42,7 @@ namespace OpenFeature
         {
             // Alias the provider reference so getting the method and returning the provider are
             // guaranteed to be the same object.
-            var provider = Api.Instance.GetProvider();
-
-            if (provider == null)
-            {
-                provider = new NoOpFeatureProvider();
-                this._logger.LogDebug("No provider configured, using no-op provider");
-            }
+            var provider = Api.Instance.GetProvider(this._metadata.Name);
 
             return (method(provider), provider);
         }

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -147,7 +147,7 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        [Specification("1.1.2", "The `API` MUST provide a function to set the global `provider` singleton, which accepts an API-conformant `provider` implementation.")]
+        [Specification("1.1.2", "The `API` MUST provide a function to set the default `provider`, which accepts an API-conformant `provider` implementation.")]
         [Specification("1.3.3", "The `client` SHOULD guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied `default value` should be returned.")]
         [Specification("1.4.7", "In cases of abnormal execution, the `evaluation details` structure's `error code` field MUST contain an `error code`.")]
         [Specification("1.4.8", "In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field in the `evaluation details` SHOULD indicate an error.")]

--- a/test/OpenFeature.Tests/TestImplementations.cs
+++ b/test/OpenFeature.Tests/TestImplementations.cs
@@ -50,7 +50,7 @@ namespace OpenFeature.Tests
         public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
             EvaluationContext context = null)
         {
-            return Task.FromResult(new ResolutionDetails<bool>(flagKey, defaultValue));
+            return Task.FromResult(new ResolutionDetails<bool>(flagKey, !defaultValue));
         }
 
         public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,


### PR DESCRIPTION
## This PR
Adds support for mapping name clients to a given provider.

- Preserves backward compatibility with existing clients

### Related Issues

Refs: Refs https://github.com/open-feature/ofep/pull/56
Fixes: https://github.com/open-feature/dotnet-sdk/issues/131

### Notes
N/A

### Follow-up Tasks

- [ ] Update documentation

### How to test
Testing is covered by the unit tests added in the PR

