### PR TITLE
refactor: Use ValueTask on plumbing methods 

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,25 +291,25 @@ To satisfy the interface, all methods (`BeforeAsync`/`AfterAsync`/`FinallyAsync`
 ```csharp
 public class MyHook : Hook
 {
-  public Task<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
+  public ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
       IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
   {
     // code to run before flag evaluation
   }
 
-  public virtual Task AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+  public virtual ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
       IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
   {
     // code to run after successful flag evaluation
   }
 
-  public virtual Task ErrorAsync<T>(HookContext<T> context, Exception error,
+  public virtual ValueTask ErrorAsync<T>(HookContext<T> context, Exception error,
       IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
   {
     // code to run if there's an error during before hooks or during flag evaluation
   }
 
-  public virtual Task FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+  public virtual ValueTask FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
   {
     // code to run after all other stages, regardless of success/failure
   }

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ dotnet add package OpenFeature
 public async Task Example()
 {
     // Register your feature flag provider
-    await Api.Instance.SetProvider(new InMemoryProvider());
+    await Api.Instance.SetProviderAsync(new InMemoryProvider());
 
     // Create a new client
     FeatureClient client = Api.Instance.GetClient();
 
     // Evaluate your feature flag
-    bool v2Enabled = await client.GetBooleanValue("v2_enabled", false);
+    bool v2Enabled = await client.GetBooleanValueAsync("v2_enabled", false);
 
     if ( v2Enabled )
     {
@@ -112,7 +112,7 @@ If the provider you're looking for hasn't been created yet, see the [develop a p
 Once you've added a provider as a dependency, it can be registered with OpenFeature like this:
 
 ```csharp
-await Api.Instance.SetProvider(new MyProvider());
+await Api.Instance.SetProviderAsync(new MyProvider());
 ```
 
 In some situations, it may be beneficial to register multiple providers in the same application.
@@ -143,7 +143,7 @@ builder = EvaluationContext.Builder();
 builder.Set("region", "us-east-1");
 EvaluationContext reqCtx = builder.Build();
 
-bool flagValue = await client.GetBooleanValue("some-flag", false, reqCtx);
+bool flagValue = await client.GetBooleanValueAsync("some-flag", false, reqCtx);
 
 ```
 
@@ -164,7 +164,7 @@ var client = Api.Instance.GetClient();
 client.AddHooks(new ExampleClientHook());
 
 // add a hook for this evaluation only
-var value = await client.GetBooleanValue("boolFlag", false, context, new FlagEvaluationOptions(new ExampleInvocationHook()));
+var value = await client.GetBooleanValueAsync("boolFlag", false, context, new FlagEvaluationOptions(new ExampleInvocationHook()));
 ```
 
 ### Logging
@@ -224,7 +224,7 @@ EventHandlerDelegate callback = EventHandler;
 var myClient = Api.Instance.GetClient("my-client");
 
 var provider = new ExampleProvider();
-await Api.Instance.SetProvider(myClient.GetMetadata().Name, provider);
+await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name, provider);
 
 myClient.AddHandler(ProviderEventTypes.ProviderReady, callback);
 ```
@@ -235,7 +235,7 @@ The OpenFeature API provides a close function to perform a cleanup of all regist
 
 ```csharp
 // Shut down all providers
-await Api.Instance.Shutdown();
+await Api.Instance.ShutdownAsync();
 ```
 
 ## Extending
@@ -254,27 +254,27 @@ public class MyProvider : FeatureProvider
         return new Metadata("My Provider");
     }
 
-    public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
+    public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
     {
         // resolve a boolean flag value
     }
 
-    public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null)
+    public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
     {
         // resolve a double flag value
     }
 
-    public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
+    public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
     {
         // resolve an int flag value
     }
 
-    public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
+    public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
     {
         // resolve a string flag value
     }
 
-    public override Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext context = null)
+    public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
     {
         // resolve an object flag value
     }
@@ -286,30 +286,30 @@ public class MyProvider : FeatureProvider
 To develop a hook, you need to create a new project and include the OpenFeature SDK as a dependency.
 This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/dotnet-sdk-contrib) available under the OpenFeature organization.
 Implement your own hook by conforming to the `Hook interface`.
