### PR TITLE
fix: More robust shutdown/cleanup/reset

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>latest</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
@@ -19,6 +19,7 @@
       Please sort alphabetically.
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
+    <MicrosoftBclAsyncInterfacesVer>[8.0.0,)</MicrosoftBclAsyncInterfacesVer>
     <MicrosoftExtensionsLoggerVer>[2.0,)</MicrosoftExtensionsLoggerVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.0.0,2.0)</MicrosoftSourceLinkGitHubPkgVer>
   </PropertyGroup>

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -17,14 +17,12 @@ namespace OpenFeature
     public sealed class Api : IEventBus
     {
         private EvaluationContext _evaluationContext = EvaluationContext.Empty;
-        private readonly ProviderRepository _repository = new ProviderRepository();
+        private EventExecutor _eventExecutor = new EventExecutor();
+        private ProviderRepository _repository = new ProviderRepository();
         private readonly ConcurrentStack<Hook> _hooks = new ConcurrentStack<Hook>();
 
         /// The reader/writer locks are not disposed because the singleton instance should never be disposed.
         private readonly ReaderWriterLockSlim _evaluationContextLock = new ReaderWriterLockSlim();
-
-        internal readonly EventExecutor EventExecutor = new EventExecutor();
-
 
         /// <summary>
         /// Singleton instance of Api
@@ -45,7 +43,7 @@ namespace OpenFeature
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
         public async Task SetProvider(FeatureProvider featureProvider)
         {
-            this.EventExecutor.RegisterDefaultFeatureProvider(featureProvider);
+            this._eventExecutor.RegisterDefaultFeatureProvider(featureProvider);
             await this._repository.SetProvider(featureProvider, this.GetContext()).ConfigureAwait(false);
         }
 
@@ -58,7 +56,7 @@ namespace OpenFeature
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
         public async Task SetProvider(string clientName, FeatureProvider featureProvider)
         {
-            this.EventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
+            this._eventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
             await this._repository.SetProvider(clientName, featureProvider, this.GetContext()).ConfigureAwait(false);
         }
 
@@ -224,20 +222,28 @@ namespace OpenFeature
         /// </summary>
         public async Task Shutdown()
         {
-            await this._repository.Shutdown().ConfigureAwait(false);
-            await this.EventExecutor.Shutdown().ConfigureAwait(false);
+            await using (this._eventExecutor.ConfigureAwait(false))
+            await using (this._repository.ConfigureAwait(false))
+            {
+                this._evaluationContext = EvaluationContext.Empty;
+                this._hooks.Clear();
+
+                // TODO: make these lazy to avoid extra allocations on the common cleanup path?
+                this._eventExecutor = new EventExecutor();
+                this._repository = new ProviderRepository();
+            }
         }
 
         /// <inheritdoc />
         public void AddHandler(ProviderEventTypes type, EventHandlerDelegate handler)
         {
-            this.EventExecutor.AddApiLevelHandler(type, handler);
+            this._eventExecutor.AddApiLevelHandler(type, handler);
         }
 
         /// <inheritdoc />
         public void RemoveHandler(ProviderEventTypes type, EventHandlerDelegate handler)
         {
-            this.EventExecutor.RemoveApiLevelHandler(type, handler);
+            this._eventExecutor.RemoveApiLevelHandler(type, handler);
         }
 
         /// <summary>
@@ -246,7 +252,13 @@ namespace OpenFeature
         /// <param name="logger">The logger to be used</param>
         public void SetLogger(ILogger logger)
         {
-            this.EventExecutor.Logger = logger;
+            this._eventExecutor.Logger = logger;
         }
+
+        internal void AddClientHandler(string client, ProviderEventTypes eventType, EventHandlerDelegate handler)
+            => this._eventExecutor.AddClientHandler(client, eventType, handler);
+
+        internal void RemoveClientHandler(string client, ProviderEventTypes eventType, EventHandlerDelegate handler)
+            => this._eventExecutor.RemoveClientHandler(client, eventType, handler);
     }
 }

