### PR TITLE
feat: Using factory for provider creation

### DIFF
--- a/OpenFeature.sln
+++ b/OpenFeature.sln
@@ -36,7 +36,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenFeature.Tests", "test\O
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenFeature.Benchmarks", "test\OpenFeature.Benchmarks\OpenFeature.Benchmarks.csproj", "{90E7EAD3-251E-4490-AF78-E758E33518E5}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenFeature.E2ETests", "test\OpenFeature.E2ETests\OpenFeature.E2ETests.csproj", "{90E7EAD3-251E-4490-AF78-E758E33518E5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenFeature.E2ETests", "test\OpenFeature.E2ETests\OpenFeature.E2ETests.csproj", "{CB82B298-040A-4E8B-B74E-1636DC5C2457}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -56,6 +56,10 @@ Global
 		{90E7EAD3-251E-4490-AF78-E758E33518E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{90E7EAD3-251E-4490-AF78-E758E33518E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{90E7EAD3-251E-4490-AF78-E758E33518E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB82B298-040A-4E8B-B74E-1636DC5C2457}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB82B298-040A-4E8B-B74E-1636DC5C2457}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB82B298-040A-4E8B-B74E-1636DC5C2457}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB82B298-040A-4E8B-B74E-1636DC5C2457}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -18,7 +18,7 @@ namespace OpenFeature
         private EvaluationContext _evaluationContext = EvaluationContext.Empty;
         private Func<FeatureProvider> _defaultProviderFunc = () => new NoOpFeatureProvider();
         private readonly ConcurrentDictionary<string, Func<FeatureProvider>> _featureProviders =
-            new ConcurrentDictionary<string, Func<FeatureProvider>> ();
+            new ConcurrentDictionary<string, Func<FeatureProvider>>();
         private readonly ConcurrentStack<Hook> _hooks = new ConcurrentStack<Hook>();
 
         /// The reader/writer locks are not disposed because the singleton instance should never be disposed.

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -49,7 +49,7 @@ namespace OpenFeature
         /// <param name="clientName">Name of client</param>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
         public void SetProvider(string clientName, FeatureProvider featureProvider)
-            => this.SetProvider(clientName, featureProvider == null ? (Func<FeatureProvider>)null : () => featureProvider);
+            => this.SetProvider(clientName, () => featureProvider);
 
         /// <summary>
         /// Sets the feature provider

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -41,17 +41,7 @@ namespace OpenFeature
         /// </summary>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
         public void SetProvider(FeatureProvider featureProvider)
-        {
-            this._featureProviderLock.EnterWriteLock();
-            try
-            {
-                this._defaultProviderFunc = featureProvider != null ? () => featureProvider : this._defaultProviderFunc;
-            }
-            finally
-            {
-                this._featureProviderLock.ExitWriteLock();
-            }
-        }
+            => this.SetProvider(featureProvider == null ? (Func<FeatureProvider>) null : () => featureProvider);
 
         /// <summary>
         /// Sets the feature provider to given clientName
@@ -59,11 +49,8 @@ namespace OpenFeature
         /// <param name="clientName">Name of client</param>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
         public void SetProvider(string clientName, FeatureProvider featureProvider)
-        {
-            FeatureProvider func() => featureProvider;
-            this._featureProviders.AddOrUpdate(clientName, func,
-                (key, current) => func);
-        }
+            => this.SetProvider(clientName, featureProvider == null ? (Func<FeatureProvider>)null : () => featureProvider);
+        
 
         /// <summary>
         /// Sets the feature provider

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -41,7 +41,7 @@ namespace OpenFeature
         /// </summary>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
         public void SetProvider(FeatureProvider featureProvider)
-            => this.SetProvider(featureProvider == null ? (Func<FeatureProvider>) null : () => featureProvider);
+            => this.SetProvider(featureProvider == null ? (Func<FeatureProvider>)null : () => featureProvider);
 
         /// <summary>
         /// Sets the feature provider to given clientName
@@ -50,7 +50,6 @@ namespace OpenFeature
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
         public void SetProvider(string clientName, FeatureProvider featureProvider)
             => this.SetProvider(clientName, featureProvider == null ? (Func<FeatureProvider>)null : () => featureProvider);
-        
 
         /// <summary>
         /// Sets the feature provider

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -23,6 +23,7 @@ namespace OpenFeature
         private EvaluationContext _evaluationContext;
 
         private readonly object _evaluationContextLock = new object();
+        private FeatureProvider _featureProvider;
 
         /// <summary>
         /// Get a provider and an associated typed flag resolution method.
@@ -40,11 +41,10 @@ namespace OpenFeature
             ExtractProvider<T>(
                 Func<FeatureProvider, Func<string, T, EvaluationContext, Task<ResolutionDetails<T>>>> method)
         {
-            // Alias the provider reference so getting the method and returning the provider are
-            // guaranteed to be the same object.
-            var provider = Api.Instance.GetProvider(this._metadata.Name);
+            // Will use factory to get provider if it's not created for this client.
+            this._featureProvider = this._featureProvider ?? Api.Instance.GetProvider(this._metadata.Name);
 
-            return (method(provider), provider);
+            return (method(this._featureProvider), this._featureProvider);
         }
 
         /// <inheritdoc />

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -351,7 +351,7 @@ namespace OpenFeature.Tests
         [Fact]
         public async Task Should_Use_No_Op_When_Provider_Is_Null()
         {
-            Api.Instance.SetProvider(null);
+            Api.Instance.SetProvider((FeatureProvider)null);
             var client = new FeatureClient("test", "test");
             (await client.GetIntegerValue("some-key", 12)).Should().Be(12);
         }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds possibility to use factories for getting provider. With this feature we can easily control lifecycle of provider instances (not only singleton).

### Notes
<!-- any additional notes for this PR -->
This is a problem when your provider uses some services like HttpClient (which should be scoped or transient to avoid DNS problems) or configuration that can be changed in runtime. Using factories we can configure lifecycle of providers by registering a client in DI.

### How to test
<!-- if applicable, add testing instructions under this section -->
```
var flagsmithConfig = builder.Configuration.GetSection(nameof(FlagsmithConfiguration));
var providerConfig = new FlagsmithProviderConfiguration();
Api.Instance.SetProvider(() => new FlagsmithProvider(providerConfig, flagsmithConfig.Get<FlagsmithConfiguration>()));
var evaluationContextbuilder = EvaluationContext.Builder();
evaluationContextbuilder.Set(providerConfig.TargetingKey, "Your key");
var context = evaluationContextbuilder.Build();
services.AddScoped<IFeatureClient>(serviceProvider => Api.Instance.GetClient(logger: serviceProvider.GetRequiredService<ILogger<FeatureClient>>(), context: context));
```
In this example I can change configuration at runtime and be sure that new Provider with all deps will be created per request.
You still can set singleton instance of provider or register client itself as singleton.

This is not the best DI using, but it looks difficult to change current static implementation without major changes
