### PR TITLE
fix: Fix NU1009 reference assembly warning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
   <ItemGroup Label="src">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
   </ItemGroup>
@@ -27,6 +26,10 @@
     <PackageVersion Include="SpecFlow.xUnit" Version="3.9.74" />
     <PackageVersion Include="xunit" Version="[2.4.1, 3.0)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="[2.4.3, 3.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(OS)' == 'Unix'">
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Very silly, had this right in my internal projects and decided to "simplify" it when I reimplemented here 🤦🤦🤦

tldr; NuGet analyzers run over the `Directory.Packages.props` file without validating whether a given `PackageVersion` is used in a given TFM, so the analyzer pops even though the build is happy. I'm still a little confused as to why I can't repro locally, but probably caching, so "un-simplifying" my earlier oops and all should hopefully work as intended going forward.

See: #165, #196, #219, #220

H/T @CommCody