### PR TITLE
chore: Add support for GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,46 @@ jobs:
 
     - name: Run Tests
       run: dotnet test test\OpenFeature.Tests\ --configuration Release --logger GitHubActions
+
+  packaging:
+    needs:
+    - unit-tests-linux
+    - unit-tests-windows
+
+    permissions:
+      contents: read
+      packages: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          6.0.x
+          7.0.x
+
+    - name: Restore
+      run: dotnet restore
+
+    - name: Pack NuGet packages (CI versions)
+      if: startsWith(github.ref, 'refs/heads/')
+      run: dotnet pack --no-restore --version-suffix "ci.$(date -u +%Y%m%dT%H%M%S)+sha.${GITHUB_SHA:0:9}"
+
+    - name: Pack NuGet packages (PR versions)
+      if: startsWith(github.ref, 'refs/pull/')
+      run: dotnet pack --no-restore --version-suffix "pr.$(date -u +%Y%m%dT%H%M%S)+sha.${GITHUB_SHA:0:9}"
+
+    - name: Publish NuGet packages (base)
+      if: github.event.pull_request.head.repo.fork == false
+      run: dotnet nuget push "src/**/*.nupkg" --api-key "${{ secrets.GITHUB_TOKEN }}" --source https://nuget.pkg.github.com/open-feature/index.json
+
+    - name: Publish NuGet packages (fork)
+      if: github.event.pull_request.head.repo.fork == true
+      uses: actions/upload-artifact@v4.2.0
+      with:
+        name: nupkgs
+        path: src/**/*.nupkg

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -2,7 +2,10 @@
   <Import Project=".\Common.props" />
 
   <PropertyGroup>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+    <Deterministic Condition="'$(CI)' == 'true'">true</Deterministic>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackRelease>true</PackRelease>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -16,7 +19,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Authors>OpenFeature Authors</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>$(VersionNumber)</Version>
+    <VersionPrefix>$(VersionNumber)</VersionPrefix>
     <AssemblyVersion>$(VersionNumber)</AssemblyVersion>
     <FileVersion>$(VersionNumber)</FileVersion>
   </PropertyGroup>
@@ -32,11 +35,4 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(Deterministic)'=='true'">
-    <SourceRoot Include="$(MSBuildThisFileDirectory)/" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(Deterministic)'=='true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
 </Project>

--- a/build/Common.props
+++ b/build/Common.props
@@ -28,4 +28,8 @@
     <PackageReference Include="System.Collections.Immutable" Version="[1.7.1,)" />
     <PackageReference Include="System.Threading.Channels" Version="[6.0.0,)" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(OS)' == 'Unix'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
| `GITHUB_REF`     | version format                                     |
|------------------|----------------------------------------------------|
| `refs/heads/*`   | `#.#.#-ci.{%Y%m%d}T{%H%M%S}+sha.${GITHUB_SHA:0:9}` |
| `refs/pull/*`    | `#.#.#-pr.{%Y%m%d}T{%H%M%S}+sha.${GITHUB_SHA:0:9}` |

See: #54, open-feature/dotnet-sdk-contrib#134

Closes: #54