### PR TITLE
docs: update readme to be pure markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,21 @@
 <!-- markdownlint-disable MD033 -->
 <!-- x-hide-in-docs-start -->
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/white/openfeature-horizontal-white.svg" />
-    <img align="center" alt="OpenFeature Logo" src="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/black/openfeature-horizontal-black.svg" />
-  </picture>
-</p>
+![OpenFeature Light Logo](https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/white/openfeature-horizontal-white.svg#gh-dark-mode-only)
+![OpenFeature Dark Logo](https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/black/openfeature-horizontal-black.svg#gh-light-mode-only)
 
-<h2 align="center">OpenFeature .NET SDK</h2>
+## .NET SDK
 
 <!-- x-hide-in-docs-end -->
-<!-- The 'github-badges' class is used in the docs -->
-<p align="center" class="github-badges">
-  <a href="https://github.com/open-feature/spec/releases/tag/v0.5.2">
-    <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.5.2&color=yellow&style=for-the-badge" />
-  </a>
-  <!-- x-release-please-start-version -->
+![Specification](https://img.shields.io/static/v1?label=specification&message=v0.5.2&color=yellow&style=for-the-badge)
+![Release](https://img.shields.io/static/v1?label=release&message=v1.4.0&color=blue&style=for-the-badge)
 
-  <a href="https://github.com/open-feature/dotnet-sdk/releases/tag/v1.4.0">
-    <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v1.4.0&color=blue&style=for-the-badge" />
-  </a>
-  <!-- x-release-please-end -->
-  <br/>
-  <a href="https://cloud-native.slack.com/archives/C0344AANLA1">
-    <img alt="Slack" src="https://img.shields.io/badge/slack-%40cncf%2Fopenfeature-brightgreen?style=flat&logo=slack"/>
-</a>
-  <a href="https://codecov.io/gh/open-feature/dotnet-sdk">
-    <img alt="Codecov" src="https://codecov.io/gh/open-feature/dotnet-sdk/branch/main/graph/badge.svg?token=MONAVJBXUJ" />
-  </a>
-  <a href="https://www.nuget.org/packages/OpenFeature">
-    <img alt="NuGet" src="https://img.shields.io/nuget/vpre/OpenFeature" />
-  </a>
-  <a href="https://www.bestpractices.dev/en/projects/6250">
-    <img alt="CII Best Practices" src="https://bestpractices.coreinfrastructure.org/projects/6250/badge" />
-
-  </a>
-</p>
+![Slack](https://img.shields.io/badge/slack-%40cncf%2Fopenfeature-brightgreen?style=flat&logo=slack)
+![Codecov](https://codecov.io/gh/open-feature/dotnet-sdk/branch/main/graph/badge.svg?token=MONAVJBXUJ)
+![NuGet](https://img.shields.io/nuget/vpre/OpenFeature)
+![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6250/badge)  
 <!-- x-hide-in-docs-start -->
 
-[OpenFeature](https://openfeature.dev) is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool.
+[OpenFeature](https://openfeature.dev) is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool or in-house solution.
 
 <!-- x-hide-in-docs-end -->
 
@@ -100,7 +77,7 @@ public async Task Example()
 | ✅    | [Shutdown](#shutdown)           | Gracefully clean up a provider during application shutdown.                                                                        |
 | ✅     | [Extending](#extending)         | Extend OpenFeature with custom providers and hooks.                                                                                |
 
-<sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>
+_Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌_
 
 ### Providers
 
@@ -334,9 +311,7 @@ Interested in contributing? Great, we'd love your help! To get started, take a l
 
 ### Thanks to everyone who has already contributed
 
-<a href="https://github.com/open-feature/dotnet-sdk/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=open-feature/dotnet-sdk" />
-</a>
+![Contrib Rocks](https://contrib.rocks/image?repo=open-feature/dotnet-sdk)
 
 Made with [contrib.rocks](https://contrib.rocks).
 <!-- x-hide-in-docs-end -->


### PR DESCRIPTION
## This PR

- update readme to be pure markdown without HTML

### Notes

https://cloud-native.slack.com/archives/C06EDTWU25B/p1706000859339279

### Follow-up Tasks

 - Update org template
 - Update doc scripts
 - Update other SDK readmes