-To satisfy the interface, all methods (`Before`/`After`/`Finally`/`Error`) need to be defined.
+To satisfy the interface, all methods (`BeforeAsync`/`AfterAsync`/`FinallyAsync`/`ErrorAsync`) need to be defined.
 
 ```csharp
 public class MyHook : Hook
 {
-  public Task<EvaluationContext> Before<T>(HookContext<T> context,
-      IReadOnlyDictionary<string, object> hints = null)
+  public Task<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
+      IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
   {
     // code to run before flag evaluation
   }
 
-  public virtual Task After<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
-      IReadOnlyDictionary<string, object> hints = null)
+  public virtual Task AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+      IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
   {
     // code to run after successful flag evaluation
   }
 
-  public virtual Task Error<T>(HookContext<T> context, Exception error,
-      IReadOnlyDictionary<string, object> hints = null)
+  public virtual Task ErrorAsync<T>(HookContext<T> context, Exception error,
+      IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
   {
     // code to run if there's an error during before hooks or during flag evaluation
   }
 
-  public virtual Task Finally<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null)
+  public virtual Task FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
   {
     // code to run after all other stages, regardless of success/failure
   }

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -44,7 +44,7 @@ namespace OpenFeature
         /// <remarks>The provider cannot be set to null. Attempting to set the provider to null has no effect.</remarks>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public async Task SetProviderAsync(FeatureProvider featureProvider, CancellationToken cancellationToken = default)
+        public async ValueTask SetProviderAsync(FeatureProvider featureProvider, CancellationToken cancellationToken = default)
         {
             this.EventExecutor.RegisterDefaultFeatureProvider(featureProvider);
             await this._repository.SetProviderAsync(featureProvider, this.GetContext(), cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -58,7 +58,7 @@ namespace OpenFeature
         /// <param name="clientName">Name of client</param>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public async Task SetProviderAsync(string clientName, FeatureProvider featureProvider, CancellationToken cancellationToken = default)
+        public async ValueTask SetProviderAsync(string clientName, FeatureProvider featureProvider, CancellationToken cancellationToken = default)
         {
             this.EventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
             await this._repository.SetProviderAsync(clientName, featureProvider, this.GetContext(), cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -225,7 +225,7 @@ namespace OpenFeature
         /// </para>
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public async Task ShutdownAsync(CancellationToken cancellationToken = default)
+        public async ValueTask ShutdownAsync(CancellationToken cancellationToken = default)
         {
             await this._repository.ShutdownAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             await this.EventExecutor.ShutdownAsync(cancellationToken).ConfigureAwait(false);

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -43,10 +43,11 @@ namespace OpenFeature
         /// </summary>
         /// <remarks>The provider cannot be set to null. Attempting to set the provider to null has no effect.</remarks>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
-        public async Task SetProvider(FeatureProvider featureProvider)
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public async Task SetProviderAsync(FeatureProvider featureProvider, CancellationToken cancellationToken = default)
         {
             this.EventExecutor.RegisterDefaultFeatureProvider(featureProvider);
-            await this._repository.SetProvider(featureProvider, this.GetContext()).ConfigureAwait(false);
+            await this._repository.SetProviderAsync(featureProvider, this.GetContext(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -56,10 +57,11 @@ namespace OpenFeature
         /// </summary>
         /// <param name="clientName">Name of client</param>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
-        public async Task SetProvider(string clientName, FeatureProvider featureProvider)
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public async Task SetProviderAsync(string clientName, FeatureProvider featureProvider, CancellationToken cancellationToken = default)
         {
             this.EventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
-            await this._repository.SetProvider(clientName, featureProvider, this.GetContext()).ConfigureAwait(false);
+            await this._repository.SetProviderAsync(clientName, featureProvider, this.GetContext(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -222,10 +224,11 @@ namespace OpenFeature
         /// Once shut down is complete, API is reset and ready to use again.
         /// </para>
         /// </summary>
-        public async Task Shutdown()
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public async Task ShutdownAsync(CancellationToken cancellationToken = default)
         {
-            await this._repository.Shutdown().ConfigureAwait(false);
-            await this.EventExecutor.Shutdown().ConfigureAwait(false);
+            await this._repository.ShutdownAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            await this.EventExecutor.ShutdownAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/src/OpenFeature/EventExecutor.cs
+++ b/src/OpenFeature/EventExecutor.cs
@@ -11,7 +11,7 @@ using OpenFeature.Model;
 namespace OpenFeature
 {
 
-    internal delegate Task ShutdownDelegate(CancellationToken cancellationToken);
+    internal delegate ValueTask ShutdownDelegate(CancellationToken cancellationToken);
 
     internal class EventExecutor
     {
@@ -327,7 +327,7 @@ namespace OpenFeature
             }
         }
 
-        public async Task ShutdownAsync(CancellationToken cancellationToken = default)
+        public async ValueTask ShutdownAsync(CancellationToken cancellationToken = default)
         {
             await this._shutdownDelegate(cancellationToken).ConfigureAwait(false);
         }
@@ -338,7 +338,7 @@ namespace OpenFeature
         }
 
         // Method to signal shutdown
-        private async Task SignalShutdownAsync(CancellationToken cancellationToken)
+        private async ValueTask SignalShutdownAsync(CancellationToken cancellationToken)
         {
             // Enqueue a shutdown signal
             await this.EventChannel.Writer.WriteAsync(new ShutdownSignal(), cancellationToken).ConfigureAwait(false);

--- a/src/OpenFeature/EventExecutor.cs
+++ b/src/OpenFeature/EventExecutor.cs
@@ -11,7 +11,7 @@ using OpenFeature.Model;
 namespace OpenFeature
 {
 
-    internal delegate Task ShutdownDelegate();
+    internal delegate Task ShutdownDelegate(CancellationToken cancellationToken);
 
     internal class EventExecutor
     {
@@ -327,9 +327,9 @@ namespace OpenFeature
             }
         }
 
-        public async Task Shutdown()
+        public async Task ShutdownAsync(CancellationToken cancellationToken = default)
         {
-            await this._shutdownDelegate().ConfigureAwait(false);
+            await this._shutdownDelegate(cancellationToken).ConfigureAwait(false);
         }
 
         internal void SetShutdownDelegate(ShutdownDelegate del)
@@ -338,13 +338,13 @@ namespace OpenFeature
         }
 
         // Method to signal shutdown
-        private async Task SignalShutdownAsync()
+        private async Task SignalShutdownAsync(CancellationToken cancellationToken)
         {
             // Enqueue a shutdown signal
-            await this.EventChannel.Writer.WriteAsync(new ShutdownSignal()).ConfigureAwait(false);
+            await this.EventChannel.Writer.WriteAsync(new ShutdownSignal(), cancellationToken).ConfigureAwait(false);
 
             // Wait for the processing loop to acknowledge the shutdown
-            await this._shutdownSemaphore.WaitAsync().ConfigureAwait(false);
+            await this._shutdownSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -125,10 +125,10 @@ namespace OpenFeature
         /// the <see cref="GetStatus"/> method after initialization is complete.
         /// </para>
         /// </remarks>
-        public virtual Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
+        public virtual ValueTask InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
         {
             // Intentionally left blank.
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
         /// <summary>
@@ -137,10 +137,10 @@ namespace OpenFeature
         /// </summary>
         /// <returns>A task that completes when the shutdown process is complete.</returns>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public virtual Task ShutdownAsync(CancellationToken cancellationToken = default)
+        public virtual ValueTask ShutdownAsync(CancellationToken cancellationToken = default)
         {
             // Intentionally left blank.
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
         /// <summary>

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
@@ -43,9 +44,10 @@ namespace OpenFeature
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
-            EvaluationContext context = null);
+        public abstract Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue,
+            EvaluationContext context = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a string feature flag
@@ -53,9 +55,10 @@ namespace OpenFeature
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
-            EvaluationContext context = null);
+        public abstract Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue,
+            EvaluationContext context = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a integer feature flag
@@ -63,9 +66,10 @@ namespace OpenFeature
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
-            EvaluationContext context = null);
+        public abstract Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue,
+            EvaluationContext context = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a double feature flag
@@ -73,9 +77,10 @@ namespace OpenFeature
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
-            EvaluationContext context = null);
+        public abstract Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue,
+            EvaluationContext context = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a structured feature flag
@@ -83,9 +88,10 @@ namespace OpenFeature
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue,
-            EvaluationContext context = null);
+        public abstract Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue,
+            EvaluationContext context = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get the status of the provider.
@@ -95,7 +101,7 @@ namespace OpenFeature
         /// If a provider does not override this method, then its status will be assumed to be
         /// <see cref="ProviderStatus.Ready"/>. If a provider implements this method, and supports initialization,
         /// then it should start in the <see cref="ProviderStatus.NotReady"/>status . If the status is
-        /// <see cref="ProviderStatus.NotReady"/>, then the Api will call the <see cref="Initialize" /> when the
+        /// <see cref="ProviderStatus.NotReady"/>, then the Api will call the <see cref="InitializeAsync" /> when the
         /// provider is set.
         /// </remarks>
         public virtual ProviderStatus GetStatus() => ProviderStatus.Ready;
@@ -107,6 +113,7 @@ namespace OpenFeature
         /// </para>
         /// </summary>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>A task that completes when the initialization process is complete.</returns>
         /// <remarks>
         /// <para>
@@ -118,7 +125,7 @@ namespace OpenFeature
         /// the <see cref="GetStatus"/> method after initialization is complete.
         /// </para>
         /// </remarks>
-        public virtual Task Initialize(EvaluationContext context)
+        public virtual Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
         {
             // Intentionally left blank.
             return Task.CompletedTask;
@@ -129,7 +136,8 @@ namespace OpenFeature
         /// Providers can overwrite this method, if they have special shutdown actions needed.
         /// </summary>
         /// <returns>A task that completes when the shutdown process is complete.</returns>
-        public virtual Task Shutdown()
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public virtual Task ShutdownAsync(CancellationToken cancellationToken = default)
         {
             // Intentionally left blank.
             return Task.CompletedTask;

--- a/src/OpenFeature/Hook.cs
+++ b/src/OpenFeature/Hook.cs
@@ -30,10 +30,10 @@ namespace OpenFeature
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
         /// <returns>Modified EvaluationContext that is used for the flag evaluation</returns>
-        public virtual Task<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
+        public virtual ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
             IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(EvaluationContext.Empty);
+            return new ValueTask<EvaluationContext>(EvaluationContext.Empty);
         }
 
         /// <summary>
@@ -44,10 +44,10 @@ namespace OpenFeature
         /// <param name="hints">Caller provided data</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual Task AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+        public virtual ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
             IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
         /// <summary>
@@ -58,10 +58,10 @@ namespace OpenFeature
         /// <param name="hints">Caller provided data</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual Task ErrorAsync<T>(HookContext<T> context, Exception error,
+        public virtual ValueTask ErrorAsync<T>(HookContext<T> context, Exception error,
             IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
         /// <summary>
@@ -71,9 +71,9 @@ namespace OpenFeature
         /// <param name="hints">Caller provided data</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual Task FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+        public virtual ValueTask FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
     }
 }

--- a/src/OpenFeature/Hook.cs
+++ b/src/OpenFeature/Hook.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenFeature.Model;
 
@@ -26,10 +27,11 @@ namespace OpenFeature
         /// </summary>
         /// <param name="context">Provides context of innovation</param>
         /// <param name="hints">Caller provided data</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
         /// <returns>Modified EvaluationContext that is used for the flag evaluation</returns>
-        public virtual Task<EvaluationContext> Before<T>(HookContext<T> context,
-            IReadOnlyDictionary<string, object> hints = null)
+        public virtual Task<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
+            IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(EvaluationContext.Empty);
         }
@@ -40,9 +42,10 @@ namespace OpenFeature
         /// <param name="context">Provides context of innovation</param>
         /// <param name="details">Flag evaluation information</param>
         /// <param name="hints">Caller provided data</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual Task After<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
-            IReadOnlyDictionary<string, object> hints = null)
+        public virtual Task AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+            IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -53,9 +56,10 @@ namespace OpenFeature
         /// <param name="context">Provides context of innovation</param>
         /// <param name="error">Exception representing what went wrong</param>
         /// <param name="hints">Caller provided data</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual Task Error<T>(HookContext<T> context, Exception error,
-            IReadOnlyDictionary<string, object> hints = null)
+        public virtual Task ErrorAsync<T>(HookContext<T> context, Exception error,
+            IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -65,8 +69,9 @@ namespace OpenFeature
         /// </summary>
         /// <param name="context">Provides context of innovation</param>
         /// <param name="hints">Caller provided data</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual Task Finally<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null)
+        public virtual Task FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/src/OpenFeature/IFeatureClient.cs
+++ b/src/OpenFeature/IFeatureClient.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
-using OpenFeature.Constant;
 using OpenFeature.Model;
 
 namespace OpenFeature
@@ -60,8 +60,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag value.</returns>
-        Task<bool> GetBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<bool> GetBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a boolean feature flag
@@ -70,8 +71,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        Task<FlagEvaluationDetails<bool>> GetBooleanDetails(string flagKey, bool defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<FlagEvaluationDetails<bool>> GetBooleanDetailsAsync(string flagKey, bool defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a string feature flag
@@ -80,8 +82,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag value.</returns>
-        Task<string> GetStringValue(string flagKey, string defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<string> GetStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a string feature flag
@@ -90,8 +93,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        Task<FlagEvaluationDetails<string>> GetStringDetails(string flagKey, string defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<FlagEvaluationDetails<string>> GetStringDetailsAsync(string flagKey, string defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a integer feature flag
@@ -100,8 +104,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag value.</returns>
-        Task<int> GetIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<int> GetIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a integer feature flag
@@ -110,8 +115,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        Task<FlagEvaluationDetails<int>> GetIntegerDetails(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<FlagEvaluationDetails<int>> GetIntegerDetailsAsync(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a double feature flag
@@ -120,8 +126,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag value.</returns>
-        Task<double> GetDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<double> GetDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a double feature flag
@@ -130,8 +137,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        Task<FlagEvaluationDetails<double>> GetDoubleDetails(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<FlagEvaluationDetails<double>> GetDoubleDetailsAsync(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a structure object feature flag
@@ -140,8 +148,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag value.</returns>
-        Task<Value> GetObjectValue(string flagKey, Value defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<Value> GetObjectValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a structure object feature flag
@@ -150,7 +159,8 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        Task<FlagEvaluationDetails<Value>> GetObjectDetails(string flagKey, Value defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+        Task<FlagEvaluationDetails<Value>> GetObjectDetailsAsync(string flagKey, Value defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/OpenFeature/NoOpProvider.cs
+++ b/src/OpenFeature/NoOpProvider.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Model;
@@ -13,27 +14,27 @@ namespace OpenFeature
             return this._metadata;
         }
 
-        public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -36,9 +37,9 @@ namespace OpenFeature
         /// </param>
         /// <typeparam name="T">The type of the resolution method</typeparam>
         /// <returns>A tuple containing a resolution method and the provider it came from.</returns>
-        private (Func<string, T, EvaluationContext, Task<ResolutionDetails<T>>>, FeatureProvider)
+        private (Func<string, T, EvaluationContext, CancellationToken, Task<ResolutionDetails<T>>>, FeatureProvider)
             ExtractProvider<T>(
-                Func<FeatureProvider, Func<string, T, EvaluationContext, Task<ResolutionDetails<T>>>> method)
+                Func<FeatureProvider, Func<string, T, EvaluationContext, CancellationToken, Task<ResolutionDetails<T>>>> method)
         {
             // Alias the provider reference so getting the method and returning the provider are
             // guaranteed to be the same object.
@@ -136,70 +137,71 @@ namespace OpenFeature
         public void ClearHooks() => this._hooks.Clear();
 
         /// <inheritdoc />
-        public async Task<bool> GetBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null,
-            FlagEvaluationOptions config = null) =>
-            (await this.GetBooleanDetails(flagKey, defaultValue, context, config).ConfigureAwait(false)).Value;
+        public async Task<bool> GetBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null,
+            FlagEvaluationOptions config = null, CancellationToken cancellationToken = default) =>
+            (await this.GetBooleanDetailsAsync(flagKey, defaultValue, context, config, cancellationToken).ConfigureAwait(false)).Value;
 
         /// <inheritdoc />
-        public async Task<FlagEvaluationDetails<bool>> GetBooleanDetails(string flagKey, bool defaultValue,
-            EvaluationContext context = null, FlagEvaluationOptions config = null) =>
-            await this.EvaluateFlag(this.ExtractProvider<bool>(provider => provider.ResolveBooleanValue),
+        public async Task<FlagEvaluationDetails<bool>> GetBooleanDetailsAsync(string flagKey, bool defaultValue,
+            EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default) =>
+            await this.EvaluateFlagAsync(this.ExtractProvider<bool>(provider => provider.ResolveBooleanValueAsync),
                 FlagValueType.Boolean, flagKey,
-                defaultValue, context, config).ConfigureAwait(false);
+                defaultValue, context, config, cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<string> GetStringValue(string flagKey, string defaultValue, EvaluationContext context = null,
-            FlagEvaluationOptions config = null) =>
-            (await this.GetStringDetails(flagKey, defaultValue, context, config).ConfigureAwait(false)).Value;
+        public async Task<string> GetStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null,
+            FlagEvaluationOptions config = null, CancellationToken cancellationToken = default) =>
+            (await this.GetStringDetailsAsync(flagKey, defaultValue, context, config, cancellationToken).ConfigureAwait(false)).Value;
 
         /// <inheritdoc />
-        public async Task<FlagEvaluationDetails<string>> GetStringDetails(string flagKey, string defaultValue,
-            EvaluationContext context = null, FlagEvaluationOptions config = null) =>
-            await this.EvaluateFlag(this.ExtractProvider<string>(provider => provider.ResolveStringValue),
+        public async Task<FlagEvaluationDetails<string>> GetStringDetailsAsync(string flagKey, string defaultValue,
+            EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default) =>
+            await this.EvaluateFlagAsync(this.ExtractProvider<string>(provider => provider.ResolveStringValueAsync),
                 FlagValueType.String, flagKey,
-                defaultValue, context, config).ConfigureAwait(false);
+                defaultValue, context, config, cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<int> GetIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null,
-            FlagEvaluationOptions config = null) =>
-            (await this.GetIntegerDetails(flagKey, defaultValue, context, config).ConfigureAwait(false)).Value;
+        public async Task<int> GetIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null,
+            FlagEvaluationOptions config = null, CancellationToken cancellationToken = default) =>
+            (await this.GetIntegerDetailsAsync(flagKey, defaultValue, context, config, cancellationToken).ConfigureAwait(false)).Value;
 
         /// <inheritdoc />
-        public async Task<FlagEvaluationDetails<int>> GetIntegerDetails(string flagKey, int defaultValue,
-            EvaluationContext context = null, FlagEvaluationOptions config = null) =>
-            await this.EvaluateFlag(this.ExtractProvider<int>(provider => provider.ResolveIntegerValue),
+        public async Task<FlagEvaluationDetails<int>> GetIntegerDetailsAsync(string flagKey, int defaultValue,
+            EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default) =>
+            await this.EvaluateFlagAsync(this.ExtractProvider<int>(provider => provider.ResolveIntegerValueAsync),
                 FlagValueType.Number, flagKey,
-                defaultValue, context, config).ConfigureAwait(false);
+                defaultValue, context, config, cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<double> GetDoubleValue(string flagKey, double defaultValue,
+        public async Task<double> GetDoubleValueAsync(string flagKey, double defaultValue,
             EvaluationContext context = null,
-            FlagEvaluationOptions config = null) =>
-            (await this.GetDoubleDetails(flagKey, defaultValue, context, config).ConfigureAwait(false)).Value;
+            FlagEvaluationOptions config = null, CancellationToken cancellationToken = default) =>
+            (await this.GetDoubleDetailsAsync(flagKey, defaultValue, context, config, cancellationToken).ConfigureAwait(false)).Value;
 
         /// <inheritdoc />
-        public async Task<FlagEvaluationDetails<double>> GetDoubleDetails(string flagKey, double defaultValue,
-            EvaluationContext context = null, FlagEvaluationOptions config = null) =>
-            await this.EvaluateFlag(this.ExtractProvider<double>(provider => provider.ResolveDoubleValue),
+        public async Task<FlagEvaluationDetails<double>> GetDoubleDetailsAsync(string flagKey, double defaultValue,
+            EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default) =>
+            await this.EvaluateFlagAsync(this.ExtractProvider<double>(provider => provider.ResolveDoubleValueAsync),
                 FlagValueType.Number, flagKey,
-                defaultValue, context, config).ConfigureAwait(false);
+                defaultValue, context, config, cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<Value> GetObjectValue(string flagKey, Value defaultValue, EvaluationContext context = null,
-            FlagEvaluationOptions config = null) =>
-            (await this.GetObjectDetails(flagKey, defaultValue, context, config).ConfigureAwait(false)).Value;
+        public async Task<Value> GetObjectValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null,
+            FlagEvaluationOptions config = null, CancellationToken cancellationToken = default) =>
+            (await this.GetObjectDetailsAsync(flagKey, defaultValue, context, config, cancellationToken).ConfigureAwait(false)).Value;
 
         /// <inheritdoc />
-        public async Task<FlagEvaluationDetails<Value>> GetObjectDetails(string flagKey, Value defaultValue,
-            EvaluationContext context = null, FlagEvaluationOptions config = null) =>
-            await this.EvaluateFlag(this.ExtractProvider<Value>(provider => provider.ResolveStructureValue),
+        public async Task<FlagEvaluationDetails<Value>> GetObjectDetailsAsync(string flagKey, Value defaultValue,
+            EvaluationContext context = null, FlagEvaluationOptions config = null, CancellationToken cancellationToken = default) =>
+            await this.EvaluateFlagAsync(this.ExtractProvider<Value>(provider => provider.ResolveStructureValueAsync),
                 FlagValueType.Object, flagKey,
-                defaultValue, context, config).ConfigureAwait(false);
+                defaultValue, context, config, cancellationToken).ConfigureAwait(false);
 
-        private async Task<FlagEvaluationDetails<T>> EvaluateFlag<T>(
-            (Func<string, T, EvaluationContext, Task<ResolutionDetails<T>>>, FeatureProvider) providerInfo,
+        private async Task<FlagEvaluationDetails<T>> EvaluateFlagAsync<T>(
+            (Func<string, T, EvaluationContext, CancellationToken, Task<ResolutionDetails<T>>>, FeatureProvider) providerInfo,
             FlagValueType flagValueType, string flagKey, T defaultValue, EvaluationContext context = null,
-            FlagEvaluationOptions options = null)
+            FlagEvaluationOptions options = null,
+            CancellationToken cancellationToken = default)
         {
             var resolveValueDelegate = providerInfo.Item1;
             var provider = providerInfo.Item2;
@@ -242,13 +244,13 @@ namespace OpenFeature
             FlagEvaluationDetails<T> evaluation;
             try
             {
-                var contextFromHooks = await this.TriggerBeforeHooks(allHooks, hookContext, options).ConfigureAwait(false);
+                var contextFromHooks = await this.TriggerBeforeHooksAsync(allHooks, hookContext, options, cancellationToken).ConfigureAwait(false);
 
                 evaluation =
-                    (await resolveValueDelegate.Invoke(flagKey, defaultValue, contextFromHooks.EvaluationContext).ConfigureAwait(false))
+                    (await resolveValueDelegate.Invoke(flagKey, defaultValue, contextFromHooks.EvaluationContext, cancellationToken).ConfigureAwait(false))
                     .ToFlagEvaluationDetails();
 
-                await this.TriggerAfterHooks(allHooksReversed, hookContext, evaluation, options).ConfigureAwait(false);
+                await this.TriggerAfterHooksAsync(allHooksReversed, hookContext, evaluation, options, cancellationToken).ConfigureAwait(false);
             }
             catch (FeatureProviderException ex)
             {
@@ -256,32 +258,32 @@ namespace OpenFeature
                     ex.ErrorType.GetDescription());
                 evaluation = new FlagEvaluationDetails<T>(flagKey, defaultValue, ex.ErrorType, Reason.Error,
                     string.Empty, ex.Message);
-                await this.TriggerErrorHooks(allHooksReversed, hookContext, ex, options).ConfigureAwait(false);
+                await this.TriggerErrorHooksAsync(allHooksReversed, hookContext, ex, options, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 this._logger.LogError(ex, "Error while evaluating flag {FlagKey}", flagKey);
                 var errorCode = ex is InvalidCastException ? ErrorType.TypeMismatch : ErrorType.General;
                 evaluation = new FlagEvaluationDetails<T>(flagKey, defaultValue, errorCode, Reason.Error, string.Empty);
-                await this.TriggerErrorHooks(allHooksReversed, hookContext, ex, options).ConfigureAwait(false);
+                await this.TriggerErrorHooksAsync(allHooksReversed, hookContext, ex, options, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
-                await this.TriggerFinallyHooks(allHooksReversed, hookContext, options).ConfigureAwait(false);
+                await this.TriggerFinallyHooksAsync(allHooksReversed, hookContext, options, cancellationToken).ConfigureAwait(false);
             }
 
             return evaluation;
         }
 
-        private async Task<HookContext<T>> TriggerBeforeHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
-            FlagEvaluationOptions options)
+        private async Task<HookContext<T>> TriggerBeforeHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+            FlagEvaluationOptions options, CancellationToken cancellationToken = default)
         {
             var evalContextBuilder = EvaluationContext.Builder();
             evalContextBuilder.Merge(context.EvaluationContext);
 
             foreach (var hook in hooks)
             {
-                var resp = await hook.Before(context, options?.HookHints).ConfigureAwait(false);
+                var resp = await hook.BeforeAsync(context, options?.HookHints, cancellationToken).ConfigureAwait(false);
                 if (resp != null)
                 {
                     evalContextBuilder.Merge(resp);
@@ -297,23 +299,23 @@ namespace OpenFeature
             return context.WithNewEvaluationContext(evalContextBuilder.Build());
         }
 
-        private async Task TriggerAfterHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
-            FlagEvaluationDetails<T> evaluationDetails, FlagEvaluationOptions options)
+        private async Task TriggerAfterHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+            FlagEvaluationDetails<T> evaluationDetails, FlagEvaluationOptions options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)
             {
-                await hook.After(context, evaluationDetails, options?.HookHints).ConfigureAwait(false);
+                await hook.AfterAsync(context, evaluationDetails, options?.HookHints, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task TriggerErrorHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context, Exception exception,
-            FlagEvaluationOptions options)
+        private async Task TriggerErrorHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context, Exception exception,
+            FlagEvaluationOptions options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)
             {
                 try
                 {
-                    await hook.Error(context, exception, options?.HookHints).ConfigureAwait(false);
+                    await hook.ErrorAsync(context, exception, options?.HookHints, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -322,14 +324,14 @@ namespace OpenFeature
             }
         }
 
-        private async Task TriggerFinallyHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
-            FlagEvaluationOptions options)
+        private async Task TriggerFinallyHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+            FlagEvaluationOptions options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)
             {
                 try
                 {
-                    await hook.Finally(context, options?.HookHints).ConfigureAwait(false);
+                    await hook.FinallyAsync(context, options?.HookHints, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -275,7 +275,7 @@ namespace OpenFeature
             return evaluation;
         }
 
-        private async Task<HookContext<T>> TriggerBeforeHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+        private async ValueTask<HookContext<T>> TriggerBeforeHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
             FlagEvaluationOptions options, CancellationToken cancellationToken = default)
         {
             var evalContextBuilder = EvaluationContext.Builder();
@@ -299,7 +299,7 @@ namespace OpenFeature
             return context.WithNewEvaluationContext(evalContextBuilder.Build());
         }
 
-        private async Task TriggerAfterHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+        private async ValueTask TriggerAfterHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
             FlagEvaluationDetails<T> evaluationDetails, FlagEvaluationOptions options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)
@@ -308,7 +308,7 @@ namespace OpenFeature
             }
         }
 
-        private async Task TriggerErrorHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context, Exception exception,
+        private async ValueTask TriggerErrorHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context, Exception exception,
             FlagEvaluationOptions options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)
@@ -324,7 +324,7 @@ namespace OpenFeature
             }
         }
 
-        private async Task TriggerFinallyHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+        private async ValueTask TriggerFinallyHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
             FlagEvaluationOptions options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -55,7 +55,7 @@ namespace OpenFeature
         /// </param>
         /// <param name="afterShutdown">called after a provider is shutdown, can be used to remove event handlers</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public async Task SetProviderAsync(
+        public async ValueTask SetProviderAsync(
             FeatureProvider featureProvider,
             EvaluationContext context,
             Action<FeatureProvider> afterSet = null,
@@ -98,7 +98,7 @@ namespace OpenFeature
                 .ConfigureAwait(false);
         }
 
-        private static async Task InitProviderAsync(
+        private static async ValueTask InitProviderAsync(
             FeatureProvider newProvider,
             EvaluationContext context,
             Action<FeatureProvider> afterInitialization,
@@ -148,7 +148,7 @@ namespace OpenFeature
         /// </param>
         /// <param name="afterShutdown">called after a provider is shutdown, can be used to remove event handlers</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public async Task SetProviderAsync(string clientName,
+        public async ValueTask SetProviderAsync(string clientName,
             FeatureProvider featureProvider,
             EvaluationContext context,
             Action<FeatureProvider> afterSet = null,
@@ -198,7 +198,7 @@ namespace OpenFeature
         /// <remarks>
         /// Shutdown the feature provider if it is unused. This must be called within a write lock of the _providersLock.
         /// </remarks>
-        private async Task ShutdownIfUnusedAsync(
+        private async ValueTask ShutdownIfUnusedAsync(
             FeatureProvider targetProvider,
             Action<FeatureProvider> afterShutdown,
             Action<FeatureProvider, Exception> afterError,
@@ -226,7 +226,7 @@ namespace OpenFeature
         /// it would not be meaningful to emit an error.
         /// </para>
         /// </remarks>
-        private static async Task SafeShutdownProviderAsync(FeatureProvider targetProvider,
+        private static async ValueTask SafeShutdownProviderAsync(FeatureProvider targetProvider,
             Action<FeatureProvider> afterShutdown,
             Action<FeatureProvider, Exception> afterError,
             CancellationToken cancellationToken)
@@ -267,7 +267,7 @@ namespace OpenFeature
                 : this.GetProvider();
         }
 
-        public async Task ShutdownAsync(Action<FeatureProvider, Exception> afterError = null, CancellationToken cancellationToken = default)
+        public async ValueTask ShutdownAsync(Action<FeatureProvider, Exception> afterError = null, CancellationToken cancellationToken = default)
         {
             var providers = new HashSet<FeatureProvider>();
             this._providersLock.EnterWriteLock();

--- a/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
+++ b/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
@@ -45,62 +45,62 @@ namespace OpenFeature.Benchmark
 
         [Benchmark]
         public async Task OpenFeatureClient_GetBooleanValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetBooleanValue(_flagName, _defaultBoolValue);
+            await _client.GetBooleanValueAsync(_flagName, _defaultBoolValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetBooleanValue(_flagName, _defaultBoolValue, EvaluationContext.Empty);
+            await _client.GetBooleanValueAsync(_flagName, _defaultBoolValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetBooleanValue(_flagName, _defaultBoolValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await _client.GetBooleanValueAsync(_flagName, _defaultBoolValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetStringValue(_flagName, _defaultStringValue);
+            await _client.GetStringValueAsync(_flagName, _defaultStringValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetStringValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetStringValue(_flagName, _defaultStringValue, EvaluationContext.Empty);
+            await _client.GetStringValueAsync(_flagName, _defaultStringValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetStringValue(_flagName, _defaultStringValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await _client.GetStringValueAsync(_flagName, _defaultStringValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetIntegerValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetIntegerValue(_flagName, _defaultIntegerValue);
+            await _client.GetIntegerValueAsync(_flagName, _defaultIntegerValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetIntegerValue(_flagName, _defaultIntegerValue, EvaluationContext.Empty);
+            await _client.GetIntegerValueAsync(_flagName, _defaultIntegerValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetIntegerValue(_flagName, _defaultIntegerValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await _client.GetIntegerValueAsync(_flagName, _defaultIntegerValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetDoubleValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetDoubleValue(_flagName, _defaultDoubleValue);
+            await _client.GetDoubleValueAsync(_flagName, _defaultDoubleValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetDoubleValue(_flagName, _defaultDoubleValue, EvaluationContext.Empty);
+            await _client.GetDoubleValueAsync(_flagName, _defaultDoubleValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetDoubleValue(_flagName, _defaultDoubleValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await _client.GetDoubleValueAsync(_flagName, _defaultDoubleValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetObjectValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetObjectValue(_flagName, _defaultStructureValue);
+            await _client.GetObjectValueAsync(_flagName, _defaultStructureValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetObjectValue(_flagName, _defaultStructureValue, EvaluationContext.Empty);
+            await _client.GetObjectValueAsync(_flagName, _defaultStructureValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetObjectValue(_flagName, _defaultStructureValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await _client.GetObjectValueAsync(_flagName, _defaultStructureValue, EvaluationContext.Empty, _emptyFlagOptions);
     }
 }

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -42,7 +42,7 @@ namespace OpenFeature.E2ETests
         {
             _scenarioContext = scenarioContext;
             var flagdProvider = new FlagdProvider();
-            Api.Instance.SetProviderAsync(flagdProvider).Wait();
+            Api.Instance.SetProviderAsync(flagdProvider).GetAwaiter().GetResult();
             client = Api.Instance.GetClient();
         }
 

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -42,7 +42,7 @@ namespace OpenFeature.E2ETests
         {
             _scenarioContext = scenarioContext;
             var flagdProvider = new FlagdProvider();
-            Api.Instance.SetProvider(flagdProvider).Wait();
+            Api.Instance.SetProviderAsync(flagdProvider).Wait();
             client = Api.Instance.GetClient();
         }
 
@@ -55,7 +55,7 @@ namespace OpenFeature.E2ETests
         [When(@"a boolean flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Whenabooleanflagwithkeyisevaluatedwithdefaultvalue(string flagKey, bool defaultValue)
         {
-            this.booleanFlagValue = client.GetBooleanValue(flagKey, defaultValue);
+            this.booleanFlagValue = client.GetBooleanValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved boolean value should be ""(.*)""")]
@@ -67,7 +67,7 @@ namespace OpenFeature.E2ETests
         [When(@"a string flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Whenastringflagwithkeyisevaluatedwithdefaultvalue(string flagKey, string defaultValue)
         {
-            this.stringFlagValue = client.GetStringValue(flagKey, defaultValue);
+            this.stringFlagValue = client.GetStringValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved string value should be ""(.*)""")]
@@ -79,7 +79,7 @@ namespace OpenFeature.E2ETests
         [When(@"an integer flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void Whenanintegerflagwithkeyisevaluatedwithdefaultvalue(string flagKey, int defaultValue)
         {
-            this.intFlagValue = client.GetIntegerValue(flagKey, defaultValue);
+            this.intFlagValue = client.GetIntegerValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved integer value should be (.*)")]
@@ -91,7 +91,7 @@ namespace OpenFeature.E2ETests
         [When(@"a float flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void Whenafloatflagwithkeyisevaluatedwithdefaultvalue(string flagKey, double defaultValue)
         {
-            this.doubleFlagValue = client.GetDoubleValue(flagKey, defaultValue);
+            this.doubleFlagValue = client.GetDoubleValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved float value should be (.*)")]
@@ -103,7 +103,7 @@ namespace OpenFeature.E2ETests
         [When(@"an object flag with key ""(.*)"" is evaluated with a null default value")]
         public void Whenanobjectflagwithkeyisevaluatedwithanulldefaultvalue(string flagKey)
         {
-            this.objectFlagValue = client.GetObjectValue(flagKey, new Value());
+            this.objectFlagValue = client.GetObjectValueAsync(flagKey, new Value());
         }
 
         [Then(@"the resolved object value should be contain fields ""(.*)"", ""(.*)"", and ""(.*)"", with values ""(.*)"", ""(.*)"" and (.*), respectively")]
@@ -118,7 +118,7 @@ namespace OpenFeature.E2ETests
         [When(@"a boolean flag with key ""(.*)"" is evaluated with details and default value ""(.*)""")]
         public void Whenabooleanflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, bool defaultValue)
         {
-            this.booleanFlagDetails = client.GetBooleanDetails(flagKey, defaultValue);
+            this.booleanFlagDetails = client.GetBooleanDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved boolean details value should be ""(.*)"", the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -133,7 +133,7 @@ namespace OpenFeature.E2ETests
         [When(@"a string flag with key ""(.*)"" is evaluated with details and default value ""(.*)""")]
         public void Whenastringflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, string defaultValue)
         {
-            this.stringFlagDetails = client.GetStringDetails(flagKey, defaultValue);
+            this.stringFlagDetails = client.GetStringDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved string details value should be ""(.*)"", the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -148,7 +148,7 @@ namespace OpenFeature.E2ETests
         [When(@"an integer flag with key ""(.*)"" is evaluated with details and default value (.*)")]
         public void Whenanintegerflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, int defaultValue)
         {
-            this.intFlagDetails = client.GetIntegerDetails(flagKey, defaultValue);
+            this.intFlagDetails = client.GetIntegerDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved integer details value should be (.*), the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -163,7 +163,7 @@ namespace OpenFeature.E2ETests
         [When(@"a float flag with key ""(.*)"" is evaluated with details and default value (.*)")]
         public void Whenafloatflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, double defaultValue)
         {
-            this.doubleFlagDetails = client.GetDoubleDetails(flagKey, defaultValue);
+            this.doubleFlagDetails = client.GetDoubleDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved float details value should be (.*), the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -178,7 +178,7 @@ namespace OpenFeature.E2ETests
         [When(@"an object flag with key ""(.*)"" is evaluated with details and a null default value")]
         public void Whenanobjectflagwithkeyisevaluatedwithdetailsandanulldefaultvalue(string flagKey)
         {
-            this.objectFlagDetails = client.GetObjectDetails(flagKey, new Value());
+            this.objectFlagDetails = client.GetObjectDetailsAsync(flagKey, new Value());
         }
 
         [Then(@"the resolved object details value should be contain fields ""(.*)"", ""(.*)"", and ""(.*)"", with values ""(.*)"", ""(.*)"" and (.*), respectively")]
@@ -213,7 +213,7 @@ namespace OpenFeature.E2ETests
         {
             contextAwareFlagKey = flagKey;
             contextAwareDefaultValue = defaultValue;
-            contextAwareValue = client.GetStringValue(flagKey, contextAwareDefaultValue, context).Result;
+            contextAwareValue = client.GetStringValueAsync(flagKey, contextAwareDefaultValue, context).Result;
         }
 
         [Then(@"the resolved string response should be ""(.*)""")]
@@ -225,7 +225,7 @@ namespace OpenFeature.E2ETests
         [Then(@"the resolved flag value is ""(.*)"" when the context is empty")]
         public void Giventheresolvedflagvalueiswhenthecontextisempty(string expected)
         {
-            string emptyContextValue = client.GetStringValue(contextAwareFlagKey, contextAwareDefaultValue, new EvaluationContext(new Structure(ImmutableDictionary<string, Value>.Empty))).Result;
+            string emptyContextValue = client.GetStringValueAsync(contextAwareFlagKey, contextAwareDefaultValue, new EvaluationContext(new Structure(ImmutableDictionary<string, Value>.Empty))).Result;
             Assert.Equal(expected, emptyContextValue);
         }
 
@@ -234,7 +234,7 @@ namespace OpenFeature.E2ETests
         {
             this.notFoundFlagKey = flagKey;
             this.notFoundDefaultValue = defaultValue;
-            this.notFoundDetails = client.GetStringDetails(this.notFoundFlagKey, this.notFoundDefaultValue).Result;
+            this.notFoundDetails = client.GetStringDetailsAsync(this.notFoundFlagKey, this.notFoundDefaultValue).Result;
         }
 
         [Then(@"the default string value should be returned")]
@@ -255,7 +255,7 @@ namespace OpenFeature.E2ETests
         {
             this.typeErrorFlagKey = flagKey;
             this.typeErrorDefaultValue = defaultValue;
-            this.typeErrorDetails = client.GetIntegerDetails(this.typeErrorFlagKey, this.typeErrorDefaultValue).Result;
+            this.typeErrorDetails = client.GetIntegerDetailsAsync(this.typeErrorFlagKey, this.typeErrorDefaultValue).Result;
         }
 
         [Then(@"the default integer value should be returned")]

--- a/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -7,7 +7,7 @@ namespace OpenFeature.Tests
         {
             Api.Instance.SetContext(null);
             Api.Instance.ClearHooks();
-            Api.Instance.SetProvider(new NoOpFeatureProvider()).Wait();
+            Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).Wait();
         }
     }
 }

--- a/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -7,7 +7,7 @@ namespace OpenFeature.Tests
         {
             Api.Instance.SetContext(null);
             Api.Instance.ClearHooks();
-            Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).Wait();
+            Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).GetAwaiter().GetResult();
         }
     }
 }

--- a/test/OpenFeature.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderTests.cs
@@ -44,27 +44,27 @@ namespace OpenFeature.Tests
 
             var boolResolutionDetails = new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.None,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveBooleanValue(flagName, defaultBoolValue)).Should()
+            (await provider.ResolveBooleanValueAsync(flagName, defaultBoolValue)).Should()
                 .BeEquivalentTo(boolResolutionDetails);
 
             var integerResolutionDetails = new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.None,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveIntegerValue(flagName, defaultIntegerValue)).Should()
+            (await provider.ResolveIntegerValueAsync(flagName, defaultIntegerValue)).Should()
                 .BeEquivalentTo(integerResolutionDetails);
 
             var doubleResolutionDetails = new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.None,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveDoubleValue(flagName, defaultDoubleValue)).Should()
+            (await provider.ResolveDoubleValueAsync(flagName, defaultDoubleValue)).Should()
                 .BeEquivalentTo(doubleResolutionDetails);
 
             var stringResolutionDetails = new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.None,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveStringValue(flagName, defaultStringValue)).Should()
+            (await provider.ResolveStringValueAsync(flagName, defaultStringValue)).Should()
                 .BeEquivalentTo(stringResolutionDetails);
 
             var structureResolutionDetails = new ResolutionDetails<Value>(flagName, defaultStructureValue,
                 ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveStructureValue(flagName, defaultStructureValue)).Should()
+            (await provider.ResolveStructureValueAsync(flagName, defaultStructureValue)).Should()
                 .BeEquivalentTo(structureResolutionDetails);
         }
 
@@ -84,59 +84,59 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             const string testMessage = "An error message";
 
-            providerMock.ResolveBooleanValue(flagName, defaultBoolValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveBooleanValueAsync(flagName, defaultBoolValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.General,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveIntegerValue(flagName, defaultIntegerValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveIntegerValueAsync(flagName, defaultIntegerValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.ParseError,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveDoubleValue(flagName, defaultDoubleValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveDoubleValueAsync(flagName, defaultDoubleValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.InvalidContext,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveStringValue(flagName, defaultStringValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveStringValueAsync(flagName, defaultStringValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.TypeMismatch,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveStructureValue(flagName, defaultStructureValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveStructureValueAsync(flagName, defaultStructureValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<Value>(flagName, defaultStructureValue, ErrorType.FlagNotFound,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveStructureValue(flagName2, defaultStructureValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveStructureValueAsync(flagName2, defaultStructureValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<Value>(flagName2, defaultStructureValue, ErrorType.ProviderNotReady,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveBooleanValue(flagName2, defaultBoolValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveBooleanValueAsync(flagName2, defaultBoolValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<bool>(flagName2, defaultBoolValue, ErrorType.TargetingKeyMissing,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
-            var boolRes = await providerMock.ResolveBooleanValue(flagName, defaultBoolValue);
+            var boolRes = await providerMock.ResolveBooleanValueAsync(flagName, defaultBoolValue);
             boolRes.ErrorType.Should().Be(ErrorType.General);
             boolRes.ErrorMessage.Should().Be(testMessage);
 
-            var intRes = await providerMock.ResolveIntegerValue(flagName, defaultIntegerValue);
+            var intRes = await providerMock.ResolveIntegerValueAsync(flagName, defaultIntegerValue);
             intRes.ErrorType.Should().Be(ErrorType.ParseError);
             intRes.ErrorMessage.Should().Be(testMessage);
 
-            var doubleRes = await providerMock.ResolveDoubleValue(flagName, defaultDoubleValue);
+            var doubleRes = await providerMock.ResolveDoubleValueAsync(flagName, defaultDoubleValue);
             doubleRes.ErrorType.Should().Be(ErrorType.InvalidContext);
             doubleRes.ErrorMessage.Should().Be(testMessage);
 
-            var stringRes = await providerMock.ResolveStringValue(flagName, defaultStringValue);
+            var stringRes = await providerMock.ResolveStringValueAsync(flagName, defaultStringValue);
             stringRes.ErrorType.Should().Be(ErrorType.TypeMismatch);
             stringRes.ErrorMessage.Should().Be(testMessage);
 
-            var structRes1 = await providerMock.ResolveStructureValue(flagName, defaultStructureValue);
+            var structRes1 = await providerMock.ResolveStructureValueAsync(flagName, defaultStructureValue);
             structRes1.ErrorType.Should().Be(ErrorType.FlagNotFound);
             structRes1.ErrorMessage.Should().Be(testMessage);
 
-            var structRes2 = await providerMock.ResolveStructureValue(flagName2, defaultStructureValue);
+            var structRes2 = await providerMock.ResolveStructureValueAsync(flagName2, defaultStructureValue);
             structRes2.ErrorType.Should().Be(ErrorType.ProviderNotReady);
             structRes2.ErrorMessage.Should().Be(testMessage);
 
-            var boolRes2 = await providerMock.ResolveBooleanValue(flagName2, defaultBoolValue);
+            var boolRes2 = await providerMock.ResolveBooleanValueAsync(flagName2, defaultBoolValue);
             boolRes2.ErrorType.Should().Be(ErrorType.TargetingKeyMissing);
             boolRes2.ErrorMessage.Should().BeNull();
         }

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -75,28 +75,28 @@ namespace OpenFeature.Tests
             var defaultStructureValue = fixture.Create<Value>();
             var emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
-            await Api.Instance.SetProvider(new NoOpFeatureProvider());
+            await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetBooleanValue(flagName, defaultBoolValue)).Should().Be(defaultBoolValue);
-            (await client.GetBooleanValue(flagName, defaultBoolValue, EvaluationContext.Empty)).Should().Be(defaultBoolValue);
-            (await client.GetBooleanValue(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultBoolValue);
+            (await client.GetBooleanValueAsync(flagName, defaultBoolValue)).Should().Be(defaultBoolValue);
+            (await client.GetBooleanValueAsync(flagName, defaultBoolValue, EvaluationContext.Empty)).Should().Be(defaultBoolValue);
+            (await client.GetBooleanValueAsync(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultBoolValue);
 
-            (await client.GetIntegerValue(flagName, defaultIntegerValue)).Should().Be(defaultIntegerValue);
-            (await client.GetIntegerValue(flagName, defaultIntegerValue, EvaluationContext.Empty)).Should().Be(defaultIntegerValue);
-            (await client.GetIntegerValue(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultIntegerValue);
+            (await client.GetIntegerValueAsync(flagName, defaultIntegerValue)).Should().Be(defaultIntegerValue);
+            (await client.GetIntegerValueAsync(flagName, defaultIntegerValue, EvaluationContext.Empty)).Should().Be(defaultIntegerValue);
+            (await client.GetIntegerValueAsync(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultIntegerValue);
 
-            (await client.GetDoubleValue(flagName, defaultDoubleValue)).Should().Be(defaultDoubleValue);
-            (await client.GetDoubleValue(flagName, defaultDoubleValue, EvaluationContext.Empty)).Should().Be(defaultDoubleValue);
-            (await client.GetDoubleValue(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultDoubleValue);
+            (await client.GetDoubleValueAsync(flagName, defaultDoubleValue)).Should().Be(defaultDoubleValue);
+            (await client.GetDoubleValueAsync(flagName, defaultDoubleValue, EvaluationContext.Empty)).Should().Be(defaultDoubleValue);
+            (await client.GetDoubleValueAsync(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultDoubleValue);
 
-            (await client.GetStringValue(flagName, defaultStringValue)).Should().Be(defaultStringValue);
-            (await client.GetStringValue(flagName, defaultStringValue, EvaluationContext.Empty)).Should().Be(defaultStringValue);
-            (await client.GetStringValue(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultStringValue);
+            (await client.GetStringValueAsync(flagName, defaultStringValue)).Should().Be(defaultStringValue);
+            (await client.GetStringValueAsync(flagName, defaultStringValue, EvaluationContext.Empty)).Should().Be(defaultStringValue);
+            (await client.GetStringValueAsync(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultStringValue);
 
-            (await client.GetObjectValue(flagName, defaultStructureValue)).Should().BeEquivalentTo(defaultStructureValue);
-            (await client.GetObjectValue(flagName, defaultStructureValue, EvaluationContext.Empty)).Should().BeEquivalentTo(defaultStructureValue);
-            (await client.GetObjectValue(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(defaultStructureValue);
+            (await client.GetObjectValueAsync(flagName, defaultStructureValue)).Should().BeEquivalentTo(defaultStructureValue);
+            (await client.GetObjectValueAsync(flagName, defaultStructureValue, EvaluationContext.Empty)).Should().BeEquivalentTo(defaultStructureValue);
+            (await client.GetObjectValueAsync(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(defaultStructureValue);
         }
 
         [Fact]
@@ -121,33 +121,33 @@ namespace OpenFeature.Tests
             var defaultStructureValue = fixture.Create<Value>();
             var emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
-            await Api.Instance.SetProvider(new NoOpFeatureProvider());
+            await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
             var boolFlagEvaluationDetails = new FlagEvaluationDetails<bool>(flagName, defaultBoolValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await client.GetBooleanDetails(flagName, defaultBoolValue)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
-            (await client.GetBooleanDetails(flagName, defaultBoolValue, EvaluationContext.Empty)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
-            (await client.GetBooleanDetails(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
+            (await client.GetBooleanDetailsAsync(flagName, defaultBoolValue)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
+            (await client.GetBooleanDetailsAsync(flagName, defaultBoolValue, EvaluationContext.Empty)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
+            (await client.GetBooleanDetailsAsync(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
 
             var integerFlagEvaluationDetails = new FlagEvaluationDetails<int>(flagName, defaultIntegerValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await client.GetIntegerDetails(flagName, defaultIntegerValue)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
-            (await client.GetIntegerDetails(flagName, defaultIntegerValue, EvaluationContext.Empty)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
-            (await client.GetIntegerDetails(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
+            (await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
+            (await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue, EvaluationContext.Empty)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
+            (await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
 
             var doubleFlagEvaluationDetails = new FlagEvaluationDetails<double>(flagName, defaultDoubleValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await client.GetDoubleDetails(flagName, defaultDoubleValue)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
-            (await client.GetDoubleDetails(flagName, defaultDoubleValue, EvaluationContext.Empty)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
-            (await client.GetDoubleDetails(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
+            (await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
+            (await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue, EvaluationContext.Empty)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
+            (await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
 
             var stringFlagEvaluationDetails = new FlagEvaluationDetails<string>(flagName, defaultStringValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await client.GetStringDetails(flagName, defaultStringValue)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
-            (await client.GetStringDetails(flagName, defaultStringValue, EvaluationContext.Empty)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
-            (await client.GetStringDetails(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
+            (await client.GetStringDetailsAsync(flagName, defaultStringValue)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
+            (await client.GetStringDetailsAsync(flagName, defaultStringValue, EvaluationContext.Empty)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
+            (await client.GetStringDetailsAsync(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
 
             var structureFlagEvaluationDetails = new FlagEvaluationDetails<Value>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await client.GetObjectDetails(flagName, defaultStructureValue)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
-            (await client.GetObjectDetails(flagName, defaultStructureValue, EvaluationContext.Empty)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
-            (await client.GetObjectDetails(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
+            (await client.GetObjectDetailsAsync(flagName, defaultStructureValue)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
+            (await client.GetObjectDetailsAsync(flagName, defaultStructureValue, EvaluationContext.Empty)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
+            (await client.GetObjectDetailsAsync(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
         }
 
         [Fact]
@@ -168,17 +168,17 @@ namespace OpenFeature.Tests
             var mockedLogger = Substitute.For<ILogger<Api>>();
 
             // This will fail to case a String to TestStructure
-            mockedFeatureProvider.ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Throws<InvalidCastException>();
+            mockedFeatureProvider.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Throws<InvalidCastException>();
             mockedFeatureProvider.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             mockedFeatureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(mockedFeatureProvider);
+            await Api.Instance.SetProviderAsync(mockedFeatureProvider);
             var client = Api.Instance.GetClient(clientName, clientVersion, mockedLogger);
 
-            var evaluationDetails = await client.GetObjectDetails(flagName, defaultValue);
+            var evaluationDetails = await client.GetObjectDetailsAsync(flagName, defaultValue);
             evaluationDetails.ErrorType.Should().Be(ErrorType.TypeMismatch);
 
-            _ = mockedFeatureProvider.Received(1).ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = mockedFeatureProvider.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
 
             mockedLogger.Received(1).Log(
                 LogLevel.Error,
@@ -198,16 +198,16 @@ namespace OpenFeature.Tests
             var defaultValue = fixture.Create<bool>();
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveBooleanValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>(flagName, defaultValue));
+            featureProviderMock.ResolveBooleanValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>(flagName, defaultValue));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetBooleanValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetBooleanValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
-            _ = featureProviderMock.Received(1).ResolveBooleanValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveBooleanValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -220,16 +220,16 @@ namespace OpenFeature.Tests
             var defaultValue = fixture.Create<string>();
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveStringValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<string>(flagName, defaultValue));
+            featureProviderMock.ResolveStringValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<string>(flagName, defaultValue));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetStringValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetStringValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
-            _ = featureProviderMock.Received(1).ResolveStringValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveStringValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -242,16 +242,16 @@ namespace OpenFeature.Tests
             var defaultValue = fixture.Create<int>();
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveIntegerValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<int>(flagName, defaultValue));
+            featureProviderMock.ResolveIntegerValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<int>(flagName, defaultValue));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetIntegerValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetIntegerValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
-            _ = featureProviderMock.Received(1).ResolveIntegerValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveIntegerValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -264,16 +264,16 @@ namespace OpenFeature.Tests
             var defaultValue = fixture.Create<double>();
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveDoubleValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<double>(flagName, defaultValue));
+            featureProviderMock.ResolveDoubleValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<double>(flagName, defaultValue));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetDoubleValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetDoubleValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
-            _ = featureProviderMock.Received(1).ResolveDoubleValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveDoubleValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -286,16 +286,16 @@ namespace OpenFeature.Tests
             var defaultValue = fixture.Create<Value>();
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<Value>(flagName, defaultValue));
+            featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<Value>(flagName, defaultValue));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetObjectValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetObjectValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
-            _ = featureProviderMock.Received(1).ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -309,18 +309,18 @@ namespace OpenFeature.Tests
             const string testMessage = "Couldn't parse flag data.";
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(Task.FromResult(new ResolutionDetails<Value>(flagName, defaultValue, ErrorType.ParseError, "ERROR", null, testMessage)));
+            featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(Task.FromResult(new ResolutionDetails<Value>(flagName, defaultValue, ErrorType.ParseError, "ERROR", null, testMessage)));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
-            var response = await client.GetObjectDetails(flagName, defaultValue);
+            var response = await client.GetObjectDetailsAsync(flagName, defaultValue);
 
             response.ErrorType.Should().Be(ErrorType.ParseError);
             response.Reason.Should().Be(Reason.Error);
             response.ErrorMessage.Should().Be(testMessage);
-            _ = featureProviderMock.Received(1).ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -334,26 +334,26 @@ namespace OpenFeature.Tests
             const string testMessage = "Couldn't parse flag data.";
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Throws(new FeatureProviderException(ErrorType.ParseError, testMessage));
+            featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Throws(new FeatureProviderException(ErrorType.ParseError, testMessage));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
-            var response = await client.GetObjectDetails(flagName, defaultValue);
+            var response = await client.GetObjectDetailsAsync(flagName, defaultValue);
 
             response.ErrorType.Should().Be(ErrorType.ParseError);
             response.Reason.Should().Be(Reason.Error);
             response.ErrorMessage.Should().Be(testMessage);
-            _ = featureProviderMock.Received(1).ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
         public async Task Should_Use_No_Op_When_Provider_Is_Null()
         {
-            await Api.Instance.SetProvider(null);
+            await Api.Instance.SetProviderAsync(null);
             var client = new FeatureClient("test", "test");
-            (await client.GetIntegerValue("some-key", 12)).Should().Be(12);
+            (await client.GetIntegerValueAsync("some-key", 12)).Should().Be(12);
         }
 
         [Fact]

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -43,7 +43,7 @@ namespace OpenFeature.Tests
             eventHandler.Received().Invoke(Arg.Is<ProviderEventPayload>(payload => payload == myEvent.EventPayload));
 
             // shut down the event executor
-            await eventExecutor.Shutdown();
+            await eventExecutor.ShutdownAsync();
 
             // the next event should not be propagated to the event handler
             var newEventPayload = new ProviderEventPayload { Type = ProviderEventTypes.ProviderStale };
@@ -70,11 +70,11 @@ namespace OpenFeature.Tests
             Api.Instance.AddHandler(ProviderEventTypes.ProviderStale, eventHandler);
 
             var testProvider = new TestProvider();
-            await Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
 
-            testProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
-            testProvider.SendEvent(ProviderEventTypes.ProviderError);
-            testProvider.SendEvent(ProviderEventTypes.ProviderStale);
+            await testProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
+            await testProvider.SendEventAsync(ProviderEventTypes.ProviderError);
+            await testProvider.SendEventAsync(ProviderEventTypes.ProviderStale);
 
             Thread.Sleep(1000);
             eventHandler
@@ -118,7 +118,7 @@ namespace OpenFeature.Tests
             var eventHandler = Substitute.For<EventHandlerDelegate>();
 
             var testProvider = new TestProvider();
-            await Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
 
             Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
@@ -143,7 +143,7 @@ namespace OpenFeature.Tests
             var eventHandler = Substitute.For<EventHandlerDelegate>();
 
             var testProvider = new TestProvider();
-            await Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
 
             testProvider.SetStatus(ProviderStatus.Error);
 
@@ -169,7 +169,7 @@ namespace OpenFeature.Tests
             var eventHandler = Substitute.For<EventHandlerDelegate>();
 
             var testProvider = new TestProvider();
-            await Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
 
             testProvider.SetStatus(ProviderStatus.Stale);
 
@@ -198,14 +198,14 @@ namespace OpenFeature.Tests
             Api.Instance.AddHandler(ProviderEventTypes.ProviderConfigurationChanged, eventHandler);
 
             var testProvider = new TestProvider();
-            await Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
 
-            testProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
+            await testProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
 
             var newTestProvider = new TestProvider();
-            await Api.Instance.SetProvider(newTestProvider);
+            await Api.Instance.SetProviderAsync(newTestProvider);
 
-            newTestProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
+            await newTestProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
 
             Thread.Sleep(1000);
             eventHandler.Received(2).Invoke(Arg.Is<ProviderEventPayload>(payload => payload.ProviderName == testProvider.GetMetadata().Name && payload.Type == ProviderEventTypes.ProviderReady));
@@ -224,13 +224,13 @@ namespace OpenFeature.Tests
             Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
             var testProvider = new TestProvider();
-            await Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
 
             Thread.Sleep(1000);
             Api.Instance.RemoveHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
             var newTestProvider = new TestProvider();
-            await Api.Instance.SetProvider(newTestProvider);
+            await Api.Instance.SetProviderAsync(newTestProvider);
 
             eventHandler.Received(1).Invoke(Arg.Is<ProviderEventPayload>(payload => payload.ProviderName == testProvider.GetMetadata().Name));
         }
@@ -255,7 +255,7 @@ namespace OpenFeature.Tests
             Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
             var testProvider = new TestProvider(fixture.Create<string>());
-            await Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
 
             failingEventHandler.Received().Invoke(Arg.Is<ProviderEventPayload>(payload => payload.ProviderName == testProvider.GetMetadata().Name));
             eventHandler.Received().Invoke(Arg.Is<ProviderEventPayload>(payload => payload.ProviderName == testProvider.GetMetadata().Name));
@@ -274,7 +274,7 @@ namespace OpenFeature.Tests
             var myClient = Api.Instance.GetClient(fixture.Create<string>());
 
             var testProvider = new TestProvider();
-            await Api.Instance.SetProvider(myClient.GetMetadata().Name, testProvider);
+            await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name, testProvider);
 
             myClient.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
@@ -303,7 +303,7 @@ namespace OpenFeature.Tests
             myClient.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
             var testProvider = new TestProvider();
-            await Api.Instance.SetProvider(myClient.GetMetadata().Name, testProvider);
+            await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name, testProvider);
 
             Thread.Sleep(1000);
 
@@ -330,9 +330,9 @@ namespace OpenFeature.Tests
             var clientProvider = new TestProvider(fixture.Create<string>());
 
             // set the default provider on API level, but not specifically to the client
-            await Api.Instance.SetProvider(apiProvider);
+            await Api.Instance.SetProviderAsync(apiProvider);
             // set the other provider specifically for the client
-            await Api.Instance.SetProvider(myClientWithBoundProvider.GetMetadata().Name, clientProvider);
+            await Api.Instance.SetProviderAsync(myClientWithBoundProvider.GetMetadata().Name, clientProvider);
 
             myClientWithNoBoundProvider.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
             myClientWithBoundProvider.AddHandler(ProviderEventTypes.ProviderReady, clientEventHandler);
@@ -362,11 +362,11 @@ namespace OpenFeature.Tests
             var clientProvider = new TestProvider(fixture.Create<string>());
 
             // set the default provider
-            await Api.Instance.SetProvider(defaultProvider);
+            await Api.Instance.SetProviderAsync(defaultProvider);
 
             client.AddHandler(ProviderEventTypes.ProviderConfigurationChanged, clientEventHandler);
 
-            defaultProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
+            await defaultProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
 
             Thread.Sleep(1000);
 
@@ -374,11 +374,11 @@ namespace OpenFeature.Tests
             clientEventHandler.Received(1).Invoke(Arg.Is<ProviderEventPayload>(payload => payload.ProviderName == defaultProvider.GetMetadata().Name && payload.Type == ProviderEventTypes.ProviderConfigurationChanged));
 
             // set the other provider specifically for the client
-            await Api.Instance.SetProvider(client.GetMetadata().Name, clientProvider);
+            await Api.Instance.SetProviderAsync(client.GetMetadata().Name, clientProvider);
 
             // now, send another event for the default handler
-            defaultProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
-            clientProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
+            await defaultProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
+            await clientProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
 
             Thread.Sleep(1000);
 
@@ -403,7 +403,7 @@ namespace OpenFeature.Tests
             var myClient = Api.Instance.GetClient(fixture.Create<string>());
 
             var testProvider = new TestProvider();
-            await Api.Instance.SetProvider(myClient.GetMetadata().Name, testProvider);
+            await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name, testProvider);
 
             // add the event handler after the provider has already transitioned into the ready state
             myClient.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
@@ -428,14 +428,14 @@ namespace OpenFeature.Tests
             myClient.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
             var testProvider = new TestProvider();
-            await Api.Instance.SetProvider(myClient.GetMetadata().Name, testProvider);
+            await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name, testProvider);
 
             // wait for the first event to be received
             Thread.Sleep(1000);
             myClient.RemoveHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
             // send another event from the provider - this one should not be received
-            testProvider.SendEvent(ProviderEventTypes.ProviderReady);
+            await testProvider.SendEventAsync(ProviderEventTypes.ProviderReady);
 
             // wait a bit and make sure we only have received the first event, but nothing after removing the event handler
             Thread.Sleep(1000);

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -35,57 +35,57 @@ namespace OpenFeature.Tests
             var providerHook = Substitute.For<Hook>();
 
             // Sequence
-            apiHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-            clientHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-            invocationHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-            providerHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-            providerHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            invocationHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            clientHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            apiHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            providerHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            invocationHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            clientHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            apiHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
+            apiHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
+            clientHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
+            invocationHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
+            providerHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
+            providerHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
+            invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
+            clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
+            apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
+            providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
+            invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
+            clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
+            apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
 
             var testProvider = new TestProvider();
             testProvider.AddHook(providerHook);
             Api.Instance.AddHooks(apiHook);
-            await Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
             var client = Api.Instance.GetClient(clientName, clientVersion);
             client.AddHooks(clientHook);
 
-            await client.GetBooleanValue(flagName, defaultValue, EvaluationContext.Empty,
+            await client.GetBooleanValueAsync(flagName, defaultValue, EvaluationContext.Empty,
                 new FlagEvaluationOptions(invocationHook, ImmutableDictionary<string, object>.Empty));
 
             Received.InOrder(() =>
             {
-                apiHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                clientHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                invocationHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                providerHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                providerHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                invocationHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                clientHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                apiHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                providerHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                invocationHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                clientHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                apiHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                apiHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                clientHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                invocationHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                providerHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                providerHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
             });
 
-            _ = apiHook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = clientHook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = invocationHook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = providerHook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = providerHook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = invocationHook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = clientHook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = apiHook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = providerHook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = invocationHook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = clientHook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = apiHook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = apiHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = clientHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = invocationHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = providerHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = providerHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = invocationHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = clientHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = apiHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = providerHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = invocationHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = clientHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = apiHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
         }
 
         [Fact]
@@ -139,15 +139,15 @@ namespace OpenFeature.Tests
                 FlagValueType.Boolean, new ClientMetadata("test", "1.0.0"), new Metadata(NoOpProvider.NoOpProviderName),
                 evaluationContext);
 
-            hook1.Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>()).Returns(evaluationContext);
-            hook2.Before(hookContext, Arg.Any<ImmutableDictionary<string, object>>()).Returns(evaluationContext);
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>()).Returns(evaluationContext);
+            hook2.BeforeAsync(hookContext, Arg.Any<ImmutableDictionary<string, object>>()).Returns(evaluationContext);
 
             var client = Api.Instance.GetClient("test", "1.0.0");
-            await client.GetBooleanValue("test", false, EvaluationContext.Empty,
+            await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty,
                 new FlagEvaluationOptions(ImmutableList.Create(hook1, hook2), ImmutableDictionary<string, object>.Empty));
 
-            _ = hook1.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-            _ = hook2.Received(1).Before(Arg.Is<HookContext<bool>>(a => a.EvaluationContext.GetValue("test").AsString == "test"), Arg.Any<ImmutableDictionary<string, object>>());
+            _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+            _ = hook2.Received(1).BeforeAsync(Arg.Is<HookContext<bool>>(a => a.EvaluationContext.GetValue("test").AsString == "test"), Arg.Any<ImmutableDictionary<string, object>>());
         }
 
         [Fact]
@@ -195,19 +195,19 @@ namespace OpenFeature.Tests
 
             provider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            provider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", true));
+            provider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", true));
 
-            await Api.Instance.SetProvider(provider);
+            await Api.Instance.SetProviderAsync(provider);
 
             var hook = Substitute.For<Hook>();
-            hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>()).Returns(hookContext);
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>()).Returns(hookContext);
 
 
             var client = Api.Instance.GetClient("test", "1.0.0", null, clientContext);
-            await client.GetBooleanValue("test", false, invocationContext, new FlagEvaluationOptions(ImmutableList.Create(hook), ImmutableDictionary<string, object>.Empty));
+            await client.GetBooleanValueAsync("test", false, invocationContext, new FlagEvaluationOptions(ImmutableList.Create(hook), ImmutableDictionary<string, object>.Empty));
 
             // after proper merging, all properties should equal true
-            _ = provider.Received(1).ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Is<EvaluationContext>(y =>
+            _ = provider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Is<EvaluationContext>(y =>
                 (y.GetValue(propGlobal).AsBoolean ?? false)
                 && (y.GetValue(propClient).AsBoolean ?? false)
                 && (y.GetValue(propGlobalToOverwrite).AsBoolean ?? false)
@@ -238,10 +238,10 @@ namespace OpenFeature.Tests
             var hookContext = new HookContext<bool>("test", false, FlagValueType.Boolean,
                 new ClientMetadata(null, null), new Metadata(null), EvaluationContext.Empty);
 
-            await hook.Before(hookContext, hookHints);
-            await hook.After(hookContext, new FlagEvaluationDetails<bool>("test", false, ErrorType.None, "testing", "testing"), hookHints);
-            await hook.Finally(hookContext, hookHints);
-            await hook.Error(hookContext, new Exception(), hookHints);
+            await hook.BeforeAsync(hookContext, hookHints);
+            await hook.AfterAsync(hookContext, new FlagEvaluationDetails<bool>("test", false, ErrorType.None, "testing", "testing"), hookHints);
+            await hook.FinallyAsync(hookContext, hookHints);
+            await hook.ErrorAsync(hookContext, new Exception(), hookHints);
 
             hookContext.ClientMetadata.Name.Should().BeNull();
             hookContext.ClientMetadata.Version.Should().BeNull();
@@ -264,29 +264,29 @@ namespace OpenFeature.Tests
             featureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             // Sequence
-            hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Returns(EvaluationContext.Empty);
-            featureProvider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
-            _ = hook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Returns(EvaluationContext.Empty);
+            featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
+            _ = hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
 
-            await Api.Instance.SetProvider(featureProvider);
+            await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(hook);
 
-            await client.GetBooleanValue("test", false);
+            await client.GetBooleanValueAsync("test", false);
 
             Received.InOrder(() =>
             {
-                hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-                featureProvider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-                hook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-                hook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+                hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+                featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
+                hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
+                hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
             });
 
-            _ = hook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = featureProvider.Received(1).ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
+            _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = featureProvider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -301,10 +301,10 @@ namespace OpenFeature.Tests
             var testProvider = new TestProvider();
             testProvider.AddHook(hook4);
             Api.Instance.AddHooks(hook1);
-            await Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(hook2);
-            await client.GetBooleanValue("test", false, null,
+            await client.GetBooleanValueAsync("test", false, null,
                 new FlagEvaluationOptions(hook3, ImmutableDictionary<string, object>.Empty));
 
             Assert.Single(Api.Instance.GetHooks());
@@ -324,39 +324,39 @@ namespace OpenFeature.Tests
             featureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             // Sequence
-            hook1.Before(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-            hook2.Before(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-            featureProvider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
-            hook2.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(Task.CompletedTask);
-            hook1.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(Task.CompletedTask);
-            hook2.Finally(Arg.Any<HookContext<bool>>(), null).Returns(Task.CompletedTask);
-            hook1.Finally(Arg.Any<HookContext<bool>>(), null).Throws(new Exception());
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
+            hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
+            featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
+            hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(Task.CompletedTask);
+            hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(Task.CompletedTask);
+            hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Returns(Task.CompletedTask);
+            hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Throws(new Exception());
 
-            await Api.Instance.SetProvider(featureProvider);
+            await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(new[] { hook1, hook2 });
             client.GetHooks().Count().Should().Be(2);
 
-            await client.GetBooleanValue("test", false);
+            await client.GetBooleanValueAsync("test", false);
 
             Received.InOrder(() =>
             {
-                hook1.Before(Arg.Any<HookContext<bool>>(), null);
-                hook2.Before(Arg.Any<HookContext<bool>>(), null);
-                featureProvider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-                hook2.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-                hook1.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-                hook2.Finally(Arg.Any<HookContext<bool>>(), null);
-                hook1.Finally(Arg.Any<HookContext<bool>>(), null);
+                hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+                hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+                featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
+                hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+                hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+                hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), null);
+                hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), null);
             });
 
-            _ = hook1.Received(1).Before(Arg.Any<HookContext<bool>>(), null);
-            _ = hook2.Received(1).Before(Arg.Any<HookContext<bool>>(), null);
-            _ = featureProvider.Received(1).ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-            _ = hook2.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-            _ = hook1.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-            _ = hook2.Received(1).Finally(Arg.Any<HookContext<bool>>(), null);
-            _ = hook1.Received(1).Finally(Arg.Any<HookContext<bool>>(), null);
+            _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook2.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = featureProvider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
+            _ = hook2.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+            _ = hook1.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+            _ = hook2.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook1.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), null);
         }
 
         [Fact]
@@ -371,31 +371,31 @@ namespace OpenFeature.Tests
             featureProvider1.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             // Sequence
-            hook1.Before(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-            hook2.Before(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-            featureProvider1.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Throws(new Exception());
-            hook2.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
-            hook1.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
+            hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
+            featureProvider1.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Throws(new Exception());
+            hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
+            hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
 
-            await Api.Instance.SetProvider(featureProvider1);
+            await Api.Instance.SetProviderAsync(featureProvider1);
             var client = Api.Instance.GetClient();
             client.AddHooks(new[] { hook1, hook2 });
 
-            await client.GetBooleanValue("test", false);
+            await client.GetBooleanValueAsync("test", false);
 
             Received.InOrder(() =>
             {
-                hook1.Before(Arg.Any<HookContext<bool>>(), null);
-                hook2.Before(Arg.Any<HookContext<bool>>(), null);
-                featureProvider1.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-                hook2.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-                hook1.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+                hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+                hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+                featureProvider1.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
+                hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+                hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
             });
 
-            _ = hook1.Received(1).Before(Arg.Any<HookContext<bool>>(), null);
-            _ = hook2.Received(1).Before(Arg.Any<HookContext<bool>>(), null);
-            _ = hook1.Received(1).Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-            _ = hook2.Received(1).Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook2.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook1.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            _ = hook2.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
         }
 
         [Fact]
@@ -410,27 +410,27 @@ namespace OpenFeature.Tests
             featureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             // Sequence
-            hook1.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).ThrowsAsync(new Exception());
-            _ = hook1.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-            _ = hook2.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).ThrowsAsync(new Exception());
+            _ = hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            _ = hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
 
-            await Api.Instance.SetProvider(featureProvider);
+            await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(new[] { hook1, hook2 });
 
-            await client.GetBooleanValue("test", false);
+            await client.GetBooleanValueAsync("test", false);
 
             Received.InOrder(() =>
             {
-                hook1.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-                hook2.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-                hook1.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+                hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+                hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+                hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
             });
 
-            _ = hook1.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook2.DidNotReceive().Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook1.Received(1).Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-            _ = hook2.Received(1).Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook2.DidNotReceive().BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook1.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            _ = hook2.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
         }
 
         [Fact]
@@ -447,29 +447,29 @@ namespace OpenFeature.Tests
             featureProvider.GetProviderHooks()
                 .Returns(ImmutableList<Hook>.Empty);
 
-            hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(EvaluationContext.Empty);
 
-            featureProvider.ResolveBooleanValue("test", false, Arg.Any<EvaluationContext>())
+            featureProvider.ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<bool>("test", false));
 
-            hook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(Task.FromResult(Task.CompletedTask));
 
-            hook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(Task.CompletedTask);
 
-            await Api.Instance.SetProvider(featureProvider);
+            await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
 
-            await client.GetBooleanValue("test", false, EvaluationContext.Empty, flagOptions);
+            await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty, flagOptions);
 
             Received.InOrder(() =>
             {
-                hook.Received().Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-                featureProvider.Received().ResolveBooleanValue("test", false, Arg.Any<EvaluationContext>());
-                hook.Received().After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-                hook.Received().Finally(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received().BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                featureProvider.Received().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>());
+                hook.Received().AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received().FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
             });
         }
 
@@ -485,26 +485,26 @@ namespace OpenFeature.Tests
             featureProvider.GetMetadata().Returns(new Metadata(null));
 
             // Sequence
-            hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).ThrowsAsync(exceptionToThrow);
-            hook.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
-            hook.Finally(Arg.Any<HookContext<bool>>(), null).Returns(Task.CompletedTask);
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).ThrowsAsync(exceptionToThrow);
+            hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Returns(Task.CompletedTask);
 
             var client = Api.Instance.GetClient();
             client.AddHooks(hook);
 
-            var resolvedFlag = await client.GetBooleanValue("test", true);
+            var resolvedFlag = await client.GetBooleanValueAsync("test", true);
 
             Received.InOrder(() =>
             {
-                hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-                hook.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-                hook.Finally(Arg.Any<HookContext<bool>>(), null);
+                hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+                hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+                hook.FinallyAsync(Arg.Any<HookContext<bool>>(), null);
             });
 
             resolvedFlag.Should().BeTrue();
-            _ = hook.Received(1).Before(Arg.Any<HookContext<bool>>(), null);
-            _ = hook.Received(1).Error(Arg.Any<HookContext<bool>>(), exceptionToThrow, null);
-            _ = hook.Received(1).Finally(Arg.Any<HookContext<bool>>(), null);
+            _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), exceptionToThrow, null);
+            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), null);
         }
 
         [Fact]
@@ -522,36 +522,36 @@ namespace OpenFeature.Tests
             featureProvider.GetProviderHooks()
                 .Returns(ImmutableList<Hook>.Empty);
 
-            hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(EvaluationContext.Empty);
 
-            featureProvider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>())
+            featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<bool>("test", false));
 
-            hook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .ThrowsAsync(exceptionToThrow);
 
-            hook.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(Task.CompletedTask);
 
-            hook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(Task.CompletedTask);
 
-            await Api.Instance.SetProvider(featureProvider);
+            await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
 
-            var resolvedFlag = await client.GetBooleanValue("test", true, config: flagOptions);
+            var resolvedFlag = await client.GetBooleanValueAsync("test", true, config: flagOptions);
 
             resolvedFlag.Should().BeTrue();
 
             Received.InOrder(() =>
             {
-                hook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-                hook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-                hook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
             });
 
-            await featureProvider.DidNotReceive().ResolveBooleanValue("test", false, Arg.Any<EvaluationContext>());
+            await featureProvider.DidNotReceive().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>());
         }
 
         [Fact]

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -39,14 +39,14 @@ namespace OpenFeature.Tests
             clientHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
             invocationHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
             providerHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-            providerHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
+            providerHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
 
             var testProvider = new TestProvider();
             testProvider.AddHook(providerHook);
@@ -327,9 +327,9 @@ namespace OpenFeature.Tests
             hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
             hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
             featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
-            hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(Task.CompletedTask);
-            hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(Task.CompletedTask);
-            hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Returns(Task.CompletedTask);
+            hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
+            hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
+            hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Returns(new ValueTask());
             hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Throws(new Exception());
 
             await Api.Instance.SetProviderAsync(featureProvider);
@@ -374,8 +374,8 @@ namespace OpenFeature.Tests
             hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
             hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
             featureProvider1.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Throws(new Exception());
-            hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
-            hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
+            hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(new ValueTask());
+            hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(new ValueTask());
 
             await Api.Instance.SetProviderAsync(featureProvider1);
             var client = Api.Instance.GetClient();
@@ -410,7 +410,7 @@ namespace OpenFeature.Tests
             featureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             // Sequence
-            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).ThrowsAsync(new Exception());
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Throws(new Exception());
             _ = hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
             _ = hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
 
@@ -454,10 +454,10 @@ namespace OpenFeature.Tests
                 .Returns(new ResolutionDetails<bool>("test", false));
 
             hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-                .Returns(Task.FromResult(Task.CompletedTask));
+                .Returns(new ValueTask());
 
             hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-                .Returns(Task.CompletedTask);
+                .Returns(new ValueTask());
 
             await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
@@ -485,9 +485,9 @@ namespace OpenFeature.Tests
             featureProvider.GetMetadata().Returns(new Metadata(null));
 
             // Sequence
-            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).ThrowsAsync(exceptionToThrow);
-            hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
-            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Returns(Task.CompletedTask);
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Throws(exceptionToThrow);
+            hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(new ValueTask());
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Returns(new ValueTask());
 
             var client = Api.Instance.GetClient();
             client.AddHooks(hook);
@@ -529,13 +529,13 @@ namespace OpenFeature.Tests
                 .Returns(new ResolutionDetails<bool>("test", false));
 
             hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-                .ThrowsAsync(exceptionToThrow);
+                .Throws(exceptionToThrow);
 
             hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>())
-                .Returns(Task.CompletedTask);
+                .Returns(new ValueTask());
 
             hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-                .Returns(Task.CompletedTask);
+                .Returns(new ValueTask());
 
             await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -12,10 +12,7 @@ namespace OpenFeature.Tests
 {
     public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
     {
-        static async Task EmptyShutdown(CancellationToken cancellationToken)
-        {
-            await Task.FromResult(0).ConfigureAwait(false);
-        }
+        static ValueTask EmptyShutdown(CancellationToken cancellationToken) => new ValueTask();
 
         [Fact]
         [Specification("1.1.1", "The `API`, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the `API` are present at runtime.")]
@@ -189,7 +186,7 @@ namespace OpenFeature.Tests
         [Specification("1.1.5", "The API MUST provide a function for retrieving the metadata field of the configured `provider`.")]
         public void OpenFeature_Should_Get_Metadata()
         {
-            Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).Wait();
+            Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).GetAwaiter().GetResult();
             var openFeature = Api.Instance;
             var metadata = openFeature.GetProviderMetadata();
 

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -21,7 +21,7 @@ namespace OpenFeature.Tests
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();
             var context = new EvaluationContextBuilder().Build();
-            repository.SetProvider(provider, context);
+            repository.SetProviderAsync(provider, context);
             Assert.Equal(provider, repository.GetProvider());
         }
 
@@ -33,7 +33,7 @@ namespace OpenFeature.Tests
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
             // The setting of the provider is synchronous, so the afterSet should be as well.
-            repository.SetProvider(provider, context, afterSet: (theProvider) =>
+            repository.SetProviderAsync(provider, context, afterSet: (theProvider) =>
             {
                 callCount++;
                 Assert.Equal(provider, theProvider);
@@ -48,9 +48,9 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(providerMock, context);
-            providerMock.Received(1).Initialize(context);
-            providerMock.DidNotReceive().Shutdown();
+            await repository.SetProviderAsync(providerMock, context);
+            providerMock.Received(1).InitializeAsync(context);
+            providerMock.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace OpenFeature.Tests
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
-            await repository.SetProvider(providerMock, context, afterInitialization: (theProvider) =>
+            await repository.SetProviderAsync(providerMock, context, afterInitialization: (theProvider) =>
             {
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
@@ -76,10 +76,10 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            providerMock.When(x => x.Initialize(context)).Throw(new Exception("BAD THINGS"));
+            providerMock.When(x => x.InitializeAsync(context)).Throw(new Exception("BAD THINGS"));
             var callCount = 0;
             Exception receivedError = null;
-            await repository.SetProvider(providerMock, context, afterError: (theProvider, error) =>
+            await repository.SetProviderAsync(providerMock, context, afterError: (theProvider, error) =>
             {
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
@@ -99,8 +99,8 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(status);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(providerMock, context);
-            providerMock.DidNotReceive().Initialize(context);
+            await repository.SetProviderAsync(providerMock, context);
+            providerMock.DidNotReceive().InitializeAsync(context);
         }
 
         [Theory]
@@ -114,7 +114,7 @@ namespace OpenFeature.Tests
             providerMock.GetStatus().Returns(status);
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
-            await repository.SetProvider(providerMock, context, afterInitialization: provider => { callCount++; });
+            await repository.SetProviderAsync(providerMock, context, afterInitialization: provider => { callCount++; });
             Assert.Equal(0, callCount);
         }
 
@@ -129,10 +129,10 @@ namespace OpenFeature.Tests
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(provider1, context);
-            await repository.SetProvider(provider2, context);
-            provider1.Received(1).Shutdown();
-            provider2.DidNotReceive().Shutdown();
+            await repository.SetProviderAsync(provider1, context);
+            await repository.SetProviderAsync(provider2, context);
+            provider1.Received(1).ShutdownAsync();
+            provider2.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -146,9 +146,9 @@ namespace OpenFeature.Tests
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(provider1, context);
+            await repository.SetProviderAsync(provider1, context);
             var callCount = 0;
-            await repository.SetProvider(provider2, context, afterShutdown: provider =>
+            await repository.SetProviderAsync(provider2, context, afterShutdown: provider =>
             {
                 Assert.Equal(provider, provider1);
                 callCount++;
@@ -161,17 +161,17 @@ namespace OpenFeature.Tests
         {
             var repository = new ProviderRepository();
             var provider1 = Substitute.For<FeatureProvider>();
-            provider1.Shutdown().Throws(new Exception("SHUTDOWN ERROR"));
+            provider1.ShutdownAsync().Throws(new Exception("SHUTDOWN ERROR"));
             provider1.GetStatus().Returns(ProviderStatus.NotReady);
 
             var provider2 = Substitute.For<FeatureProvider>();
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(provider1, context);
+            await repository.SetProviderAsync(provider1, context);
             var callCount = 0;
             Exception errorThrown = null;
-            await repository.SetProvider(provider2, context, afterError: (provider, ex) =>
+            await repository.SetProviderAsync(provider2, context, afterError: (provider, ex) =>
             {
                 Assert.Equal(provider, provider1);
                 errorThrown = ex;
@@ -187,7 +187,7 @@ namespace OpenFeature.Tests
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();
             var context = new EvaluationContextBuilder().Build();
-            repository.SetProvider("the-name", provider, context);
+            repository.SetProviderAsync("the-name", provider, context);
             Assert.Equal(provider, repository.GetProvider("the-name"));
         }
 
@@ -199,7 +199,7 @@ namespace OpenFeature.Tests
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
             // The setting of the provider is synchronous, so the afterSet should be as well.
-            repository.SetProvider("the-name", provider, context, afterSet: (theProvider) =>
+            repository.SetProviderAsync("the-name", provider, context, afterSet: (theProvider) =>
             {
                 callCount++;
                 Assert.Equal(provider, theProvider);
@@ -214,9 +214,9 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider("the-name", providerMock, context);
-            providerMock.Received(1).Initialize(context);
-            providerMock.DidNotReceive().Shutdown();
+            await repository.SetProviderAsync("the-name", providerMock, context);
+            providerMock.Received(1).InitializeAsync(context);
+            providerMock.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -227,7 +227,7 @@ namespace OpenFeature.Tests
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
-            await repository.SetProvider("the-name", providerMock, context, afterInitialization: (theProvider) =>
+            await repository.SetProviderAsync("the-name", providerMock, context, afterInitialization: (theProvider) =>
             {
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
@@ -242,10 +242,10 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            providerMock.When(x => x.Initialize(context)).Throw(new Exception("BAD THINGS"));
+            providerMock.When(x => x.InitializeAsync(context)).Throw(new Exception("BAD THINGS"));
             var callCount = 0;
             Exception receivedError = null;
-            await repository.SetProvider("the-provider", providerMock, context, afterError: (theProvider, error) =>
+            await repository.SetProviderAsync("the-provider", providerMock, context, afterError: (theProvider, error) =>
             {
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
@@ -265,8 +265,8 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(status);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider("the-name", providerMock, context);
-            providerMock.DidNotReceive().Initialize(context);
+            await repository.SetProviderAsync("the-name", providerMock, context);
+            providerMock.DidNotReceive().InitializeAsync(context);
         }
 
         [Theory]
@@ -280,7 +280,7 @@ namespace OpenFeature.Tests
             providerMock.GetStatus().Returns(status);
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
-            await repository.SetProvider("the-name", providerMock, context,
+            await repository.SetProviderAsync("the-name", providerMock, context,
                 afterInitialization: provider => { callCount++; });
             Assert.Equal(0, callCount);
         }
@@ -296,10 +296,10 @@ namespace OpenFeature.Tests
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider("the-name", provider1, context);
-            await repository.SetProvider("the-name", provider2, context);
-            provider1.Received(1).Shutdown();
-            provider2.DidNotReceive().Shutdown();
+            await repository.SetProviderAsync("the-name", provider1, context);
+            await repository.SetProviderAsync("the-name", provider2, context);
+            provider1.Received(1).ShutdownAsync();
+            provider2.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -313,9 +313,9 @@ namespace OpenFeature.Tests
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider("the-provider", provider1, context);
+            await repository.SetProviderAsync("the-provider", provider1, context);
             var callCount = 0;
-            await repository.SetProvider("the-provider", provider2, context, afterShutdown: provider =>
+            await repository.SetProviderAsync("the-provider", provider2, context, afterShutdown: provider =>
             {
                 Assert.Equal(provider, provider1);
                 callCount++;
@@ -328,17 +328,17 @@ namespace OpenFeature.Tests
         {
             var repository = new ProviderRepository();
             var provider1 = Substitute.For<FeatureProvider>();
-            provider1.Shutdown().Throws(new Exception("SHUTDOWN ERROR"));
+            provider1.ShutdownAsync().Throws(new Exception("SHUTDOWN ERROR"));
             provider1.GetStatus().Returns(ProviderStatus.NotReady);
 
             var provider2 = Substitute.For<FeatureProvider>();
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider("the-name", provider1, context);
+            await repository.SetProviderAsync("the-name", provider1, context);
             var callCount = 0;
             Exception errorThrown = null;
-            await repository.SetProvider("the-name", provider2, context, afterError: (provider, ex) =>
+            await repository.SetProviderAsync("the-name", provider2, context, afterError: (provider, ex) =>
             {
                 Assert.Equal(provider, provider1);
                 errorThrown = ex;
@@ -360,12 +360,12 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider(provider1, context);
-            await repository.SetProvider("A", provider1, context);
+            await repository.SetProviderAsync(provider1, context);
+            await repository.SetProviderAsync("A", provider1, context);
             // Provider one is replaced for "A", but not default.
-            await repository.SetProvider("A", provider2, context);
+            await repository.SetProviderAsync("A", provider2, context);
 
-            provider1.DidNotReceive().Shutdown();
+            provider1.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -380,12 +380,12 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider("B", provider1, context);
-            await repository.SetProvider("A", provider1, context);
+            await repository.SetProviderAsync("B", provider1, context);
+            await repository.SetProviderAsync("A", provider1, context);
             // Provider one is replaced for "A", but not "B".
-            await repository.SetProvider("A", provider2, context);
+            await repository.SetProviderAsync("A", provider2, context);
 
-            provider1.DidNotReceive().Shutdown();
+            provider1.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -400,13 +400,13 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider("B", provider1, context);
-            await repository.SetProvider("A", provider1, context);
+            await repository.SetProviderAsync("B", provider1, context);
+            await repository.SetProviderAsync("A", provider1, context);
 
-            await repository.SetProvider("A", provider2, context);
-            await repository.SetProvider("B", provider2, context);
+            await repository.SetProviderAsync("A", provider2, context);
+            await repository.SetProviderAsync("B", provider2, context);
 
-            provider1.Received(1).Shutdown();
+            provider1.Received(1).ShutdownAsync();
         }
 
         [Fact]
@@ -421,8 +421,8 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider("A", provider1, context);
-            await repository.SetProvider("B", provider2, context);
+            await repository.SetProviderAsync("A", provider1, context);
+            await repository.SetProviderAsync("B", provider2, context);
 
             Assert.Equal(provider1, repository.GetProvider("A"));
             Assert.Equal(provider2, repository.GetProvider("B"));
@@ -440,8 +440,8 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider("A", provider1, context);
-            await repository.SetProvider("A", provider2, context);
+            await repository.SetProviderAsync("A", provider1, context);
+            await repository.SetProviderAsync("A", provider2, context);
 
             Assert.Equal(provider2, repository.GetProvider("A"));
         }
@@ -461,17 +461,17 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider(provider1, context);
-            await repository.SetProvider("provider1", provider1, context);
-            await repository.SetProvider("provider2", provider2, context);
-            await repository.SetProvider("provider2a", provider2, context);
-            await repository.SetProvider("provider3", provider3, context);
+            await repository.SetProviderAsync(provider1, context);
+            await repository.SetProviderAsync("provider1", provider1, context);
+            await repository.SetProviderAsync("provider2", provider2, context);
+            await repository.SetProviderAsync("provider2a", provider2, context);
+            await repository.SetProviderAsync("provider3", provider3, context);
 
-            await repository.Shutdown();
+            await repository.ShutdownAsync();
 
-            provider1.Received(1).Shutdown();
-            provider2.Received(1).Shutdown();
-            provider3.Received(1).Shutdown();
+            provider1.Received(1).ShutdownAsync();
+            provider2.Received(1).ShutdownAsync();
+            provider3.Received(1).ShutdownAsync();
         }
 
         [Fact]
@@ -480,27 +480,27 @@ namespace OpenFeature.Tests
             var repository = new ProviderRepository();
             var provider1 = Substitute.For<FeatureProvider>();
             provider1.GetStatus().Returns(ProviderStatus.NotReady);
-            provider1.Shutdown().Throws(new Exception("SHUTDOWN ERROR 1"));
+            provider1.ShutdownAsync().Throws(new Exception("SHUTDOWN ERROR 1"));
 
             var provider2 = Substitute.For<FeatureProvider>();
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
-            provider2.Shutdown().Throws(new Exception("SHUTDOWN ERROR 2"));
+            provider2.ShutdownAsync().Throws(new Exception("SHUTDOWN ERROR 2"));
 
             var provider3 = Substitute.For<FeatureProvider>();
             provider3.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider(provider1, context);
-            await repository.SetProvider("provider1", provider1, context);
-            await repository.SetProvider("provider2", provider2, context);
-            await repository.SetProvider("provider2a", provider2, context);
-            await repository.SetProvider("provider3", provider3, context);
+            await repository.SetProviderAsync(provider1, context);
+            await repository.SetProviderAsync("provider1", provider1, context);
+            await repository.SetProviderAsync("provider2", provider2, context);
+            await repository.SetProviderAsync("provider2a", provider2, context);
+            await repository.SetProviderAsync("provider3", provider3, context);
 
             var callCountShutdown1 = 0;
             var callCountShutdown2 = 0;
             var totalCallCount = 0;
-            await repository.Shutdown(afterError: (provider, exception) =>
+            await repository.ShutdownAsync(afterError: (provider, exception) =>
             {
                 totalCallCount++;
                 if (provider == provider1)
@@ -519,9 +519,9 @@ namespace OpenFeature.Tests
             Assert.Equal(1, callCountShutdown1);
             Assert.Equal(1, callCountShutdown2);
 
-            provider1.Received(1).Shutdown();
-            provider2.Received(1).Shutdown();
-            provider3.Received(1).Shutdown();
+            provider1.Received(1).ShutdownAsync();
+            provider2.Received(1).ShutdownAsync();
+            provider3.Received(1).ShutdownAsync();
         }
 
         [Fact]
@@ -531,12 +531,12 @@ namespace OpenFeature.Tests
             var provider = Substitute.For<FeatureProvider>();
             provider.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(provider, context);
-            await repository.SetProvider(provider, context);
+            await repository.SetProviderAsync(provider, context);
+            await repository.SetProviderAsync(provider, context);
 
             Assert.Equal(provider, repository.GetProvider());
-            provider.Received(1).Initialize(context);
-            provider.DidNotReceive().Shutdown();
+            provider.Received(1).InitializeAsync(context);
+            provider.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -546,12 +546,12 @@ namespace OpenFeature.Tests
             var provider = Substitute.For<FeatureProvider>();
             provider.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(provider, context);
-            await repository.SetProvider(null, context);
+            await repository.SetProviderAsync(provider, context);
+            await repository.SetProviderAsync(null, context);
 
             Assert.Equal(provider, repository.GetProvider());
-            provider.Received(1).Initialize(context);
-            provider.DidNotReceive().Shutdown();
+            provider.Received(1).InitializeAsync(context);
+            provider.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -566,10 +566,10 @@ namespace OpenFeature.Tests
             defaultProvider.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(defaultProvider, context);
+            await repository.SetProviderAsync(defaultProvider, context);
 
-            await repository.SetProvider("named-provider", namedProvider, context);
-            await repository.SetProvider("named-provider", null, context);
+            await repository.SetProviderAsync("named-provider", namedProvider, context);
+            await repository.SetProviderAsync("named-provider", null, context);
 
             Assert.Equal(defaultProvider, repository.GetProvider("named-provider"));
         }
@@ -582,15 +582,15 @@ namespace OpenFeature.Tests
 
             var defaultProvider = Substitute.For<FeatureProvider>();
             defaultProvider.GetStatus().Returns(ProviderStatus.NotReady);
-            await repository.SetProvider(defaultProvider, context);
+            await repository.SetProviderAsync(defaultProvider, context);
 
             var namedProvider = Substitute.For<FeatureProvider>();
             namedProvider.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await repository.SetProvider(null, namedProvider, context);
+            await repository.SetProviderAsync(null, namedProvider, context);
 
-            namedProvider.DidNotReceive().Initialize(context);
-            namedProvider.DidNotReceive().Shutdown();
+            namedProvider.DidNotReceive().InitializeAsync(context);
+            namedProvider.DidNotReceive().ShutdownAsync();
 
             Assert.Equal(defaultProvider, repository.GetProvider(null));
         }

--- a/test/OpenFeature.Tests/TestImplementations.cs
+++ b/test/OpenFeature.Tests/TestImplementations.cs
@@ -12,25 +12,25 @@ namespace OpenFeature.Tests
 
     public class TestHook : Hook
     {
-        public override Task<EvaluationContext> BeforeAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+        public override ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(EvaluationContext.Empty);
+            return new ValueTask<EvaluationContext>(EvaluationContext.Empty);
         }
 
-        public override Task AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+        public override ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
             IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
-        public override Task ErrorAsync<T>(HookContext<T> context, Exception error, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+        public override ValueTask ErrorAsync<T>(HookContext<T> context, Exception error, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
-        public override Task FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+        public override ValueTask FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
     }
 
@@ -105,7 +105,7 @@ namespace OpenFeature.Tests
             this._status = status;
         }
 
-        public override async Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
+        public override async ValueTask InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
         {
             this._status = ProviderStatus.Ready;
             await this.EventChannel.Writer.WriteAsync(new ProviderEventPayload { Type = ProviderEventTypes.ProviderReady, ProviderName = this.GetMetadata().Name }, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Switch to `ValueTask` on methods that are likely to complete synchronously and/or be populated with contrib-/user-provided delegates.

See: #184

___

This follows #184 with an idea (probably best punted for post-`2.0.0`) to switch plumbing-type methods from `Task` to `ValueTask` to take advantage of the zero-cost-sync-completion sugar that the `dotnet/runtime` folks have generously given us to play with.

I've got a bigger PR planned where I'll propose returning `ValueTask<T>` on the `IFeatureClient` methods in order to hide a TTL caching layer that users can use to amortize provider requests (e.g. users could configure `IFeatureClient` to cache a value for flag `K` for `N` seconds, and for those `N` seconds any subsequent requests to _any_ `IFeatureClient` for flag `K` would result in a sync read from a memory cache).

But that's for later, and for now this PR just looks to make those user-/contrib-provided plumbing methods super lightweight on the scalding hotpath.