### PR TITLE
test: Fix up xunit warnings

### DIFF
--- a/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
+++ b/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
@@ -1,15 +1,14 @@
-using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Threading;
+using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 using OpenFeature.Error;
 using OpenFeature.Model;
 using OpenFeature.Providers.Memory;
 using Xunit;
 
-namespace OpenFeature.Tests
+namespace OpenFeature.Tests.Providers.Memory
 {
+    [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
     public class InMemoryProviderTests
     {
         private FeatureProvider commonProvider;
@@ -112,7 +111,7 @@ namespace OpenFeature.Tests
         [Fact]
         public async void GetBoolean_ShouldEvaluateWithReasonAndVariant()
         {
-            ResolutionDetails<bool> details = await this.commonProvider.ResolveBooleanValue("boolean-flag", false, EvaluationContext.Empty).ConfigureAwait(false);
+            ResolutionDetails<bool> details = await this.commonProvider.ResolveBooleanValue("boolean-flag", false, EvaluationContext.Empty);
             Assert.True(details.Value);
             Assert.Equal(Reason.Static, details.Reason);
             Assert.Equal("on", details.Variant);
@@ -121,7 +120,7 @@ namespace OpenFeature.Tests
         [Fact]
         public async void GetString_ShouldEvaluateWithReasonAndVariant()
         {
-            ResolutionDetails<string> details = await this.commonProvider.ResolveStringValue("string-flag", "nope", EvaluationContext.Empty).ConfigureAwait(false);
+            ResolutionDetails<string> details = await this.commonProvider.ResolveStringValue("string-flag", "nope", EvaluationContext.Empty);
             Assert.Equal("hi", details.Value);
             Assert.Equal(Reason.Static, details.Reason);
             Assert.Equal("greeting", details.Variant);
@@ -130,7 +129,7 @@ namespace OpenFeature.Tests
         [Fact]
         public async void GetInt_ShouldEvaluateWithReasonAndVariant()
         {
-            ResolutionDetails<int> details = await this.commonProvider.ResolveIntegerValue("integer-flag", 13, EvaluationContext.Empty).ConfigureAwait(false);
+            ResolutionDetails<int> details = await this.commonProvider.ResolveIntegerValue("integer-flag", 13, EvaluationContext.Empty);
             Assert.Equal(10, details.Value);
             Assert.Equal(Reason.Static, details.Reason);
             Assert.Equal("ten", details.Variant);
@@ -139,7 +138,7 @@ namespace OpenFeature.Tests
         [Fact]
         public async void GetDouble_ShouldEvaluateWithReasonAndVariant()
         {
-            ResolutionDetails<double> details = await this.commonProvider.ResolveDoubleValue("float-flag", 13, EvaluationContext.Empty).ConfigureAwait(false);
+            ResolutionDetails<double> details = await this.commonProvider.ResolveDoubleValue("float-flag", 13, EvaluationContext.Empty);
             Assert.Equal(0.5, details.Value);
             Assert.Equal(Reason.Static, details.Reason);
             Assert.Equal("half", details.Variant);
@@ -148,7 +147,7 @@ namespace OpenFeature.Tests
         [Fact]
         public async void GetStruct_ShouldEvaluateWithReasonAndVariant()
         {
-            ResolutionDetails<Value> details = await this.commonProvider.ResolveStructureValue("object-flag", new Value(), EvaluationContext.Empty).ConfigureAwait(false);
+            ResolutionDetails<Value> details = await this.commonProvider.ResolveStructureValue("object-flag", new Value(), EvaluationContext.Empty);
             Assert.Equal(true, details.Value.AsStructure["showImages"].AsBoolean);
             Assert.Equal("Check out these pics!", details.Value.AsStructure["title"].AsString);
             Assert.Equal(100, details.Value.AsStructure["imagesPerPage"].AsInteger);
@@ -160,7 +159,7 @@ namespace OpenFeature.Tests
         public async void GetString_ContextSensitive_ShouldEvaluateWithReasonAndVariant()
         {
             EvaluationContext context = EvaluationContext.Builder().Set("email", "me@faas.com").Build();
-            ResolutionDetails<string> details = await this.commonProvider.ResolveStringValue("context-aware", "nope", context).ConfigureAwait(false);
+            ResolutionDetails<string> details = await this.commonProvider.ResolveStringValue("context-aware", "nope", context);
             Assert.Equal("INTERNAL", details.Value);
             Assert.Equal(Reason.TargetingMatch, details.Reason);
             Assert.Equal("internal", details.Variant);
@@ -170,32 +169,32 @@ namespace OpenFeature.Tests
         public async void EmptyFlags_ShouldWork()
         {
             var provider = new InMemoryProvider();
-            await provider.UpdateFlags().ConfigureAwait(false);
+            await provider.UpdateFlags();
             Assert.Equal("InMemory", provider.GetMetadata().Name);
         }
 
         [Fact]
         public async void MissingFlag_ShouldThrow()
         {
-            await Assert.ThrowsAsync<FlagNotFoundException>(() => commonProvider.ResolveBooleanValue("missing-flag", false, EvaluationContext.Empty)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<FlagNotFoundException>(() => this.commonProvider.ResolveBooleanValue("missing-flag", false, EvaluationContext.Empty));
         }
 
         [Fact]
         public async void MismatchedFlag_ShouldThrow()
         {
-            await Assert.ThrowsAsync<TypeMismatchException>(() => commonProvider.ResolveStringValue("boolean-flag", "nope", EvaluationContext.Empty)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<TypeMismatchException>(() => this.commonProvider.ResolveStringValue("boolean-flag", "nope", EvaluationContext.Empty));
         }
 
         [Fact]
         public async void MissingDefaultVariant_ShouldThrow()
         {
-            await Assert.ThrowsAsync<GeneralException>(() => commonProvider.ResolveBooleanValue("invalid-flag", false, EvaluationContext.Empty)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<GeneralException>(() => this.commonProvider.ResolveBooleanValue("invalid-flag", false, EvaluationContext.Empty));
         }
 
         [Fact]
         public async void MissingEvaluatedVariant_ShouldThrow()
         {
-            await Assert.ThrowsAsync<GeneralException>(() => commonProvider.ResolveBooleanValue("invalid-evaluator-flag", false, EvaluationContext.Empty)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<GeneralException>(() => this.commonProvider.ResolveBooleanValue("invalid-evaluator-flag", false, EvaluationContext.Empty));
         }
 
         [Fact]
@@ -212,7 +211,7 @@ namespace OpenFeature.Tests
                 )
             }});
 
-            ResolutionDetails<bool> details = await provider.ResolveBooleanValue("old-flag", false, EvaluationContext.Empty).ConfigureAwait(false);
+            ResolutionDetails<bool> details = await provider.ResolveBooleanValue("old-flag", false, EvaluationContext.Empty);
             Assert.True(details.Value);
 
             // update flags
@@ -225,15 +224,15 @@ namespace OpenFeature.Tests
                     },
                     defaultVariant: "greeting"
                 )
-            }}).ConfigureAwait(false);
+            }});
 
-            var res = await provider.GetEventChannel().Reader.ReadAsync().ConfigureAwait(false) as ProviderEventPayload;
+            var res = await provider.GetEventChannel().Reader.ReadAsync() as ProviderEventPayload;
             Assert.Equal(ProviderEventTypes.ProviderConfigurationChanged, res.Type);
 
-            await Assert.ThrowsAsync<FlagNotFoundException>(() => provider.ResolveBooleanValue("old-flag", false, EvaluationContext.Empty)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<FlagNotFoundException>(() => provider.ResolveBooleanValue("old-flag", false, EvaluationContext.Empty));
 
             // new flag should be present, old gone (defaults), handler run.
-            ResolutionDetails<string> detailsAfter = await provider.ResolveStringValue("new-flag", "nope", EvaluationContext.Empty).ConfigureAwait(false);
+            ResolutionDetails<string> detailsAfter = await provider.ResolveStringValue("new-flag", "nope", EvaluationContext.Empty);
             Assert.True(details.Value);
             Assert.Equal("hi", detailsAfter.Value);
         }


### PR DESCRIPTION
## This PR
Supress ConfigureAwait for unit tests as its not relevant, cleanup warnings

![image](https://github.com/open-feature/dotnet-sdk/assets/2031163/6dd21810-3938-4f81-a226-ce785951984e)

