### PR TITLE
fix: Remove upper-bound version constraint from SCI

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="[1.7.1, 8.0.0)" />
+    <PackageReference Include="System.Collections.Immutable" Version="[1.7.1,)" />
     <PackageReference Include="System.Threading.Channels" Version="[6.0.0, 8.0.0)" />
   </ItemGroup>
 </Project>

--- a/build/Common.props
+++ b/build/Common.props
@@ -25,6 +25,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="[1.7.1,)" />
-    <PackageReference Include="System.Threading.Channels" Version="[6.0.0, 8.0.0)" />
+    <PackageReference Include="System.Threading.Channels" Version="[6.0.0,)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: #170

See: #136, #137, #170 

___

_Anticipate similar arguments/discussion as in #137, but opening as a companion to #170 because this is causing me real-world grief today 🙃_