### PR TITLE
chore: Fix props to support more than one project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Pack
         if: ${{ steps.release.outputs.releases_created }}
         run:  |
-          dotnet pack OpenFeature.proj --configuration Release --no-build -p:PackageID=OpenFeature
+          dotnet pack OpenFeature.proj --configuration Release --no-build
 
       - name: Publish to Nuget
         if: ${{ steps.release.outputs.releases_created }}

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -11,7 +11,6 @@
     <RepositoryUrl>https://github.com/open-feature/dotnet-sdk</RepositoryUrl>
     <Description>OpenFeature is an open standard for feature flag management, created to support a robust feature flag ecosystem using cloud native technologies. OpenFeature will provide a unified API and SDK, and a developer-first, cloud-native implementation, with extensibility for open source and commercial offerings.</Description>
     <PackageTags>Feature;OpenFeature;Flags;</PackageTags>
-    <PackageId>OpenFeature</PackageId>
     <PackageIcon>openfeature-icon.png</PackageIcon>
     <PackageProjectUrl>https://openfeature.dev</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
Ran across this while working on open-feature/dotnet-sdk-contrib#127, and tldr; if there's more than one project under `src/`, having the `<PackageId>` hard-coded in `build/Common.prod.props` causes MSBuild to panic.

There are two options to fix this:

1. ```diff
   - <PackageId>OpenFeature</PackageId>
   + <PackageId>$(MSBuildProjectName)</PackageId>
   ```
2. ```diff
   - <PackageId>OpenFeature</PackageId>
   ```

Since NuGet defaults `PackageId` to the assembly name, I'm opting for (2), but if I've overlooked some nuance/custom build steps that require setting `PackageId` explicitly, then we could just as well fallback to (1).

## Example

```console
$ dotnet restore
  Determining projects to restore...
dotnet/sdk/7.0.404/NuGet.targets(158,5): error : Ambiguous project name 'OpenFeature'. [~/rider/open-feature/dotnet-sdk/OpenFeature.sln]
```

## Related

- https://learn.microsoft.com/nuget/create-packages/creating-a-package-msbuild#set-properties