### PR TITLE
chore: Reduce dependency on MEL -> MELA

### DIFF
--- a/src/OpenFeature/OpenFeature.csproj
+++ b/src/OpenFeature/OpenFeature.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggerVer)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggerVer)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Ran across this while working on open-feature/dotnet-sdk-contrib#127, but tldr; libraries don't need the implementation package, so reduce to the abstractions package to remove transitive dependencies on:

- `Microsoft.Extensions.DependencyInjection`
- `Microsoft.Extensions.Options`
- (and a few others depending on the TFM)
