### PR TITLE
test: Upgrade test deps

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,20 +12,20 @@
   </ItemGroup>
 
   <ItemGroup Label="test">
-    <PackageVersion Include="AutoFixture" Version="4.17.0" />
+    <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageVersion Include="coverlet.collector" Version="3.1.2" />
-    <PackageVersion Include="coverlet.msbuild" Version="3.1.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="OpenFeature.Contrib.Providers.Flagd" Version="0.1.8" />
     <PackageVersion Include="SpecFlow" Version="3.9.74" />
     <PackageVersion Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
     <PackageVersion Include="SpecFlow.xUnit" Version="3.9.74" />
-    <PackageVersion Include="xunit" Version="[2.4.1, 3.0)" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="[2.4.3, 3.0)" />
+    <PackageVersion Include="xunit" Version="2.6.6" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Unix'">

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -9,6 +10,7 @@ using Xunit;
 
 namespace OpenFeature.Tests
 {
+    [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
     public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
     {
         [Fact]
@@ -28,14 +30,14 @@ namespace OpenFeature.Tests
             var providerMockDefault = Substitute.For<FeatureProvider>();
             providerMockDefault.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync(providerMockDefault).ConfigureAwait(false);
-            await providerMockDefault.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerMockDefault);
+            await providerMockDefault.Received(1).Initialize(Api.Instance.GetContext());
 
             var providerMockNamed = Substitute.For<FeatureProvider>();
             providerMockNamed.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync("the-name", providerMockNamed).ConfigureAwait(false);
-            await providerMockNamed.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync("the-name", providerMockNamed);
+            await providerMockNamed.Received(1).Initialize(Api.Instance.GetContext());
         }
 
         [Fact]
@@ -46,28 +48,28 @@ namespace OpenFeature.Tests
             var providerA = Substitute.For<FeatureProvider>();
             providerA.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync(providerA).ConfigureAwait(false);
-            await providerA.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerA);
+            await providerA.Received(1).Initialize(Api.Instance.GetContext());
 
             var providerB = Substitute.For<FeatureProvider>();
             providerB.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync(providerB).ConfigureAwait(false);
-            await providerB.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
-            await providerA.Received(1).Shutdown().ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerB);
+            await providerB.Received(1).Initialize(Api.Instance.GetContext());
+            await providerA.Received(1).Shutdown();
 
             var providerC = Substitute.For<FeatureProvider>();
             providerC.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync("named", providerC).ConfigureAwait(false);
-            await providerC.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync("named", providerC);
+            await providerC.Received(1).Initialize(Api.Instance.GetContext());
 
             var providerD = Substitute.For<FeatureProvider>();
             providerD.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync("named", providerD).ConfigureAwait(false);
-            await providerD.Received(1).Initialize(Api.Instance.GetContext()).ConfigureAwait(false);
-            await providerC.Received(1).Shutdown().ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync("named", providerD);
+            await providerD.Received(1).Initialize(Api.Instance.GetContext());
+            await providerC.Received(1).Shutdown();
         }
 
         [Fact]
@@ -80,13 +82,13 @@ namespace OpenFeature.Tests
             var providerB = Substitute.For<FeatureProvider>();
             providerB.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync(providerA).ConfigureAwait(false);
-            await Api.Instance.SetProviderAsync("named", providerB).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerA);
+            await Api.Instance.SetProviderAsync("named", providerB);
 
-            await Api.Instance.Shutdown().ConfigureAwait(false);
+            await Api.Instance.Shutdown();
 
-            await providerA.Received(1).Shutdown().ConfigureAwait(false);
-            await providerB.Received(1).Shutdown().ConfigureAwait(false);
+            await providerA.Received(1).Shutdown();
+            await providerB.Received(1).Shutdown();
         }
 
         [Fact]
