### PR TITLE
chore: revert breaking setProvider

### DIFF
--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -44,7 +44,7 @@ namespace OpenFeature
         [Obsolete("Will be removed in later versions; use SetProviderAsync, which can be awaited")]
         public void SetProvider(FeatureProvider featureProvider)
         {
-            this.EventExecutor.RegisterDefaultFeatureProvider(featureProvider);
+            this._eventExecutor.RegisterDefaultFeatureProvider(featureProvider);
             _ = this._repository.SetProvider(featureProvider, this.GetContext());
         }
 
@@ -68,7 +68,7 @@ namespace OpenFeature
         [Obsolete("Will be removed in later versions; use SetProviderAsync, which can be awaited")]
         public void SetProvider(string clientName, FeatureProvider featureProvider)
         {
-            this.EventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
+            this._eventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
             _ = this._repository.SetProvider(clientName, featureProvider, this.GetContext());
         }
 

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -47,7 +47,7 @@ namespace OpenFeature
         public void SetProvider(FeatureProvider featureProvider)
         {
             this.EventExecutor.RegisterDefaultFeatureProvider(featureProvider);
-            this._repository.SetProvider(featureProvider, this.GetContext()).ConfigureAwait(false);
+            _ = this._repository.SetProvider(featureProvider, this.GetContext());
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace OpenFeature
         public void SetProvider(string clientName, FeatureProvider featureProvider)
         {
             this.EventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
-            this._repository.SetProvider(clientName, featureProvider, this.GetContext()).ConfigureAwait(false);
+            _ = this._repository.SetProvider(clientName, featureProvider, this.GetContext());
         }
 
         /// <summary>

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,17 +39,40 @@ namespace OpenFeature
         private Api() { }
 
         /// <summary>
-        /// Sets the feature provider. In order to wait for the provider to be set, and initialization to complete,
+        /// Sets the default feature provider to given clientName without awaiting its initialization.
+        /// </summary>
+        /// <remarks>The provider cannot be set to null. Attempting to set the provider to null has no effect.</remarks>
+        /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
+        [Obsolete("Will be removed in later versions; use SetProviderAsync, which can be awaited")]
+        public void SetProvider(FeatureProvider featureProvider)
+        {
+            this.EventExecutor.RegisterDefaultFeatureProvider(featureProvider);
+            this._repository.SetProvider(featureProvider, this.GetContext()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sets the default feature provider. In order to wait for the provider to be set, and initialization to complete,
         /// await the returned task.
         /// </summary>
         /// <remarks>The provider cannot be set to null. Attempting to set the provider to null has no effect.</remarks>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
-        public async Task SetProvider(FeatureProvider featureProvider)
+        public async Task SetProviderAsync(FeatureProvider featureProvider)
         {
             this.EventExecutor.RegisterDefaultFeatureProvider(featureProvider);
             await this._repository.SetProvider(featureProvider, this.GetContext()).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Sets the feature provider to given clientName without awaiting its initialization.
+        /// </summary>
+        /// <param name="clientName">Name of client</param>
+        /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
+        [Obsolete("Will be removed in later versions; use SetProviderAsync, which can be awaited")]
+        public void SetProvider(string clientName, FeatureProvider featureProvider)
+        {
+            this.EventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
+            this._repository.SetProvider(clientName, featureProvider, this.GetContext()).ConfigureAwait(false);
+        }
 
         /// <summary>
         /// Sets the feature provider to given clientName. In order to wait for the provider to be set, and
@@ -56,7 +80,7 @@ namespace OpenFeature
         /// </summary>
         /// <param name="clientName">Name of client</param>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
-        public async Task SetProvider(string clientName, FeatureProvider featureProvider)
+        public async Task SetProviderAsync(string clientName, FeatureProvider featureProvider)
         {
             this.EventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
             await this._repository.SetProvider(clientName, featureProvider, this.GetContext()).ConfigureAwait(false);

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -42,7 +42,7 @@ namespace OpenFeature.E2ETests
         {
             _scenarioContext = scenarioContext;
             var flagdProvider = new FlagdProvider();
-            Api.Instance.SetProvider(flagdProvider).Wait();
+            Api.Instance.SetProviderAsync(flagdProvider).Wait();
             client = Api.Instance.GetClient();
         }
 

--- a/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -7,7 +7,7 @@ namespace OpenFeature.Tests
         {
             Api.Instance.SetContext(null);
             Api.Instance.ClearHooks();
-            Api.Instance.SetProvider(new NoOpFeatureProvider()).Wait();
+            Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).Wait();
         }
     }
 }

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -75,7 +75,7 @@ namespace OpenFeature.Tests
             var defaultStructureValue = fixture.Create<Value>();
             var emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
-            await Api.Instance.SetProvider(new NoOpFeatureProvider());
+            await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
             (await client.GetBooleanValue(flagName, defaultBoolValue)).Should().Be(defaultBoolValue);
@@ -121,7 +121,7 @@ namespace OpenFeature.Tests
             var defaultStructureValue = fixture.Create<Value>();
             var emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
-            await Api.Instance.SetProvider(new NoOpFeatureProvider());
+            await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
             var boolFlagEvaluationDetails = new FlagEvaluationDetails<bool>(flagName, defaultBoolValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
@@ -172,7 +172,7 @@ namespace OpenFeature.Tests
             mockedFeatureProvider.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             mockedFeatureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(mockedFeatureProvider);
+            await Api.Instance.SetProviderAsync(mockedFeatureProvider);
             var client = Api.Instance.GetClient(clientName, clientVersion, mockedLogger);
 
             var evaluationDetails = await client.GetObjectDetails(flagName, defaultValue);
@@ -202,7 +202,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
             (await client.GetBooleanValue(flagName, defaultValue)).Should().Be(defaultValue);
@@ -224,7 +224,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
             (await client.GetStringValue(flagName, defaultValue)).Should().Be(defaultValue);
@@ -246,7 +246,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
             (await client.GetIntegerValue(flagName, defaultValue)).Should().Be(defaultValue);
@@ -268,7 +268,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
             (await client.GetDoubleValue(flagName, defaultValue)).Should().Be(defaultValue);
@@ -290,7 +290,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
             (await client.GetObjectValue(flagName, defaultValue)).Should().Be(defaultValue);
@@ -313,7 +313,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
             var response = await client.GetObjectDetails(flagName, defaultValue);
 
@@ -338,7 +338,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProvider(featureProviderMock);
+            await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
             var response = await client.GetObjectDetails(flagName, defaultValue);
 
@@ -351,7 +351,7 @@ namespace OpenFeature.Tests
         [Fact]
         public async Task Should_Use_No_Op_When_Provider_Is_Null()
         {
-            await Api.Instance.SetProvider(null);
+            await Api.Instance.SetProviderAsync(null);
             var client = new FeatureClient("test", "test");
             (await client.GetIntegerValue("some-key", 12)).Should().Be(12);
         }

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -143,7 +143,9 @@ namespace OpenFeature.Tests
             var eventHandler = Substitute.For<EventHandlerDelegate>();
 
             var testProvider = new TestProvider();
+            #pragma warning disable CS0618 // Type or member is obsolete
             Api.Instance.SetProvider(testProvider);
+            #pragma warning restore CS0618 // Type or member is obsolete
 
             Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -136,7 +136,7 @@ namespace OpenFeature.Tests
         [Specification("5.2.4", "The `handler function` MUST accept a `event details` parameter.")]
         [Specification("5.3.1", "If the provider's `initialize` function terminates normally, `PROVIDER_READY` handlers MUST run.")]
         [Specification("5.3.3", "Handlers attached after the provider is already in the associated state, MUST run immediately.")]
-        public async void API_Level_Event_Handlers_Should_Be_Informed_About_Ready_State_After_Registering_Provider_Ready_Sync()
+        public async Task API_Level_Event_Handlers_Should_Be_Informed_About_Ready_State_After_Registering_Provider_Ready_Sync()
         {
             var eventHandler = Substitute.For<EventHandlerDelegate>();
 

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -137,7 +137,7 @@ namespace OpenFeature.Tests
         [Specification("5.2.4", "The `handler function` MUST accept a `event details` parameter.")]
         [Specification("5.3.1", "If the provider's `initialize` function terminates normally, `PROVIDER_READY` handlers MUST run.")]
         [Specification("5.3.3", "Handlers attached after the provider is already in the associated state, MUST run immediately.")]
-        public void API_Level_Event_Handlers_Should_Be_Informed_About_Ready_State_After_Registering_Provider_Ready_Sync()
+        public async void API_Level_Event_Handlers_Should_Be_Informed_About_Ready_State_After_Registering_Provider_Ready_Sync()
         {
             var eventHandler = Substitute.For<EventHandlerDelegate>();
 

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -121,13 +121,12 @@ namespace OpenFeature.Tests
 
             Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
-            Thread.Sleep(1000);
-            eventHandler
+            await Utils.AssertUntilAsync(_ => eventHandler
                 .Received()
                 .Invoke(
                     Arg.Is<ProviderEventPayload>(
                         payload => payload.ProviderName == testProvider.GetMetadata().Name && payload.Type == ProviderEventTypes.ProviderReady
-                    ));
+                    )));
         }
 
         [Fact]

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -143,9 +143,9 @@ namespace OpenFeature.Tests
             var eventHandler = Substitute.For<EventHandlerDelegate>();
 
             var testProvider = new TestProvider();
-            #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
             Api.Instance.SetProvider(testProvider);
-            #pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 
             Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -51,7 +51,7 @@ namespace OpenFeature.Tests
             var testProvider = new TestProvider();
             testProvider.AddHook(providerHook);
             Api.Instance.AddHooks(apiHook);
-            await Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
             var client = Api.Instance.GetClient(clientName, clientVersion);
             client.AddHooks(clientHook);
 
@@ -197,7 +197,7 @@ namespace OpenFeature.Tests
 
             provider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", true));
 
-            await Api.Instance.SetProvider(provider);
+            await Api.Instance.SetProviderAsync(provider);
 
             var hook = Substitute.For<Hook>();
             hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>()).Returns(hookContext);
@@ -269,7 +269,7 @@ namespace OpenFeature.Tests
             _ = hook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
             _ = hook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
 
-            await Api.Instance.SetProvider(featureProvider);
+            await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(hook);
 
@@ -301,7 +301,7 @@ namespace OpenFeature.Tests
             var testProvider = new TestProvider();
             testProvider.AddHook(hook4);
             Api.Instance.AddHooks(hook1);
-            await Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(hook2);
             await client.GetBooleanValue("test", false, null,
@@ -332,7 +332,7 @@ namespace OpenFeature.Tests
             hook2.Finally(Arg.Any<HookContext<bool>>(), null).Returns(Task.CompletedTask);
             hook1.Finally(Arg.Any<HookContext<bool>>(), null).Throws(new Exception());
 
-            await Api.Instance.SetProvider(featureProvider);
+            await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(new[] { hook1, hook2 });
             client.GetHooks().Count().Should().Be(2);
@@ -377,7 +377,7 @@ namespace OpenFeature.Tests
             hook2.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
             hook1.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
 
-            await Api.Instance.SetProvider(featureProvider1);
+            await Api.Instance.SetProviderAsync(featureProvider1);
             var client = Api.Instance.GetClient();
             client.AddHooks(new[] { hook1, hook2 });
 
@@ -414,7 +414,7 @@ namespace OpenFeature.Tests
             _ = hook1.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
             _ = hook2.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
 
-            await Api.Instance.SetProvider(featureProvider);
+            await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(new[] { hook1, hook2 });
 
@@ -459,7 +459,7 @@ namespace OpenFeature.Tests
             hook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(Task.CompletedTask);
 
-            await Api.Instance.SetProvider(featureProvider);
+            await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
 
             await client.GetBooleanValue("test", false, EvaluationContext.Empty, flagOptions);
@@ -537,7 +537,7 @@ namespace OpenFeature.Tests
             hook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(Task.CompletedTask);
 
-            await Api.Instance.SetProvider(featureProvider);
+            await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
 
             var resolvedFlag = await client.GetBooleanValue("test", true, config: flagOptions);

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -133,7 +133,8 @@ namespace OpenFeature.Tests
 
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
-        public async void OpenFeature_Should_Allow_Multiple_Client_Names_Of_Same_Instance()
+        public async Task OpenFeature_Should_Allow_Multiple_Client_Names_Of_Same_Instance()
+
         {
             var openFeature = Api.Instance;
             var provider = new TestProvider();

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -230,7 +230,6 @@ namespace OpenFeature.Tests
 
         [Fact]
         public async Task OpenFeature_Should_Allow_Multiple_Client_Mapping()
-
         {
             var openFeature = Api.Instance;
 

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -120,7 +120,8 @@ namespace OpenFeature.Tests
 
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
-        public async void OpenFeature_Should_Assign_Provider_To_Existing_Client()
+        public async Task OpenFeature_Should_Assign_Provider_To_Existing_Client()
+
         {
             const string name = "new-client";
             var openFeature = Api.Instance;

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -122,7 +122,6 @@ namespace OpenFeature.Tests
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
         public async Task OpenFeature_Should_Assign_Provider_To_Existing_Client()
-
         {
             const string name = "new-client";
             var openFeature = Api.Instance;

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -134,7 +134,6 @@ namespace OpenFeature.Tests
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
         public async Task OpenFeature_Should_Allow_Multiple_Client_Names_Of_Same_Instance()
-
         {
             var openFeature = Api.Instance;
             var provider = new TestProvider();

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -99,12 +99,12 @@ namespace OpenFeature.Tests
 
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
-        public void OpenFeature_Should_Not_Change_Named_Providers_When_Setting_Default_Provider()
+        public async void OpenFeature_Should_Not_Change_Named_Providers_When_Setting_Default_Provider()
         {
             var openFeature = Api.Instance;
 
-            openFeature.SetProviderAsync(new NoOpFeatureProvider());
-            openFeature.SetProviderAsync(TestProvider.DefaultName, new TestProvider());
+            await openFeature.SetProviderAsync(new NoOpFeatureProvider()).ConfigureAwait(false);
+            await openFeature.SetProviderAsync(TestProvider.DefaultName, new TestProvider()).ConfigureAwait(false);
 
             var defaultClient = openFeature.GetProviderMetadata();
             var namedClient = openFeature.GetProviderMetadata(TestProvider.DefaultName);
@@ -115,11 +115,11 @@ namespace OpenFeature.Tests
 
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
-        public void OpenFeature_Should_Set_Default_Provide_When_No_Name_Provided()
+        public async void OpenFeature_Should_Set_Default_Provide_When_No_Name_Provided()
         {
             var openFeature = Api.Instance;
 
-            openFeature.SetProviderAsync(new TestProvider());
+            await openFeature.SetProviderAsync(new TestProvider()).ConfigureAwait(false);
 
             var defaultClient = openFeature.GetProviderMetadata();
 
@@ -128,26 +128,26 @@ namespace OpenFeature.Tests
 
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
-        public void OpenFeature_Should_Assign_Provider_To_Existing_Client()
+        public async void OpenFeature_Should_Assign_Provider_To_Existing_Client()
         {
             const string name = "new-client";
             var openFeature = Api.Instance;
 
-            openFeature.SetProviderAsync(name, new TestProvider());
-            openFeature.SetProviderAsync(name, new NoOpFeatureProvider());
+            await openFeature.SetProviderAsync(name, new TestProvider()).ConfigureAwait(true);
+            await openFeature.SetProviderAsync(name, new NoOpFeatureProvider()).ConfigureAwait(true);
 
             openFeature.GetProviderMetadata(name).Name.Should().Be(NoOpProvider.NoOpProviderName);
         }
 
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
-        public void OpenFeature_Should_Allow_Multiple_Client_Names_Of_Same_Instance()
+        public async void OpenFeature_Should_Allow_Multiple_Client_Names_Of_Same_Instance()
         {
             var openFeature = Api.Instance;
             var provider = new TestProvider();
 
-            openFeature.SetProviderAsync("a", provider);
-            openFeature.SetProviderAsync("b", provider);
+            await openFeature.SetProviderAsync("a", provider).ConfigureAwait(true);
+            await openFeature.SetProviderAsync("b", provider).ConfigureAwait(true);
 
             var clientA = openFeature.GetProvider("a");
             var clientB = openFeature.GetProvider("b");
@@ -234,12 +234,12 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        public void OpenFeature_Should_Allow_Multiple_Client_Mapping()
+        public async void OpenFeature_Should_Allow_Multiple_Client_Mapping()
         {
             var openFeature = Api.Instance;
 
-            openFeature.SetProviderAsync("client1", new TestProvider());
-            openFeature.SetProviderAsync("client2", new NoOpFeatureProvider());
+            await openFeature.SetProviderAsync("client1", new TestProvider()).ConfigureAwait(true);
+            await openFeature.SetProviderAsync("client2", new NoOpFeatureProvider()).ConfigureAwait(true);
 
             var client1 = openFeature.GetClient("client1");
             var client2 = openFeature.GetClient("client2");

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -91,7 +91,8 @@ namespace OpenFeature.Tests
 
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
-        public async void OpenFeature_Should_Not_Change_Named_Providers_When_Setting_Default_Provider()
+        public async Task OpenFeature_Should_Not_Change_Named_Providers_When_Setting_Default_Provider()
+
         {
             var openFeature = Api.Instance;
 

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -92,7 +92,6 @@ namespace OpenFeature.Tests
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
         public async Task OpenFeature_Should_Not_Change_Named_Providers_When_Setting_Default_Provider()
-
         {
             var openFeature = Api.Instance;
 

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -33,13 +33,13 @@ namespace OpenFeature.Tests
             var providerMockDefault = Substitute.For<FeatureProvider>();
             providerMockDefault.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProvider(providerMockDefault).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerMockDefault).ConfigureAwait(false);
             await providerMockDefault.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
 
             var providerMockNamed = Substitute.For<FeatureProvider>();
             providerMockNamed.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProvider("the-name", providerMockNamed).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync("the-name", providerMockNamed).ConfigureAwait(false);
             await providerMockNamed.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
         }
 
@@ -51,26 +51,26 @@ namespace OpenFeature.Tests
             var providerA = Substitute.For<FeatureProvider>();
             providerA.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProvider(providerA).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerA).ConfigureAwait(false);
             await providerA.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
 
             var providerB = Substitute.For<FeatureProvider>();
             providerB.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProvider(providerB).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerB).ConfigureAwait(false);
             await providerB.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
             await providerA.Received(1).Shutdown().ConfigureAwait(false);
 
             var providerC = Substitute.For<FeatureProvider>();
             providerC.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProvider("named", providerC).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync("named", providerC).ConfigureAwait(false);
             await providerC.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
 
             var providerD = Substitute.For<FeatureProvider>();
             providerD.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProvider("named", providerD).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync("named", providerD).ConfigureAwait(false);
             await providerD.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
             await providerC.Received(1).Shutdown().ConfigureAwait(false);
         }
@@ -88,8 +88,8 @@ namespace OpenFeature.Tests
             var providerB = Substitute.For<FeatureProvider>();
             providerB.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProvider(providerA).ConfigureAwait(false);
-            await Api.Instance.SetProvider("named", providerB).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerA).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync("named", providerB).ConfigureAwait(false);
 
             await Api.Instance.Shutdown().ConfigureAwait(false);
 
@@ -103,8 +103,8 @@ namespace OpenFeature.Tests
         {
             var openFeature = Api.Instance;
 
-            openFeature.SetProvider(new NoOpFeatureProvider());
-            openFeature.SetProvider(TestProvider.DefaultName, new TestProvider());
+            openFeature.SetProviderAsync(new NoOpFeatureProvider());
+            openFeature.SetProviderAsync(TestProvider.DefaultName, new TestProvider());
 
             var defaultClient = openFeature.GetProviderMetadata();
             var namedClient = openFeature.GetProviderMetadata(TestProvider.DefaultName);
@@ -119,7 +119,7 @@ namespace OpenFeature.Tests
         {
             var openFeature = Api.Instance;
 
-            openFeature.SetProvider(new TestProvider());
+            openFeature.SetProviderAsync(new TestProvider());
 
             var defaultClient = openFeature.GetProviderMetadata();
 
@@ -133,8 +133,8 @@ namespace OpenFeature.Tests
             const string name = "new-client";
             var openFeature = Api.Instance;
 
-            openFeature.SetProvider(name, new TestProvider());
-            openFeature.SetProvider(name, new NoOpFeatureProvider());
+            openFeature.SetProviderAsync(name, new TestProvider());
+            openFeature.SetProviderAsync(name, new NoOpFeatureProvider());
 
             openFeature.GetProviderMetadata(name).Name.Should().Be(NoOpProvider.NoOpProviderName);
         }
@@ -146,8 +146,8 @@ namespace OpenFeature.Tests
             var openFeature = Api.Instance;
             var provider = new TestProvider();
 
-            openFeature.SetProvider("a", provider);
-            openFeature.SetProvider("b", provider);
+            openFeature.SetProviderAsync("a", provider);
+            openFeature.SetProviderAsync("b", provider);
 
             var clientA = openFeature.GetProvider("a");
             var clientB = openFeature.GetProvider("b");
@@ -188,7 +188,7 @@ namespace OpenFeature.Tests
         [Specification("1.1.5", "The API MUST provide a function for retrieving the metadata field of the configured `provider`.")]
         public void OpenFeature_Should_Get_Metadata()
         {
-            Api.Instance.SetProvider(new NoOpFeatureProvider()).Wait();
+            Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).Wait();
             var openFeature = Api.Instance;
             var metadata = openFeature.GetProviderMetadata();
 
@@ -238,8 +238,8 @@ namespace OpenFeature.Tests
         {
             var openFeature = Api.Instance;
 
-            openFeature.SetProvider("client1", new TestProvider());
-            openFeature.SetProvider("client2", new NoOpFeatureProvider());
+            openFeature.SetProviderAsync("client1", new TestProvider());
+            openFeature.SetProviderAsync("client2", new NoOpFeatureProvider());
 
             var client1 = openFeature.GetClient("client1");
             var client2 = openFeature.GetClient("client2");

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -226,7 +226,8 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        public async void OpenFeature_Should_Allow_Multiple_Client_Mapping()
+        public async Task OpenFeature_Should_Allow_Multiple_Client_Mapping()
+
         {
             var openFeature = Api.Instance;
 

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -107,7 +107,8 @@ namespace OpenFeature.Tests
 
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
-        public async void OpenFeature_Should_Set_Default_Provide_When_No_Name_Provided()
+        public async Task OpenFeature_Should_Set_Default_Provide_When_No_Name_Provided()
+
         {
             var openFeature = Api.Instance;
 

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -108,7 +108,6 @@ namespace OpenFeature.Tests
         [Fact]
         [Specification("1.1.3", "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.")]
         public async Task OpenFeature_Should_Set_Default_Provide_When_No_Name_Provided()
-
         {
             var openFeature = Api.Instance;
 

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -192,7 +192,7 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        public async void AfterSet_Is_Invoked_For_Setting_Named_Provider()
+        public async Task AfterSet_Is_Invoked_For_Setting_Named_Provider()
         {
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -16,7 +16,7 @@ namespace OpenFeature.Tests
     public class ProviderRepositoryTests
     {
         [Fact]
-        public async void Default_Provider_Is_Set_Without_Await()
+        public async Task Default_Provider_Is_Set_Without_Await()
         {
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -16,24 +16,24 @@ namespace OpenFeature.Tests
     public class ProviderRepositoryTests
     {
         [Fact]
-        public void Default_Provider_Is_Set_Without_Await()
+        public async void Default_Provider_Is_Set_Without_Await()
         {
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();
             var context = new EvaluationContextBuilder().Build();
-            repository.SetProvider(provider, context);
+            await repository.SetProvider(provider, context);
             Assert.Equal(provider, repository.GetProvider());
         }
 
         [Fact]
-        public void AfterSet_Is_Invoked_For_Setting_Default_Provider()
+        public async void AfterSet_Is_Invoked_For_Setting_Default_Provider()
         {
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
             // The setting of the provider is synchronous, so the afterSet should be as well.
-            repository.SetProvider(provider, context, afterSet: (theProvider) =>
+            await repository.SetProvider(provider, context, afterSet: (theProvider) =>
             {
                 callCount++;
                 Assert.Equal(provider, theProvider);
@@ -182,24 +182,24 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        public void Named_Provider_Provider_Is_Set_Without_Await()
+        public async void Named_Provider_Provider_Is_Set_Without_Await()
         {
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();
             var context = new EvaluationContextBuilder().Build();
-            repository.SetProvider("the-name", provider, context);
+            await repository.SetProvider("the-name", provider, context);
             Assert.Equal(provider, repository.GetProvider("the-name"));
         }
 
         [Fact]
-        public void AfterSet_Is_Invoked_For_Setting_Named_Provider()
+        public async void AfterSet_Is_Invoked_For_Setting_Named_Provider()
         {
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
             // The setting of the provider is synchronous, so the afterSet should be as well.
-            repository.SetProvider("the-name", provider, context, afterSet: (theProvider) =>
+            await repository.SetProvider("the-name", provider, context, afterSet: (theProvider) =>
             {
                 callCount++;
                 Assert.Equal(provider, theProvider);

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -182,7 +182,7 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        public async void Named_Provider_Provider_Is_Set_Without_Await()
+        public async Task Named_Provider_Provider_Is_Set_Without_Await()
         {
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();


### PR DESCRIPTION
This PR makes the breaking change [here](https://github.com/open-feature/dotnet-sdk/pull/158#discussion_r1378120046) non breaking, by adding a new method instead. This means our pending release will no longer be breaking.

This will allow us to release all the pending .NET work, without merging https://github.com/open-feature/dotnet-sdk/pull/184. I like the idea of https://github.com/open-feature/dotnet-sdk/pull/184, but I think I'd like us all to take some time to discuss exactly what we expect the `cancellationToken` to do in all circumstances (what should the SDK do on SDK methods like `init()/shutdown()`?, and what should providers do?).

I think buys us some without sacrificing too much, and we can release a 2.0.0 in the coming weeks.

Interested to hear the opinion of others.