### PR TITLE
fix: Remove reference to NETFramework.ReferenceAssemblies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
   <ItemGroup Label="src">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## This PR
Since turning on CPM the code coverage build has broken, see [here](https://github.com/open-feature/dotnet-sdk/actions/runs/7676368996/job/20923831827?pr=217)

Believe we don't need to reference this anymore as its being implicitly included