@@ -95,8 +97,8 @@ namespace OpenFeature.Tests
         {
             var openFeature = Api.Instance;
 
-            await openFeature.SetProviderAsync(new NoOpFeatureProvider()).ConfigureAwait(false);
-            await openFeature.SetProviderAsync(TestProvider.DefaultName, new TestProvider()).ConfigureAwait(false);
+            await openFeature.SetProviderAsync(new NoOpFeatureProvider());
+            await openFeature.SetProviderAsync(TestProvider.DefaultName, new TestProvider());
 
             var defaultClient = openFeature.GetProviderMetadata();
             var namedClient = openFeature.GetProviderMetadata(TestProvider.DefaultName);
@@ -111,7 +113,7 @@ namespace OpenFeature.Tests
         {
             var openFeature = Api.Instance;
 
-            await openFeature.SetProviderAsync(new TestProvider()).ConfigureAwait(false);
+            await openFeature.SetProviderAsync(new TestProvider());
 
             var defaultClient = openFeature.GetProviderMetadata();
 
@@ -178,9 +180,9 @@ namespace OpenFeature.Tests
 
         [Fact]
         [Specification("1.1.5", "The API MUST provide a function for retrieving the metadata field of the configured `provider`.")]
-        public void OpenFeature_Should_Get_Metadata()
+        public async Task OpenFeature_Should_Get_Metadata()
         {
-            Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).Wait();
+            await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
             var openFeature = Api.Instance;
             var metadata = openFeature.GetProviderMetadata();
 
@@ -239,8 +241,8 @@ namespace OpenFeature.Tests
             client1.GetMetadata().Name.Should().Be("client1");
             client2.GetMetadata().Name.Should().Be("client2");
 
-            client1.GetBooleanValue("test", false).Result.Should().BeTrue();
-            client2.GetBooleanValue("test", false).Result.Should().BeFalse();
+            (await client1.GetBooleanValue("test", false)).Should().BeTrue();
+            (await client2.GetBooleanValue("test", false)).Should().BeFalse();
         }
     }
 }

--- a/test/OpenFeature.Tests/StructureTests.cs
+++ b/test/OpenFeature.Tests/StructureTests.cs
@@ -89,7 +89,7 @@ namespace OpenFeature.Tests
 
             var structure = Structure.Builder()
                 .Set(KEY, VAL).Build();
-            Assert.Equal(1, structure.Values.Count);
+            Assert.Single(structure.Values);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace OpenFeature.Tests
 
             var structure = Structure.Builder()
                 .Set(KEY, VAL).Build();
-            Assert.Equal(1, structure.Keys.Count);
+            Assert.Single(structure.Keys);
             Assert.Equal(0, structure.Keys.IndexOf(KEY));
         }
 

--- a/test/OpenFeature.Tests/TestUtilsTest.cs
+++ b/test/OpenFeature.Tests/TestUtilsTest.cs
@@ -1,23 +1,22 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using OpenFeature.Model;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 namespace OpenFeature.Tests
 {
+    [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
     public class TestUtilsTest
     {
         [Fact]
         public async void Should_Fail_If_Assertion_Fails()
         {
-            await Assert.ThrowsAnyAsync<Exception>(() => Utils.AssertUntilAsync(_ => Assert.True(1.Equals(2)), 100, 10)).ConfigureAwait(false);
+            await Assert.ThrowsAnyAsync<Exception>(() => Utils.AssertUntilAsync(_ => Assert.True(1.Equals(2)), 100, 10));
         }
 
         [Fact]
         public async void Should_Pass_If_Assertion_Fails()
         {
-            await Utils.AssertUntilAsync(_ => Assert.True(1.Equals(1))).ConfigureAwait(false);
+            await Utils.AssertUntilAsync(_ => Assert.True(1.Equals(1)));
         }
     }
 }

--- a/test/OpenFeature.Tests/ValueTests.cs
+++ b/test/OpenFeature.Tests/ValueTests.cs
@@ -53,7 +53,7 @@ namespace OpenFeature.Tests
             }
             catch (Exception)
             {
-                Assert.True(false, "Expected no exception.");
+                Assert.Fail("Expected no exception.");
             }
         }
 


### PR DESCRIPTION
## This PR
Upgrade all test deps

- Autofixture 4.17 -> 4.18.1
- coverlet 3.1.2 -> 6.0.0
- FluentAssertions 6.7.0 -> 6.12.0
- MSN.Test.Sdk 17.2.0 -> 17.9.0
- NSubstitue 5 -> 5.1
- FlagD Provider 0.1.5 -> 0.1.8
- Xunit 2.4.1 -> 2.6.6

### Related Issues
Fixes #197 


