### PR TITLE
chore: Enforce coding styles on build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -140,14 +140,13 @@ dotnet_diagnostic.IDE0001.severity = warning
 dotnet_diagnostic.IDE0002.severity = warning
 
 # IDE0005: Remove unnecessary import
-# Workaround for https://github.com/dotnet/roslyn/issues/41640
-dotnet_diagnostic.IDE0005.severity = none
+dotnet_diagnostic.IDE0005.severity = error
 
 # RS0041: Public members should not use oblivious types
 dotnet_diagnostic.RS0041.severity = suggestion
 
 # CA2007: Do not directly await a Task
-dotnet_diagnostic.CA2007.severity = error
+dotnet_diagnostic.CA2007.severity = errorgit 
 
 [obj/**.cs]
 generated_code = true

--- a/build/Common.props
+++ b/build/Common.props
@@ -3,6 +3,9 @@
     <LangVersion>latest</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <!-- Workaround for IDE0005 (Remove unnecessary usings/imports); see https://github.com/dotnet/roslyn/issues/41640 -->
+    <NoWarn>EnableGenerateDocumentationFile</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
## This PR
A follow on from the previous PR that removed unused using, this will make sure it won't occur in the future. https://github.com/open-feature/dotnet-sdk/pull/240#issuecomment-1956892758

- Enforce code styles on build
- Error on unused usings
- Apply workaround for IDE0005 rule

### Related Issues
Fixes https://github.com/open-feature/dotnet-sdk/pull/240#issuecomment-1956892758


