### PR TITLE
fix: Fix ArgumentOutOfRangeException for empty hooks

### DIFF
--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -127,7 +127,26 @@ namespace OpenFeature
         /// </para>
         /// </summary>
         /// <param name="hooks">A list of <see cref="Hook"/></param>
-        public void AddHooks(IEnumerable<Hook> hooks) => this._hooks.PushRange(hooks.ToArray());
+        public void AddHooks(IEnumerable<Hook> hooks)
+#if NET7_0_OR_GREATER
+            => this._hooks.PushRange(hooks as Hook[] ?? hooks.ToArray());
+#else
+        {
+            // See: https://github.com/dotnet/runtime/issues/62121
+            if (hooks is Hook[] array)
+            {
+                if (array.Length > 0)
+                    this._hooks.PushRange(array);
+
+                return;
+            }
+
+            array = hooks.ToArray();
+
+            if (array.Length > 0)
+                this._hooks.PushRange(array);
+        }
+#endif
 
         /// <summary>
         /// Adds a hook to global hooks list

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -106,7 +106,26 @@ namespace OpenFeature
         }
 
         /// <inheritdoc />
-        public void AddHooks(IEnumerable<Hook> hooks) => this._hooks.PushRange(hooks.ToArray());
+        public void AddHooks(IEnumerable<Hook> hooks)
+#if NET7_0_OR_GREATER
+            => this._hooks.PushRange(hooks as Hook[] ?? hooks.ToArray());
+#else
+        {
+            // See: https://github.com/dotnet/runtime/issues/62121
+            if (hooks is Hook[] array)
+            {
+                if (array.Length > 0)
+                    this._hooks.PushRange(array);
+
+                return;
+            }
+
+            array = hooks.ToArray();
+
+            if (array.Length > 0)
+                this._hooks.PushRange(array);
+        }
+#endif
 
         /// <inheritdoc />
         public IEnumerable<Hook> GetHooks() => this._hooks.Reverse();

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -553,5 +553,12 @@ namespace OpenFeature.Tests
 
             await featureProvider.DidNotReceive().ResolveBooleanValue("test", false, Arg.Any<EvaluationContext>());
         }
+
+        [Fact]
+        public void Add_hooks_should_accept_empty_enumerable()
+        {
+            Api.Instance.ClearHooks();
+            Api.Instance.AddHooks(Enumerable.Empty<Hook>());
+        }
     }
 }


### PR DESCRIPTION
Stumbled into this one while working on #186 (while working on #181).

See: dotnet/runtime#62121, dotnet/runtime#62126