### PR TITLE
refactor: Add TFMs for net{6,7,8}.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup .NET Core 6.0.x, 7.0.x
+    - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
@@ -27,7 +27,7 @@ jobs:
 
     - name: Run Tests
       run: dotnet test test/OpenFeature.Tests/ --configuration Release --logger GitHubActions
-  
+
   unit-tests-windows:
     runs-on: windows-latest
     steps:
@@ -35,7 +35,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup .NET Core 6.0.x, 7.0.x
+    - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -21,10 +21,8 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup .NET Core 7.0.x
+    - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '7.0.x'
 
     - name: Run Test
       run: dotnet test --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -20,10 +20,8 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Setup .NET Core 7.0
+    - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 7.0.x
 
     - name: Install format tool
       run: dotnet tool install -g dotnet-format

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ on:
     paths-ignore:
     - '**.md'
 
-jobs: 
+jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     services:
@@ -23,7 +23,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup .NET Core 6.0.x, 7.0.x
+    - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
@@ -31,7 +31,7 @@ jobs:
           7.0.x
 
     - name: Initialize Tests
-      run: | 
+      run: |
         git submodule update --init --recursive
         cp test-harness/features/evaluation.feature test/OpenFeature.E2ETests/Features/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET Core 6.0.x, 7.0.x
+      - name: Setup .NET SDK
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/setup-dotnet@v4
         with:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "7.0.404"
+    "version": "8.0.100"
   }
 }

--- a/src/OpenFeature/OpenFeature.csproj
+++ b/src/OpenFeature/OpenFeature.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0;net462</TargetFrameworks>
     <RootNamespace>OpenFeature</RootNamespace>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj
+++ b/test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>OpenFeature.Benchmark</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
+++ b/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <RootNamespace>OpenFeature.E2ETests</RootNamespace>
   </PropertyGroup>

--- a/test/OpenFeature.Tests/OpenFeature.Tests.csproj
+++ b/test/OpenFeature.Tests/OpenFeature.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <RootNamespace>OpenFeature.Tests</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
As a consumer of the OpenFeature SDK, I want `OpenFeature.dll` to be built and tested against all of the [supported TFMs](https://learn.microsoft.com/lifecycle/products/microsoft-net-and-net-core) that my projects might encounter in the wild.

This PR:
1. Updates the `global.json` to `8.0.100`
2. Updates workflows using _only_ `7.0.x` to instead resolve based on `global.json`
3. Updates the project(s) TFMs to include `net6.0`, `net7.0`, and `net8.0`
   - `net6.0` is EOL in `2024-11-12`
   - `net7.0` is EOL in `2024-05-14`

Fixes: #160, #169