### PR TITLE
test: Replace remaining Moq with NSubstitute

### DIFF
--- a/test/OpenFeature.Tests/OpenFeature.Tests.csproj
+++ b/test/OpenFeature.Tests/OpenFeature.Tests.csproj
@@ -18,7 +18,6 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVer)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
-    <PackageReference Include="Moq" Version="[4.18.4]" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">


### PR DESCRIPTION
## This PR

Update the following test to use NSubstitute
Hook_Hints_May_Be_Optional
When_Error_Occurs_In_After_Hook_Should_Invoke_Error_Hook

### Related Issues
Fixes https://github.com/open-feature/dotnet-sdk/issues/140

### Notes
N/A

### Follow-up Tasks
N/A

### How to test
N/A

