### PR TITLE
chore: Exclude standard error from code coverage

### DIFF
--- a/src/OpenFeature/Error/FlagNotFoundException.cs
+++ b/src/OpenFeature/Error/FlagNotFoundException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 
 namespace OpenFeature.Error
@@ -6,6 +7,7 @@ namespace OpenFeature.Error
     /// <summary>
     /// Provider was unable to find the flag error when evaluating a flag.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class FlagNotFoundException : FeatureProviderException
     {
         /// <summary>

--- a/src/OpenFeature/Error/GeneralException.cs
+++ b/src/OpenFeature/Error/GeneralException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 
 namespace OpenFeature.Error
@@ -6,6 +7,7 @@ namespace OpenFeature.Error
     /// <summary>
     /// Abnormal execution of the provider when evaluating a flag.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class GeneralException : FeatureProviderException
     {
         /// <summary>

--- a/src/OpenFeature/Error/InvalidContextException.cs
+++ b/src/OpenFeature/Error/InvalidContextException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 
 namespace OpenFeature.Error
@@ -6,6 +7,7 @@ namespace OpenFeature.Error
     /// <summary>
     /// Context does not satisfy provider requirements when evaluating a flag.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class InvalidContextException : FeatureProviderException
     {
         /// <summary>

--- a/src/OpenFeature/Error/ParseErrorException.cs
+++ b/src/OpenFeature/Error/ParseErrorException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 
 namespace OpenFeature.Error
@@ -6,6 +7,7 @@ namespace OpenFeature.Error
     /// <summary>
     /// Provider failed to parse the flag response when evaluating a flag.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class ParseErrorException : FeatureProviderException
     {
         /// <summary>

--- a/src/OpenFeature/Error/ProviderNotReadyException.cs
+++ b/src/OpenFeature/Error/ProviderNotReadyException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 
 namespace OpenFeature.Error
@@ -6,6 +7,7 @@ namespace OpenFeature.Error
     /// <summary>
     /// Provider has yet been initialized when evaluating a flag.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class ProviderNotReadyException : FeatureProviderException
     {
         /// <summary>

--- a/src/OpenFeature/Error/TargetingKeyMissingException.cs
+++ b/src/OpenFeature/Error/TargetingKeyMissingException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 
 namespace OpenFeature.Error
@@ -6,6 +7,7 @@ namespace OpenFeature.Error
     /// <summary>
     /// Context does not contain a targeting key and the provider requires one when evaluating a flag.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class TargetingKeyMissingException : FeatureProviderException
     {
         /// <summary>

--- a/src/OpenFeature/Error/TypeMismatchException.cs
+++ b/src/OpenFeature/Error/TypeMismatchException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 
 namespace OpenFeature.Error
@@ -6,6 +7,7 @@ namespace OpenFeature.Error
     /// <summary>
     /// Request type does not match the expected type when evaluating a flag.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class TypeMismatchException : FeatureProviderException
     {
         /// <summary>


### PR DESCRIPTION
## This PR

Exclude standard error from code coverage
There is no point in adding unit tests around exceptions that aren't being used in the core library.

### Related Issues

These were introduced under https://github.com/open-feature/dotnet-sdk/issues/110

### Notes
N/A

### Follow-up Tasks
N/A

### How to test
N/A

