### PR TITLE
ci: Change dotnet formatter

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -22,9 +22,8 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
-
-    - name: Install format tool
-      run: dotnet tool install -g dotnet-format
+      with:
+          dotnet-version: 8.0.x
 
     - name: dotnet format
-      run: dotnet-format --folder --check
+      run: dotnet format --verify-no-changes

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -26,4 +26,4 @@ jobs:
           dotnet-version: 8.0.x
 
     - name: dotnet format
-      run: dotnet format --verify-no-changes
+      run: dotnet format --verify-no-changes OpenFeature.sln

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -2,28 +2,22 @@ name: dotnet format
 
 on:
   push:
-    branches: [ main ]
-    paths:
-    - '**.cs'
-    - '.editorconfig'
+    branches: [main]
   pull_request:
-    branches: [ main ]
-    paths:
-    - '**.cs'
-    - '.editorconfig'
+    branches: [main]
 
 jobs:
   check-format:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check out code
-      uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
 
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
-      with:
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
           dotnet-version: 8.0.x
 
-    - name: dotnet format
-      run: dotnet format --verify-no-changes OpenFeature.sln
+      - name: dotnet format
+        run: dotnet format --verify-no-changes OpenFeature.sln


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- This PR changes the code formatter we currently use to the new built-in in the SDK. See https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-format

### Notes
- We should now use this tool since it is now shipped as part of the dotnet SDK, removing the need to install an external one.
- As pointed out in the chat, this build runs in parallel and is relatively fast. I will enable all PRs instead of those focusing on changes to .cs files.
