### PR TITLE
chore: Sync ci.yml with contrib repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 
 on:
   push:
@@ -11,44 +11,41 @@ on:
     - '**.md'
 
 jobs:
-  unit-tests-linux:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+
+    runs-on: ${{ matrix.os }}
+
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        submodules: recursive
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         dotnet-version: |
           6.0.x
           7.0.x
+        source-url: https://nuget.pkg.github.com/open-feature/index.json
 
-    - name: Run Tests
-      run: dotnet test test/OpenFeature.Tests/ --configuration Release --logger GitHubActions
+    - name: Restore
+      run: dotnet restore
 
-  unit-tests-windows:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+    - name: Build
+      run: dotnet build --no-restore
 
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: |
-          6.0.x
-          7.0.x
-
-    - name: Run Tests
-      run: dotnet test test\OpenFeature.Tests\ --configuration Release --logger GitHubActions
+    - name: Test
+      run: dotnet test --no-build --logger GitHubActions
 
   packaging:
-    needs:
-    - unit-tests-linux
-    - unit-tests-windows
+    needs: build
 
     permissions:
       contents: read
@@ -57,14 +54,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: recursive
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         dotnet-version: |
           6.0.x
           7.0.x
+        source-url: https://nuget.pkg.github.com/open-feature/index.json
 
     - name: Restore
       run: dotnet restore

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -12,9 +12,11 @@ on:
 
 jobs:
   build-test-report:
-    runs-on: ubuntu-latest
-    env:
-      OS: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
@@ -23,13 +25,19 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        dotnet-version: |
+          6.0.x
+          7.0.x
+        source-url: https://nuget.pkg.github.com/open-feature/index.json
 
     - name: Run Test
       run: dotnet test --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
 
     - uses: codecov/codecov-action@v3.1.5
       with:
-        env_vars: OS
         name: Code Coverage for ${{ matrix.os }}
         fail_ci_if_error: true
         verbose: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,10 +25,13 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         dotnet-version: |
           6.0.x
           7.0.x
+        source-url: https://nuget.pkg.github.com/open-feature/index.json
 
     - name: Initialize Tests
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,13 @@ jobs:
       - name: Setup .NET SDK
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/setup-dotnet@v4
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           dotnet-version: |
             6.0.x
             7.0.x
+          source-url: https://nuget.pkg.github.com/open-feature/index.json
 
       - name: Install dependencies
         if: ${{ steps.release.outputs.releases_created }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,3 +155,38 @@ dotnet restore
 dotnet build --configuration Release --output "./release" --no-restore
 dotnet release/OpenFeature.Benchmarks.dll
 ```
+
+## Consuming pre-release packages
+
+1. Acquire a [GitHub personal access token (PAT)](https://docs.github.com/github/authenticating-to-github/creating-a-personal-access-token) scoped for `read:packages` and verify the permissions:
+   ```console
+   $ gh auth login --scopes read:packages
+
+   ? What account do you want to log into? GitHub.com
+   ? What is your preferred protocol for Git operations? HTTPS
+   ? How would you like to authenticate GitHub CLI? Login with a web browser
+
+   ! First copy your one-time code: ****-****
+   Press Enter to open github.com in your browser...
+
+   ✓ Authentication complete.
+   - gh config set -h github.com git_protocol https
+   ✓ Configured git protocol
+   ✓ Logged in as ********
+   ```
+
+   ```console
+   $ gh auth status
+
+   github.com
+     ✓ Logged in to github.com as ******** (~/.config/gh/hosts.yml)
+     ✓ Git operations for github.com configured to use https protocol.
+     ✓ Token: gho_************************************
+     ✓ Token scopes: gist, read:org, read:packages, repo, workflow
+   ```
+2. Run the following command to configure your local environment to consume packages from GitHub Packages:
+   ```console
+   $ dotnet nuget update source github-open-feature --username $(gh api user --jq .email) --password $(gh auth token) --store-password-in-clear-text
+
+   Package source "github-open-feature" was successfully updated.
+   ```

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+
+  <packageSources>
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="github-open-feature" value="https://nuget.pkg.github.com/open-feature/index.json" />
+  </packageSources>
+
+  <packageSourceMapping>
+    <packageSource key="nuget">
+      <package pattern="OpenFeature" />
+      <package pattern="OpenFeature.*" />
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="github-open-feature">
+      <package pattern="OpenFeature" />
+      <package pattern="OpenFeature.*" />
+    </packageSource>
+  </packageSourceMapping>
+
+</configuration>


### PR DESCRIPTION
Follows #173 and open-feature/dotnet-sdk-contrib#134 to synchronize `ci.yml` between both repos.

```console
$ diff dotnet-sdk{,-contrib}/.github/workflows/ci.yml


```

____

Story here is a little convoluted, but basically this repo already had the linux and windows tests in one workflow, so for #173 I was able to just condition the new `packaging` job on both `unit-tests-linux` and `unit-tests-windows` completing successfully.

However, prior to open-feature/dotnet-sdk-contrib#134, the contrib repo had separate workflow files for its respective linux and windows tests, so as part of open-feature/dotnet-sdk-contrib#134, I merged those separate workflows into one workflow and, at the same time, rewrote them to use a job matrix.

For PR consistency, I almost included the same job matrix update as part of #173, but held off in the spirit of doing one thing at a time. So, with that, this PR now syncs the two `ci.yml` files so both will exactly match _after_ open-feature/dotnet-sdk-contrib#134 is merged (anticipated sometime today).

Additionally, this PR also includes the `nuget.config` and `CONTRIBUTING.md` updates from open-feature/dotnet-sdk-contrib#134. Arguably, these may not be needed by this repo, but I'm including them here for (1) consistency, (2) to promote visibility, and (3) to help advertise that these are available if required and/or helpful to future contributors/bug reporters.