--- a/src/OpenFeature/OpenFeature.csproj
+++ b/src/OpenFeature/OpenFeature.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVer)" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVer)" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggerVer)" />
   </ItemGroup>
 

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -96,13 +96,13 @@ namespace OpenFeature
         /// <inheritdoc />
         public void AddHandler(ProviderEventTypes eventType, EventHandlerDelegate handler)
         {
-            Api.Instance.EventExecutor.AddClientHandler(this._metadata.Name, eventType, handler);
+            Api.Instance.AddClientHandler(this._metadata.Name, eventType, handler);
         }
 
         /// <inheritdoc />
         public void RemoveHandler(ProviderEventTypes type, EventHandlerDelegate handler)
         {
-            Api.Instance.EventExecutor.RemoveClientHandler(this._metadata.Name, type, handler);
+            Api.Instance.RemoveClientHandler(this._metadata.Name, type, handler);
         }
 
         /// <inheritdoc />

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -12,7 +12,7 @@ namespace OpenFeature
     /// <summary>
     /// This class manages the collection of providers, both default and named, contained by the API.
     /// </summary>
-    internal sealed class ProviderRepository
+    internal sealed class ProviderRepository : IAsyncDisposable
     {
         private FeatureProvider _defaultProvider = new NoOpFeatureProvider();
 
@@ -30,6 +30,14 @@ namespace OpenFeature
         /// as it was being added or removed such as two concurrent calls to SetProvider replacing multiple instances
         /// of that provider under different names..
         private readonly ReaderWriterLockSlim _providersLock = new ReaderWriterLockSlim();
+
+        public async ValueTask DisposeAsync()
+        {
+            using (this._providersLock)
+            {
+                await this.Shutdown().ConfigureAwait(false);
+            }
+        }
 
         /// <summary>
         /// Set the default provider

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -11,11 +11,6 @@ namespace OpenFeature.Tests
 {
     public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
     {
-        static async Task EmptyShutdown()
-        {
-            await Task.FromResult(0).ConfigureAwait(false);
-        }
-
         [Fact]
         [Specification("1.1.1", "The `API`, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the `API` are present at runtime.")]
         public void OpenFeature_Should_Be_Singleton()
@@ -79,9 +74,6 @@ namespace OpenFeature.Tests
         [Specification("1.6.1", "The API MUST define a mechanism to propagate a shutdown request to active providers.")]
         public async Task OpenFeature_Should_Support_Shutdown()
         {
-            // configure the shutdown method of the event executor to do nothing
-            // to prevent eventing tests from failing
-            Api.Instance.EventExecutor.SetShutdownDelegate(EmptyShutdown);
             var providerA = Substitute.For<FeatureProvider>();
             providerA.GetStatus().Returns(ProviderStatus.NotReady);
 


### PR DESCRIPTION
Previously, we shutdown the consumer thread causing any reuse of the Api to block on the second event emitted to the event executor.

Fixes: #186

___

Stumbled into this one while working on #181 in which I've added unit tests that each setup their own independent `IHost` and then dispose of it at the conclusion of each test case.

But since the `Api.Instance` is inherently static/shared, subsequent test cases were observed blocking until CI timeout occurred.

This PR could reasonably be criticized for going a step too far by introducing a new dependency on `Microsoft.Bcl.AsyncInterfaces`, but I decided to propose it anyways on the basis that  `Microsoft.Bcl.AsyncInterfaces` is a transitive dependency of `Microsoft.Extensions.DependencyInjection.Abstractions` which itself is a transitive dependency of `Microsoft.Extensions.Logging.Abstractions >= 8.0.0`, and only applies to TFMs that do not ship `IAsyncDisposable` and friends in-the-box, i.e., `net462` and `netstandard2.0`.

An even cleaner solution would be to just bump our minimum required version of `Microsoft.Extensions.Logging.Abstractions` to `8.0.0` at which point `Microsoft.Bcl.AsyncInterfaces` comes transitively for free. I would prefer to do this, but figured that might be too controversial right before a release. _(That said, if you like this idea too, please chime in because I have a strong belief that exceedingly few consumers in the wild __actually__ need us to keep our MELA dependency pinned back in 2017. The newer versions of MELA are available for all of the relevant TFMs, which ought to mean there's no dependency hell argument at play on this one.)_