### PR TITLE
feat: Add dx to catch ConfigureAwait(false)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -146,6 +146,9 @@ dotnet_diagnostic.IDE0005.severity = none
 # RS0041: Public members should not use oblivious types
 dotnet_diagnostic.RS0041.severity = suggestion
 
+# CA2007: Do not directly await a Task
+dotnet_diagnostic.CA2007.severity = error
+
 [obj/**.cs]
 generated_code = true
 

--- a/build/Common.props
+++ b/build/Common.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <LangVersion>7.3</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
+++ b/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
@@ -1,5 +1,6 @@
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using AutoFixture;
 using BenchmarkDotNet.Attributes;
@@ -12,6 +13,7 @@ namespace OpenFeature.Benchmark
     [SimpleJob(RuntimeMoniker.Net60, baseline: true)]
     [JsonExporterAttribute.Full]
     [JsonExporterAttribute.FullCompressed]
+    [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
     public class OpenFeatureClientBenchmarks
     {
         private readonly string _clientName;

--- a/test/OpenFeature.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using AutoFixture;
 using FluentAssertions;
@@ -9,6 +10,7 @@ using Xunit;
 
 namespace OpenFeature.Tests
 {
+    [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
     public class FeatureProviderTests : ClearOpenFeatureInstanceFixture
     {
         [Fact]

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture;
@@ -16,6 +17,7 @@ using Xunit;
 
 namespace OpenFeature.Tests
 {
+    [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
     public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
     {
         [Fact]

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture;
@@ -14,6 +15,7 @@ using Xunit;
 
 namespace OpenFeature.Tests
 {
+    [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
     public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
     {
         [Fact]


### PR DESCRIPTION
## This PR

- Enable dotnet anaylzers
- Ignore rule in benchmarks/tests

### Related Issues

Stop https://github.com/open-feature/dotnet-sdk/issues/149 happening again in the future

### Notes
N/A

### Follow-up Tasks
N/A

### How to test
N/A

