### PR TITLE
feat!: add CancellationTokens, ValueTasks hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 <!-- markdownlint-disable MD033 -->
 <!-- x-hide-in-docs-start -->
 <!-- NuGet doesn't support most HTML tags. Disabling dark mode support until https://github.com/NuGet/NuGetGallery/issues/8644 is resolved. -->
@@ -59,347 +58,6 @@ public async Task Example()
     FeatureClient client = Api.Instance.GetClient();
 
     // Evaluate your feature flag
-    bool v2Enabled = await client.GetBooleanValue("v2_enabled", false);
-
-    if ( v2Enabled )
-    {
-        //Do some work
-    }
-}
-```
-
-## 🌟 Features
-
-| Status | Features                        | Description                                                                                                                        |
-| ------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| ✅     | [Providers](#providers)         | Integrate with a commercial, open source, or in-house feature management tool.                                                     |
-| ✅     | [Targeting](#targeting)         | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context). |
-| ✅     | [Hooks](#hooks)                 | Add functionality to various stages of the flag evaluation life-cycle.                                                             |
-| ✅     | [Logging](#logging)             | Integrate with popular logging packages.                                                                                           |
-| ✅     | [Named clients](#named-clients) | Utilize multiple providers in a single application.                                                                                |
-| ✅     | [Eventing](#eventing)           | React to state changes in the provider or flag management system.                                                                  |
-| ✅    | [Shutdown](#shutdown)           | Gracefully clean up a provider during application shutdown.                                                                        |
-| ✅     | [Extending](#extending)         | Extend OpenFeature with custom providers and hooks.                                                                                |
-
-> Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌
-
-### Providers
-
-[Providers](https://openfeature.dev/docs/reference/concepts/provider) are an abstraction between a flag management system and the OpenFeature SDK.
-Here is [a complete list of available providers](https://openfeature.dev/ecosystem?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Provider&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=.NET).
-
-If the provider you're looking for hasn't been created yet, see the [develop a provider](#develop-a-provider) section to learn how to build it yourself.
-
-Once you've added a provider as a dependency, it can be registered with OpenFeature like this:
-
-```csharp
-await Api.Instance.SetProvider(new MyProvider());
-```
-
-In some situations, it may be beneficial to register multiple providers in the same application.
-This is possible using [named clients](#named-clients), which is covered in more detail below.
-
-### Targeting
-
-Sometimes, the value of a flag must consider some dynamic criteria about the application or user such as the user's location, IP, email address, or the server's location.
-In OpenFeature, we refer to this as [targeting](https://openfeature.dev/specification/glossary#targeting).
-If the flag management system you're using supports targeting, you can provide the input data using the [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).
-
-```csharp
-// set a value to the global context
-EvaluationContextBuilder builder = EvaluationContext.Builder();
-builder.Set("region", "us-east-1");
-EvaluationContext apiCtx = builder.Build();
-Api.Instance.SetContext(apiCtx);
-
-// set a value to the client context
-builder = EvaluationContext.Builder();
-builder.Set("region", "us-east-1");
-EvaluationContext clientCtx = builder.Build();
-var client = Api.Instance.GetClient();
-client.SetContext(clientCtx);
-
-// set a value to the invocation context
-builder = EvaluationContext.Builder();
-builder.Set("region", "us-east-1");
-EvaluationContext reqCtx = builder.Build();
-
-bool flagValue = await client.GetBooleanValue("some-flag", false, reqCtx);
-
-```
-
-### Hooks
-
-[Hooks](https://openfeature.dev/docs/reference/concepts/hooks) allow for custom logic to be added at well-defined points of the flag evaluation life-cycle.
-Look [here](https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Hook&instant_search%5BrefinementList%5D%5Bcategory%5D%5B0%5D=Server-side&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=.NET) for a complete list of available hooks.
-If the hook you're looking for hasn't been created yet, see the [develop a hook](#develop-a-hook) section to learn how to build it yourself.
-
-Once you've added a hook as a dependency, it can be registered at the global, client, or flag invocation level.
-
-```csharp
-// add a hook globally, to run on all evaluations
-Api.Instance.AddHooks(new ExampleGlobalHook());
-
-// add a hook on this client, to run on all evaluations made by this client
-var client = Api.Instance.GetClient();
-client.AddHooks(new ExampleClientHook());
-
-// add a hook for this evaluation only
-var value = await client.GetBooleanValue("boolFlag", false, context, new FlagEvaluationOptions(new ExampleInvocationHook()));
-```
-
-### Logging
-
-The .NET SDK uses Microsoft.Extensions.Logging. See the [manual](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line) for complete documentation.
-
-### Named clients
-
-Clients can be given a name.
-A name is a logical identifier that can be used to associate clients with a particular provider.
-If a name has no associated provider, the global provider is used.
-
-```csharp
-// registering the default provider
-await Api.Instance.SetProvider(new LocalProvider());
-
-// registering a named provider
-await Api.Instance.SetProvider("clientForCache", new CachedProvider());
-
-// a client backed by default provider
-FeatureClient clientDefault = Api.Instance.GetClient();
-
-// a client backed by CachedProvider
-FeatureClient clientNamed = Api.Instance.GetClient("clientForCache");
-
-```
-
-### Eventing
-
-Events allow you to react to state changes in the provider or underlying flag management system, such as flag definition changes,
-provider readiness, or error conditions.
-Initialization events (`PROVIDER_READY` on success, `PROVIDER_ERROR` on failure) are dispatched for every provider.
-Some providers support additional events, such as `PROVIDER_CONFIGURATION_CHANGED`.
-
-Please refer to the documentation of the provider you're using to see what events are supported.
-
-Example usage of an Event handler:
-
-```csharp
-public static void EventHandler(ProviderEventPayload eventDetails)
-{
-    Console.WriteLine(eventDetails.Type);
-}
-```
-
-```csharp
-EventHandlerDelegate callback = EventHandler;
-// add an implementation of the EventHandlerDelegate for the PROVIDER_READY event
-Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, callback);
-```
-
-It is also possible to register an event handler for a specific client, as in the following example:
-
-```csharp
-EventHandlerDelegate callback = EventHandler;
-
-var myClient = Api.Instance.GetClient("my-client");
-
-var provider = new ExampleProvider();
-await Api.Instance.SetProvider(myClient.GetMetadata().Name, provider);
-
-myClient.AddHandler(ProviderEventTypes.ProviderReady, callback);
-```
-
-### Shutdown
-
-The OpenFeature API provides a close function to perform a cleanup of all registered providers. This should only be called when your application is in the process of shutting down.
-
-```csharp
-// Shut down all providers
-await Api.Instance.Shutdown();
-```
-
-## Extending
-
-### Develop a provider
-
-To develop a provider, you need to create a new project and include the OpenFeature SDK as a dependency.
-This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/dotnet-sdk-contrib) available under the OpenFeature organization.
-You’ll then need to write the provider by implementing the `FeatureProvider` interface exported by the OpenFeature SDK.
-
-```csharp
-public class MyProvider : FeatureProvider
-{
-    public override Metadata GetMetadata()
-    {
-        return new Metadata("My Provider");
-    }
-
-    public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
-    {
-        // resolve a boolean flag value
-    }
-
-    public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null)
-    {
-        // resolve a double flag value
-    }
-
-    public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
-    {
-        // resolve an int flag value
-    }
-
-    public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
-    {
-        // resolve a string flag value
-    }
-
-    public override Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext context = null)
-    {
-        // resolve an object flag value
-    }
-}
-```
-
-### Develop a hook
-
-To develop a hook, you need to create a new project and include the OpenFeature SDK as a dependency.
-This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/dotnet-sdk-contrib) available under the OpenFeature organization.
-Implement your own hook by conforming to the `Hook interface`.
-To satisfy the interface, all methods (`Before`/`After`/`Finally`/`Error`) need to be defined.
-
-```csharp
-public class MyHook : Hook
-{
-  public Task<EvaluationContext> Before<T>(HookContext<T> context,
-      IReadOnlyDictionary<string, object> hints = null)
-  {
-    // code to run before flag evaluation
-  }
-
-  public virtual Task After<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
-      IReadOnlyDictionary<string, object> hints = null)
-  {
-    // code to run after successful flag evaluation
-  }
-
-  public virtual Task Error<T>(HookContext<T> context, Exception error,
-      IReadOnlyDictionary<string, object> hints = null)
-  {
-    // code to run if there's an error during before hooks or during flag evaluation
-  }
-
-  public virtual Task Finally<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null)
-  {
-    // code to run after all other stages, regardless of success/failure
-  }
-}
-```
-
-Built a new hook? [Let us know](https://github.com/open-feature/openfeature.dev/issues/new?assignees=&labels=hook&projects=&template=document-hook.yaml&title=%5BHook%5D%3A+) so we can add it to the docs!
-
-<!-- x-hide-in-docs-start -->
-## ⭐️ Support the project
-
--   Give this repo a ⭐️!
--   Follow us on social media:
-    -   Twitter: [@openfeature](https://twitter.com/openfeature)
-    -   LinkedIn: [OpenFeature](https://www.linkedin.com/company/openfeature/)
--   Join us on [Slack](https://cloud-native.slack.com/archives/C0344AANLA1)
--   For more information, check out our [community page](https://openfeature.dev/community/)
-
-## 🤝 Contributing
-
-Interested in contributing? Great, we'd love your help! To get started, take a look at the [CONTRIBUTING](CONTRIBUTING.md) guide.
-
-### Thanks to everyone who has already contributed
-
-[![Contrib Rocks](https://contrib.rocks/image?repo=open-feature/dotnet-sdk)](https://github.com/open-feature/dotnet-sdk/graphs/contributors)
-
-Made with [contrib.rocks](https://contrib.rocks).
-<!-- x-hide-in-docs-end -->
-=======
-<!-- markdownlint-disable MD033 -->
-<!-- x-hide-in-docs-start -->
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/white/openfeature-horizontal-white.svg" />
-    <img align="center" alt="OpenFeature Logo" src="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/black/openfeature-horizontal-black.svg" />
-  </picture>
-</p>
-
-<h2 align="center">OpenFeature .NET SDK</h2>
-
-<!-- x-hide-in-docs-end -->
-<!-- The 'github-badges' class is used in the docs -->
-<p align="center" class="github-badges">
-  <a href="https://github.com/open-feature/spec/releases/tag/v0.5.2">
-    <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.5.2&color=yellow&style=for-the-badge" />
-  </a>
-  <!-- x-release-please-start-version -->
-
-  <a href="https://github.com/open-feature/dotnet-sdk/releases/tag/v1.3.1">
-    <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v1.3.1&color=blue&style=for-the-badge" />
-  </a>
-  <!-- x-release-please-end -->
-  <br/>
-  <a href="https://cloud-native.slack.com/archives/C0344AANLA1">
-    <img alt="Slack" src="https://img.shields.io/badge/slack-%40cncf%2Fopenfeature-brightgreen?style=flat&logo=slack"/>
-</a>
-  <a href="https://codecov.io/gh/open-feature/dotnet-sdk">
-    <img alt="Codecov" src="https://codecov.io/gh/open-feature/dotnet-sdk/branch/main/graph/badge.svg?token=MONAVJBXUJ" />
-  </a>
-  <a href="https://www.nuget.org/packages/OpenFeature">
-    <img alt="NuGet" src="https://img.shields.io/nuget/vpre/OpenFeature" />
-  </a>
-  <a href="https://www.bestpractices.dev/en/projects/6250">
-    <img alt="CII Best Practices" src="https://bestpractices.coreinfrastructure.org/projects/6250/badge" />
-
-  </a>
-</p>
-<!-- x-hide-in-docs-start -->
-
-[OpenFeature](https://openfeature.dev) is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool.
-
-<!-- x-hide-in-docs-end -->
-
-## 🚀 Quick start
-
-### Requirements
-
--   .NET 6+
--   .NET Core 6+
--   .NET Framework 4.6.2+
-
-Note that the packages will aim to support all current .NET versions. Refer to the currently supported versions [.NET](https://dotnet.microsoft.com/download/dotnet) and [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework) excluding .NET Framework 3.5
-
-### Install
-
-Use the following to initialize your project:
-
-```sh
-dotnet new console
-```
-
-and install OpenFeature:
-
-```sh
-dotnet add package OpenFeature
-```
-
-### Usage
-
-```csharp
-public async Task Example()
-{
-    // Register your feature flag provider
-    await Api.Instance.SetProviderAsync(new InMemoryProvider());
-
-    // Create a new client
-    FeatureClient client = Api.Instance.GetClient();
-
-    // Evaluate your feature flag
     bool v2Enabled = await client.GetBooleanValueAsync("v2_enabled", false);
 
     if ( v2Enabled )
@@ -422,7 +80,7 @@ public async Task Example()
 | ✅    | [Shutdown](#shutdown)           | Gracefully clean up a provider during application shutdown.                                                                        |
 | ✅     | [Extending](#extending)         | Extend OpenFeature with custom providers and hooks.                                                                                |
 
-<sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>
+> Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌
 
 ### Providers
 
@@ -465,14 +123,14 @@ builder = EvaluationContext.Builder();
 builder.Set("region", "us-east-1");
 EvaluationContext reqCtx = builder.Build();
 
-bool flagValue = await client.GetBooleanValueAsync("some-flag", false, reqCtx);
+bool flagValue = await client.GetBooleanValuAsync("some-flag", false, reqCtx);
 
 ```
 
 ### Hooks
 
 [Hooks](https://openfeature.dev/docs/reference/concepts/hooks) allow for custom logic to be added at well-defined points of the flag evaluation life-cycle.
-Here is [a complete list of available hooks](https://openfeature.dev/docs/reference/technologies/server/dotnet/).
+Look [here](https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Hook&instant_search%5BrefinementList%5D%5Bcategory%5D%5B0%5D=Server-side&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=.NET) for a complete list of available hooks.
 If the hook you're looking for hasn't been created yet, see the [develop a hook](#develop-a-hook) section to learn how to build it yourself.
 
 Once you've added a hook as a dependency, it can be registered at the global, client, or flag invocation level.
@@ -501,10 +159,10 @@ If a name has no associated provider, the global provider is used.
 
 ```csharp
 // registering the default provider
-await Api.Instance.SetProvider(new LocalProvider());
+await Api.Instance.SetProviderAsync(new LocalProvider());
 
 // registering a named provider
-await Api.Instance.SetProvider("clientForCache", new CachedProvider());
+await Api.Instance.SetProviderAsync("clientForCache", new CachedProvider());
 
 // a client backed by default provider
 FeatureClient clientDefault = Api.Instance.GetClient();
@@ -576,27 +234,27 @@ public class MyProvider : FeatureProvider
         return new Metadata("My Provider");
     }
 
-    public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
     {
         // resolve a boolean flag value
     }
 
-    public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
-    {
-        // resolve a double flag value
-    }
-
-    public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
-    {
-        // resolve an int flag value
-    }
-
-    public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
     {
         // resolve a string flag value
     }
 
-    public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null)
+    {
+        // resolve an int flag value
+    }
+
+    public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
+    {
+        // resolve a double flag value
+    }
+
+    public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
     {
         // resolve an object flag value
     }
@@ -608,30 +266,30 @@ public class MyProvider : FeatureProvider
 To develop a hook, you need to create a new project and include the OpenFeature SDK as a dependency.
 This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/dotnet-sdk-contrib) available under the OpenFeature organization.
 Implement your own hook by conforming to the `Hook interface`.
-To satisfy the interface, all methods (`BeforeAsync`/`AfterAsync`/`FinallyAsync`/`ErrorAsync`) need to be defined.
+To satisfy the interface, all methods (`Before`/`After`/`Finally`/`Error`) need to be defined.
 
 ```csharp
 public class MyHook : Hook
 {
   public ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
-      IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+      IReadOnlyDictionary<string, object> hints = null)
   {
     // code to run before flag evaluation
   }
 
-  public virtual ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
-      IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+  public ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+      IReadOnlyDictionary<string, object> hints = null)
   {
     // code to run after successful flag evaluation
   }
 
-  public virtual ValueTask ErrorAsync<T>(HookContext<T> context, Exception error,
-      IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+  public ValueTask ErrorAsync<T>(HookContext<T> context, Exception error,
+      IReadOnlyDictionary<string, object> hints = null)
   {
     // code to run if there's an error during before hooks or during flag evaluation
   }
 
-  public virtual ValueTask FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+  public ValueTask FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null)
   {
     // code to run after all other stages, regardless of success/failure
   }
@@ -656,10 +314,7 @@ Interested in contributing? Great, we'd love your help! To get started, take a l
 
 ### Thanks to everyone who has already contributed
 
-<a href="https://github.com/open-feature/dotnet-sdk/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=open-feature/dotnet-sdk" />
-</a>
+[![Contrib Rocks](https://contrib.rocks/image?repo=open-feature/dotnet-sdk)](https://github.com/open-feature/dotnet-sdk/graphs/contributors)
 
 Made with [contrib.rocks](https://contrib.rocks).
 <!-- x-hide-in-docs-end -->
->>>>>>> f23274b (refactor: Cleanup + plumb cancellation tokens)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ dotnet add package OpenFeature
 public async Task Example()
 {
     // Register your feature flag provider
-    await Api.Instance.SetProvider(new InMemoryProvider());
+    await Api.Instance.SetProviderAsync(new InMemoryProvider());
 
     // Create a new client
     FeatureClient client = Api.Instance.GetClient();

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 <!-- markdownlint-disable MD033 -->
 <!-- x-hide-in-docs-start -->
 <!-- NuGet doesn't support most HTML tags. Disabling dark mode support until https://github.com/NuGet/NuGetGallery/issues/8644 is resolved. -->
@@ -318,3 +319,347 @@ Interested in contributing? Great, we'd love your help! To get started, take a l
 
 Made with [contrib.rocks](https://contrib.rocks).
 <!-- x-hide-in-docs-end -->
+=======
+<!-- markdownlint-disable MD033 -->
+<!-- x-hide-in-docs-start -->
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/white/openfeature-horizontal-white.svg" />
+    <img align="center" alt="OpenFeature Logo" src="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/black/openfeature-horizontal-black.svg" />
+  </picture>
+</p>
+
+<h2 align="center">OpenFeature .NET SDK</h2>
+
+<!-- x-hide-in-docs-end -->
+<!-- The 'github-badges' class is used in the docs -->
+<p align="center" class="github-badges">
+  <a href="https://github.com/open-feature/spec/releases/tag/v0.5.2">
+    <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.5.2&color=yellow&style=for-the-badge" />
+  </a>
+  <!-- x-release-please-start-version -->
+
+  <a href="https://github.com/open-feature/dotnet-sdk/releases/tag/v1.3.1">
+    <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v1.3.1&color=blue&style=for-the-badge" />
+  </a>
+  <!-- x-release-please-end -->
+  <br/>
+  <a href="https://cloud-native.slack.com/archives/C0344AANLA1">
+    <img alt="Slack" src="https://img.shields.io/badge/slack-%40cncf%2Fopenfeature-brightgreen?style=flat&logo=slack"/>
+</a>
+  <a href="https://codecov.io/gh/open-feature/dotnet-sdk">
+    <img alt="Codecov" src="https://codecov.io/gh/open-feature/dotnet-sdk/branch/main/graph/badge.svg?token=MONAVJBXUJ" />
+  </a>
+  <a href="https://www.nuget.org/packages/OpenFeature">
+    <img alt="NuGet" src="https://img.shields.io/nuget/vpre/OpenFeature" />
+  </a>
+  <a href="https://www.bestpractices.dev/en/projects/6250">
+    <img alt="CII Best Practices" src="https://bestpractices.coreinfrastructure.org/projects/6250/badge" />
+
+  </a>
+</p>
+<!-- x-hide-in-docs-start -->
+
+[OpenFeature](https://openfeature.dev) is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool.
+
+<!-- x-hide-in-docs-end -->
+
+## 🚀 Quick start
+
+### Requirements
+
+-   .NET 6+
+-   .NET Core 6+
+-   .NET Framework 4.6.2+
+
+Note that the packages will aim to support all current .NET versions. Refer to the currently supported versions [.NET](https://dotnet.microsoft.com/download/dotnet) and [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework) excluding .NET Framework 3.5
+
+### Install
+
+Use the following to initialize your project:
+
+```sh
+dotnet new console
+```
+
+and install OpenFeature:
+
+```sh
+dotnet add package OpenFeature
+```
+
+### Usage
+
+```csharp
+public async Task Example()
+{
+    // Register your feature flag provider
+    await Api.Instance.SetProviderAsync(new InMemoryProvider());
+
+    // Create a new client
+    FeatureClient client = Api.Instance.GetClient();
+
+    // Evaluate your feature flag
+    bool v2Enabled = await client.GetBooleanValueAsync("v2_enabled", false);
+
+    if ( v2Enabled )
+    {
+        //Do some work
+    }
+}
+```
+
+## 🌟 Features
+
+| Status | Features                        | Description                                                                                                                        |
+| ------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| ✅     | [Providers](#providers)         | Integrate with a commercial, open source, or in-house feature management tool.                                                     |
+| ✅     | [Targeting](#targeting)         | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context). |
+| ✅     | [Hooks](#hooks)                 | Add functionality to various stages of the flag evaluation life-cycle.                                                             |
+| ✅     | [Logging](#logging)             | Integrate with popular logging packages.                                                                                           |
+| ✅     | [Named clients](#named-clients) | Utilize multiple providers in a single application.                                                                                |
+| ✅     | [Eventing](#eventing)           | React to state changes in the provider or flag management system.                                                                  |
+| ✅    | [Shutdown](#shutdown)           | Gracefully clean up a provider during application shutdown.                                                                        |
+| ✅     | [Extending](#extending)         | Extend OpenFeature with custom providers and hooks.                                                                                |
+
+<sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>
+
+### Providers
+
+[Providers](https://openfeature.dev/docs/reference/concepts/provider) are an abstraction between a flag management system and the OpenFeature SDK.
+Here is [a complete list of available providers](https://openfeature.dev/ecosystem?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Provider&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=.NET).
+
+If the provider you're looking for hasn't been created yet, see the [develop a provider](#develop-a-provider) section to learn how to build it yourself.
+
+Once you've added a provider as a dependency, it can be registered with OpenFeature like this:
+
+```csharp
+await Api.Instance.SetProviderAsync(new MyProvider());
+```
+
+In some situations, it may be beneficial to register multiple providers in the same application.
+This is possible using [named clients](#named-clients), which is covered in more detail below.
+
+### Targeting
+
+Sometimes, the value of a flag must consider some dynamic criteria about the application or user such as the user's location, IP, email address, or the server's location.
+In OpenFeature, we refer to this as [targeting](https://openfeature.dev/specification/glossary#targeting).
+If the flag management system you're using supports targeting, you can provide the input data using the [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).
+
+```csharp
+// set a value to the global context
+EvaluationContextBuilder builder = EvaluationContext.Builder();
+builder.Set("region", "us-east-1");
+EvaluationContext apiCtx = builder.Build();
+Api.Instance.SetContext(apiCtx);
+
+// set a value to the client context
+builder = EvaluationContext.Builder();
+builder.Set("region", "us-east-1");
+EvaluationContext clientCtx = builder.Build();
+var client = Api.Instance.GetClient();
+client.SetContext(clientCtx);
+
+// set a value to the invocation context
+builder = EvaluationContext.Builder();
+builder.Set("region", "us-east-1");
+EvaluationContext reqCtx = builder.Build();
+
+bool flagValue = await client.GetBooleanValueAsync("some-flag", false, reqCtx);
+
+```
+
+### Hooks
+
+[Hooks](https://openfeature.dev/docs/reference/concepts/hooks) allow for custom logic to be added at well-defined points of the flag evaluation life-cycle.
+Here is [a complete list of available hooks](https://openfeature.dev/docs/reference/technologies/server/dotnet/).
+If the hook you're looking for hasn't been created yet, see the [develop a hook](#develop-a-hook) section to learn how to build it yourself.
+
+Once you've added a hook as a dependency, it can be registered at the global, client, or flag invocation level.
+
+```csharp
+// add a hook globally, to run on all evaluations
+Api.Instance.AddHooks(new ExampleGlobalHook());
+
+// add a hook on this client, to run on all evaluations made by this client
+var client = Api.Instance.GetClient();
+client.AddHooks(new ExampleClientHook());
+
+// add a hook for this evaluation only
+var value = await client.GetBooleanValueAsync("boolFlag", false, context, new FlagEvaluationOptions(new ExampleInvocationHook()));
+```
+
+### Logging
+
+The .NET SDK uses Microsoft.Extensions.Logging. See the [manual](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line) for complete documentation.
+
+### Named clients
+
+Clients can be given a name.
+A name is a logical identifier that can be used to associate clients with a particular provider.
+If a name has no associated provider, the global provider is used.
+
+```csharp
+// registering the default provider
+await Api.Instance.SetProvider(new LocalProvider());
+
+// registering a named provider
+await Api.Instance.SetProvider("clientForCache", new CachedProvider());
+
+// a client backed by default provider
+FeatureClient clientDefault = Api.Instance.GetClient();
+
+// a client backed by CachedProvider
+FeatureClient clientNamed = Api.Instance.GetClient("clientForCache");
+
+```
+
+### Eventing
+
+Events allow you to react to state changes in the provider or underlying flag management system, such as flag definition changes,
+provider readiness, or error conditions.
+Initialization events (`PROVIDER_READY` on success, `PROVIDER_ERROR` on failure) are dispatched for every provider.
+Some providers support additional events, such as `PROVIDER_CONFIGURATION_CHANGED`.
+
+Please refer to the documentation of the provider you're using to see what events are supported.
+
+Example usage of an Event handler:
+
+```csharp
+public static void EventHandler(ProviderEventPayload eventDetails)
+{
+    Console.WriteLine(eventDetails.Type);
+}
+```
+
+```csharp
+EventHandlerDelegate callback = EventHandler;
+// add an implementation of the EventHandlerDelegate for the PROVIDER_READY event
+Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, callback);
+```
+
+It is also possible to register an event handler for a specific client, as in the following example:
+
+```csharp
+EventHandlerDelegate callback = EventHandler;
+
+var myClient = Api.Instance.GetClient("my-client");
+
+var provider = new ExampleProvider();
+await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name, provider);
+
+myClient.AddHandler(ProviderEventTypes.ProviderReady, callback);
+```
+
+### Shutdown
+
+The OpenFeature API provides a close function to perform a cleanup of all registered providers. This should only be called when your application is in the process of shutting down.
+
+```csharp
+// Shut down all providers
+await Api.Instance.ShutdownAsync();
+```
+
+## Extending
+
+### Develop a provider
+
+To develop a provider, you need to create a new project and include the OpenFeature SDK as a dependency.
+This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/dotnet-sdk-contrib) available under the OpenFeature organization.
+You’ll then need to write the provider by implementing the `FeatureProvider` interface exported by the OpenFeature SDK.
+
+```csharp
+public class MyProvider : FeatureProvider
+{
+    public override Metadata GetMetadata()
+    {
+        return new Metadata("My Provider");
+    }
+
+    public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    {
+        // resolve a boolean flag value
+    }
+
+    public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    {
+        // resolve a double flag value
+    }
+
+    public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    {
+        // resolve an int flag value
+    }
+
+    public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    {
+        // resolve a string flag value
+    }
+
+    public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    {
+        // resolve an object flag value
+    }
+}
+```
+
+### Develop a hook
+
+To develop a hook, you need to create a new project and include the OpenFeature SDK as a dependency.
+This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/dotnet-sdk-contrib) available under the OpenFeature organization.
+Implement your own hook by conforming to the `Hook interface`.
+To satisfy the interface, all methods (`BeforeAsync`/`AfterAsync`/`FinallyAsync`/`ErrorAsync`) need to be defined.
+
+```csharp
+public class MyHook : Hook
+{
+  public ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
+      IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+  {
+    // code to run before flag evaluation
+  }
+
+  public virtual ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+      IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+  {
+    // code to run after successful flag evaluation
+  }
+
+  public virtual ValueTask ErrorAsync<T>(HookContext<T> context, Exception error,
+      IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+  {
+    // code to run if there's an error during before hooks or during flag evaluation
+  }
+
+  public virtual ValueTask FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
+  {
+    // code to run after all other stages, regardless of success/failure
+  }
+}
+```
+
+Built a new hook? [Let us know](https://github.com/open-feature/openfeature.dev/issues/new?assignees=&labels=hook&projects=&template=document-hook.yaml&title=%5BHook%5D%3A+) so we can add it to the docs!
+
+<!-- x-hide-in-docs-start -->
+## ⭐️ Support the project
+
+-   Give this repo a ⭐️!
+-   Follow us on social media:
+    -   Twitter: [@openfeature](https://twitter.com/openfeature)
+    -   LinkedIn: [OpenFeature](https://www.linkedin.com/company/openfeature/)
+-   Join us on [Slack](https://cloud-native.slack.com/archives/C0344AANLA1)
+-   For more information, check out our [community page](https://openfeature.dev/community/)
+
+## 🤝 Contributing
+
+Interested in contributing? Great, we'd love your help! To get started, take a look at the [CONTRIBUTING](CONTRIBUTING.md) guide.
+
+### Thanks to everyone who has already contributed
+
+<a href="https://github.com/open-feature/dotnet-sdk/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=open-feature/dotnet-sdk" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).
+<!-- x-hide-in-docs-end -->
+>>>>>>> f23274b (refactor: Cleanup + plumb cancellation tokens)

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -59,6 +59,10 @@ namespace OpenFeature
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel any async side effects.</param>
         public async Task SetProviderAsync(string clientName, FeatureProvider featureProvider, CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrWhiteSpace(clientName))
+            {
+                throw new ArgumentNullException(nameof(clientName));
+            }
             this._eventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
             await this._repository.SetProviderAsync(clientName, featureProvider, this.GetContext(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -54,10 +54,11 @@ namespace OpenFeature
         /// </summary>
         /// <remarks>The provider cannot be set to null. Attempting to set the provider to null has no effect.</remarks>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
-        public async Task SetProviderAsync(FeatureProvider? featureProvider)
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public async ValueTask SetProviderAsync(FeatureProvider featureProvider, CancellationToken cancellationToken = default)
         {
             this._eventExecutor.RegisterDefaultFeatureProvider(featureProvider);
-            await this._repository.SetProvider(featureProvider, this.GetContext()).ConfigureAwait(false);
+            await this._repository.SetProviderAsync(featureProvider, this.GetContext(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -78,14 +79,11 @@ namespace OpenFeature
         /// </summary>
         /// <param name="clientName">Name of client</param>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
-        public async Task SetProviderAsync(string clientName, FeatureProvider featureProvider)
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public async ValueTask SetProviderAsync(string clientName, FeatureProvider featureProvider, CancellationToken cancellationToken = default)
         {
-            if (string.IsNullOrWhiteSpace(clientName))
-            {
-                throw new ArgumentNullException(nameof(clientName));
-            }
             this._eventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
-            await this._repository.SetProvider(clientName, featureProvider, this.GetContext()).ConfigureAwait(false);
+            await this._repository.SetProviderAsync(clientName, featureProvider, this.GetContext(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -248,18 +246,22 @@ namespace OpenFeature
         /// Once shut down is complete, API is reset and ready to use again.
         /// </para>
         /// </summary>
-        public async Task Shutdown()
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public async ValueTask ShutdownAsync(CancellationToken cancellationToken = default)
         {
-            await using (this._eventExecutor.ConfigureAwait(false))
-            await using (this._repository.ConfigureAwait(false))
-            {
-                this._evaluationContext = EvaluationContext.Empty;
-                this._hooks.Clear();
+            // TODO: conflict
+            // await using (this._eventExecutor.ConfigureAwait(false))
+            // await using (this._repository.ConfigureAwait(false))
+            // {
+            //     this._evaluationContext = EvaluationContext.Empty;
+            //     this._hooks.Clear();
 
-                // TODO: make these lazy to avoid extra allocations on the common cleanup path?
-                this._eventExecutor = new EventExecutor();
-                this._repository = new ProviderRepository();
-            }
+            //     // TODO: make these lazy to avoid extra allocations on the common cleanup path?
+            //     this._eventExecutor = new EventExecutor();
+            //     this._repository = new ProviderRepository();
+            // }
+            // await this._repository.ShutdownAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            // await this.EventExecutor.ShutdownAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
@@ -43,9 +44,10 @@ namespace OpenFeature
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
-            EvaluationContext? context = null);
+        public abstract Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue,
+            EvaluationContext? context = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a string feature flag
@@ -53,9 +55,10 @@ namespace OpenFeature
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
-            EvaluationContext? context = null);
+        public abstract Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue,
+            EvaluationContext? context = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a integer feature flag
@@ -63,9 +66,10 @@ namespace OpenFeature
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
-            EvaluationContext? context = null);
+        public abstract Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue,
+            EvaluationContext? context = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a double feature flag
@@ -73,9 +77,10 @@ namespace OpenFeature
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
-            EvaluationContext? context = null);
+        public abstract Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue,
+            EvaluationContext? context = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a structured feature flag
@@ -83,9 +88,10 @@ namespace OpenFeature
         /// <param name="flagKey">Feature flag key</param>
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="ResolutionDetails{T}"/></returns>
-        public abstract Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue,
-            EvaluationContext? context = null);
+        public abstract Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue,
+            EvaluationContext? context = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get the status of the provider.
@@ -95,7 +101,7 @@ namespace OpenFeature
         /// If a provider does not override this method, then its status will be assumed to be
         /// <see cref="ProviderStatus.Ready"/>. If a provider implements this method, and supports initialization,
         /// then it should start in the <see cref="ProviderStatus.NotReady"/>status . If the status is
-        /// <see cref="ProviderStatus.NotReady"/>, then the Api will call the <see cref="Initialize" /> when the
+        /// <see cref="ProviderStatus.NotReady"/>, then the Api will call the <see cref="InitializeAsync" /> when the
         /// provider is set.
         /// </remarks>
         public virtual ProviderStatus GetStatus() => ProviderStatus.Ready;
@@ -107,6 +113,7 @@ namespace OpenFeature
         /// </para>
         /// </summary>
         /// <param name="context"><see cref="EvaluationContext"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>A task that completes when the initialization process is complete.</returns>
         /// <remarks>
         /// <para>
@@ -118,10 +125,10 @@ namespace OpenFeature
         /// the <see cref="GetStatus"/> method after initialization is complete.
         /// </para>
         /// </remarks>
-        public virtual Task Initialize(EvaluationContext context)
+        public virtual ValueTask InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
         {
             // Intentionally left blank.
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
         /// <summary>
@@ -129,10 +136,11 @@ namespace OpenFeature
         /// Providers can overwrite this method, if they have special shutdown actions needed.
         /// </summary>
         /// <returns>A task that completes when the shutdown process is complete.</returns>
-        public virtual Task Shutdown()
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public virtual ValueTask ShutdownAsync(CancellationToken cancellationToken = default)
         {
             // Intentionally left blank.
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
         /// <summary>

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -113,7 +113,7 @@ namespace OpenFeature
         /// </para>
         /// </summary>
         /// <param name="context"><see cref="EvaluationContext"/></param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel any async side effects.</param>
         /// <returns>A task that completes when the initialization process is complete.</returns>
         /// <remarks>
         /// <para>
@@ -125,10 +125,10 @@ namespace OpenFeature
         /// the <see cref="GetStatus"/> method after initialization is complete.
         /// </para>
         /// </remarks>
-        public virtual ValueTask InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
+        public virtual Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
         {
             // Intentionally left blank.
-            return new ValueTask();
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -136,11 +136,11 @@ namespace OpenFeature
         /// Providers can overwrite this method, if they have special shutdown actions needed.
         /// </summary>
         /// <returns>A task that completes when the shutdown process is complete.</returns>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public virtual ValueTask ShutdownAsync(CancellationToken cancellationToken = default)
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel any async side effects.</param>
+        public virtual Task ShutdownAsync(CancellationToken cancellationToken = default)
         {
             // Intentionally left blank.
-            return new ValueTask();
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/OpenFeature/Hook.cs
+++ b/src/OpenFeature/Hook.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenFeature.Model;
 
@@ -26,12 +27,13 @@ namespace OpenFeature
         /// </summary>
         /// <param name="context">Provides context of innovation</param>
         /// <param name="hints">Caller provided data</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
         /// <returns>Modified EvaluationContext that is used for the flag evaluation</returns>
-        public virtual Task<EvaluationContext> Before<T>(HookContext<T> context,
-            IReadOnlyDictionary<string, object>? hints = null)
+        public virtual ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
+            IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(EvaluationContext.Empty);
+            return new ValueTask<EvaluationContext>(EvaluationContext.Empty);
         }
 
         /// <summary>
@@ -40,11 +42,12 @@ namespace OpenFeature
         /// <param name="context">Provides context of innovation</param>
         /// <param name="details">Flag evaluation information</param>
         /// <param name="hints">Caller provided data</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual Task After<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
-            IReadOnlyDictionary<string, object>? hints = null)
+        public virtual ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+            IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
         /// <summary>
@@ -53,11 +56,12 @@ namespace OpenFeature
         /// <param name="context">Provides context of innovation</param>
         /// <param name="error">Exception representing what went wrong</param>
         /// <param name="hints">Caller provided data</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual Task Error<T>(HookContext<T> context, Exception error,
-            IReadOnlyDictionary<string, object>? hints = null)
+        public virtual ValueTask ErrorAsync<T>(HookContext<T> context, Exception error,
+            IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
         /// <summary>
@@ -65,10 +69,11 @@ namespace OpenFeature
         /// </summary>
         /// <param name="context">Provides context of innovation</param>
         /// <param name="hints">Caller provided data</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual Task Finally<T>(HookContext<T> context, IReadOnlyDictionary<string, object>? hints = null)
+        public virtual ValueTask FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
     }
 }

--- a/src/OpenFeature/IFeatureClient.cs
+++ b/src/OpenFeature/IFeatureClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenFeature.Model;
 
@@ -59,8 +60,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag value.</returns>
-        Task<bool> GetBooleanValue(string flagKey, bool defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null);
+        Task<bool> GetBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a boolean feature flag
@@ -69,8 +71,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        Task<FlagEvaluationDetails<bool>> GetBooleanDetails(string flagKey, bool defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null);
+        Task<FlagEvaluationDetails<bool>> GetBooleanDetailsAsync(string flagKey, bool defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a string feature flag
@@ -79,8 +82,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag value.</returns>
-        Task<string> GetStringValue(string flagKey, string defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null);
+        Task<string> GetStringValueAsync(string flagKey, string defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a string feature flag
@@ -89,8 +93,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        Task<FlagEvaluationDetails<string>> GetStringDetails(string flagKey, string defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null);
+        Task<FlagEvaluationDetails<string>> GetStringDetailsAsync(string flagKey, string defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a integer feature flag
@@ -99,8 +104,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag value.</returns>
-        Task<int> GetIntegerValue(string flagKey, int defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null);
+        Task<int> GetIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a integer feature flag
@@ -109,8 +115,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        Task<FlagEvaluationDetails<int>> GetIntegerDetails(string flagKey, int defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null);
+        Task<FlagEvaluationDetails<int>> GetIntegerDetailsAsync(string flagKey, int defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a double feature flag
@@ -119,8 +126,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag value.</returns>
-        Task<double> GetDoubleValue(string flagKey, double defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null);
+        Task<double> GetDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a double feature flag
@@ -129,8 +137,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        Task<FlagEvaluationDetails<double>> GetDoubleDetails(string flagKey, double defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null);
+        Task<FlagEvaluationDetails<double>> GetDoubleDetailsAsync(string flagKey, double defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a structure object feature flag
@@ -139,8 +148,9 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag value.</returns>
-        Task<Value> GetObjectValue(string flagKey, Value defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null);
+        Task<Value> GetObjectValueAsync(string flagKey, Value defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resolves a structure object feature flag
@@ -149,7 +159,8 @@ namespace OpenFeature
         /// <param name="defaultValue">Default value</param>
         /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
         /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
-        Task<FlagEvaluationDetails<Value>> GetObjectDetails(string flagKey, Value defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null);
+        Task<FlagEvaluationDetails<Value>> GetObjectDetailsAsync(string flagKey, Value defaultValue, EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/OpenFeature/Model/EvaluationContext.cs
+++ b/src/OpenFeature/Model/EvaluationContext.cs
@@ -25,6 +25,16 @@ namespace OpenFeature.Model
         }
 
         /// <summary>
+        /// Internal constructor used by the builder.
+        /// </summary>
+        /// <param name="content">The content of the context.</param>
+        internal EvaluationContext(Structure content)
+        {
+            this.TargetingKey = string.Empty;
+            this._structure = content;
+        }
+
+        /// <summary>
         /// Private constructor for making an empty <see cref="EvaluationContext"/>.
         /// </summary>
         private EvaluationContext()

--- a/src/OpenFeature/Model/EvaluationContext.cs
+++ b/src/OpenFeature/Model/EvaluationContext.cs
@@ -25,16 +25,6 @@ namespace OpenFeature.Model
         }
 
         /// <summary>
-        /// Internal constructor used by the builder.
-        /// </summary>
-        /// <param name="content">The content of the context.</param>
-        internal EvaluationContext(Structure content)
-        {
-            this.TargetingKey = string.Empty;
-            this._structure = content;
-        }
-
-        /// <summary>
         /// Private constructor for making an empty <see cref="EvaluationContext"/>.
         /// </summary>
         private EvaluationContext()

--- a/src/OpenFeature/NoOpProvider.cs
+++ b/src/OpenFeature/NoOpProvider.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Model;
@@ -13,27 +14,27 @@ namespace OpenFeature
             return this._metadata;
         }
 
-        public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext? context = null)
+        public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext? context = null)
+        public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext? context = null)
+        public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext? context = null)
+        public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext? context = null)
+        public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(NoOpResponse(flagKey, defaultValue));
         }

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -36,9 +37,9 @@ namespace OpenFeature
         /// </param>
         /// <typeparam name="T">The type of the resolution method</typeparam>
         /// <returns>A tuple containing a resolution method and the provider it came from.</returns>
-        private (Func<string, T, EvaluationContext, Task<ResolutionDetails<T>>>, FeatureProvider)
+        private (Func<string, T, EvaluationContext, CancellationToken, Task<ResolutionDetails<T>>>, FeatureProvider)
             ExtractProvider<T>(
-                Func<FeatureProvider, Func<string, T, EvaluationContext, Task<ResolutionDetails<T>>>> method)
+                Func<FeatureProvider, Func<string, T, EvaluationContext, CancellationToken, Task<ResolutionDetails<T>>>> method)
         {
             // Alias the provider reference so getting the method and returning the provider are
             // guaranteed to be the same object.
@@ -136,70 +137,71 @@ namespace OpenFeature
         public void ClearHooks() => this._hooks.Clear();
 
         /// <inheritdoc />
-        public async Task<bool> GetBooleanValue(string flagKey, bool defaultValue, EvaluationContext? context = null,
-            FlagEvaluationOptions? config = null) =>
-            (await this.GetBooleanDetails(flagKey, defaultValue, context, config).ConfigureAwait(false)).Value;
+        public async Task<bool> GetBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext? context = null,
+            FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default) =>
+            (await this.GetBooleanDetailsAsync(flagKey, defaultValue, context, config, cancellationToken).ConfigureAwait(false)).Value;
 
         /// <inheritdoc />
-        public async Task<FlagEvaluationDetails<bool>> GetBooleanDetails(string flagKey, bool defaultValue,
-            EvaluationContext? context = null, FlagEvaluationOptions? config = null) =>
-            await this.EvaluateFlag(this.ExtractProvider<bool>(provider => provider.ResolveBooleanValue),
+        public async Task<FlagEvaluationDetails<bool>> GetBooleanDetailsAsync(string flagKey, bool defaultValue,
+            EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default) =>
+            await this.EvaluateFlagAsync(this.ExtractProvider<bool>(provider => provider.ResolveBooleanValueAsync),
                 FlagValueType.Boolean, flagKey,
-                defaultValue, context, config).ConfigureAwait(false);
+                defaultValue, context, config, cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<string> GetStringValue(string flagKey, string defaultValue, EvaluationContext? context = null,
-            FlagEvaluationOptions? config = null) =>
-            (await this.GetStringDetails(flagKey, defaultValue, context, config).ConfigureAwait(false)).Value;
+        public async Task<string> GetStringValueAsync(string flagKey, string defaultValue, EvaluationContext? context = null,
+            FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default) =>
+            (await this.GetStringDetailsAsync(flagKey, defaultValue, context, config, cancellationToken).ConfigureAwait(false)).Value;
 
         /// <inheritdoc />
-        public async Task<FlagEvaluationDetails<string>> GetStringDetails(string flagKey, string defaultValue,
-            EvaluationContext? context = null, FlagEvaluationOptions? config = null) =>
-            await this.EvaluateFlag(this.ExtractProvider<string>(provider => provider.ResolveStringValue),
+        public async Task<FlagEvaluationDetails<string>> GetStringDetailsAsync(string flagKey, string defaultValue,
+            EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default) =>
+            await this.EvaluateFlagAsync(this.ExtractProvider<string>(provider => provider.ResolveStringValueAsync),
                 FlagValueType.String, flagKey,
-                defaultValue, context, config).ConfigureAwait(false);
+                defaultValue, context, config, cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<int> GetIntegerValue(string flagKey, int defaultValue, EvaluationContext? context = null,
-            FlagEvaluationOptions? config = null) =>
-            (await this.GetIntegerDetails(flagKey, defaultValue, context, config).ConfigureAwait(false)).Value;
+        public async Task<int> GetIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext? context = null,
+            FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default) =>
+            (await this.GetIntegerDetailsAsync(flagKey, defaultValue, context, config, cancellationToken).ConfigureAwait(false)).Value;
 
         /// <inheritdoc />
-        public async Task<FlagEvaluationDetails<int>> GetIntegerDetails(string flagKey, int defaultValue,
-            EvaluationContext? context = null, FlagEvaluationOptions? config = null) =>
-            await this.EvaluateFlag(this.ExtractProvider<int>(provider => provider.ResolveIntegerValue),
+        public async Task<FlagEvaluationDetails<int>> GetIntegerDetailsAsync(string flagKey, int defaultValue,
+            EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default) =>
+            await this.EvaluateFlagAsync(this.ExtractProvider<int>(provider => provider.ResolveIntegerValueAsync),
                 FlagValueType.Number, flagKey,
-                defaultValue, context, config).ConfigureAwait(false);
+                defaultValue, context, config, cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<double> GetDoubleValue(string flagKey, double defaultValue,
+        public async Task<double> GetDoubleValueAsync(string flagKey, double defaultValue,
             EvaluationContext? context = null,
-            FlagEvaluationOptions? config = null) =>
-            (await this.GetDoubleDetails(flagKey, defaultValue, context, config).ConfigureAwait(false)).Value;
+            FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default) =>
+            (await this.GetDoubleDetailsAsync(flagKey, defaultValue, context, config, cancellationToken).ConfigureAwait(false)).Value;
 
         /// <inheritdoc />
-        public async Task<FlagEvaluationDetails<double>> GetDoubleDetails(string flagKey, double defaultValue,
-            EvaluationContext? context = null, FlagEvaluationOptions? config = null) =>
-            await this.EvaluateFlag(this.ExtractProvider<double>(provider => provider.ResolveDoubleValue),
+        public async Task<FlagEvaluationDetails<double>> GetDoubleDetailsAsync(string flagKey, double defaultValue,
+            EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default) =>
+            await this.EvaluateFlagAsync(this.ExtractProvider<double>(provider => provider.ResolveDoubleValueAsync),
                 FlagValueType.Number, flagKey,
-                defaultValue, context, config).ConfigureAwait(false);
+                defaultValue, context, config, cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<Value> GetObjectValue(string flagKey, Value defaultValue, EvaluationContext? context = null,
-            FlagEvaluationOptions? config = null) =>
-            (await this.GetObjectDetails(flagKey, defaultValue, context, config).ConfigureAwait(false)).Value;
+        public async Task<Value> GetObjectValueAsync(string flagKey, Value defaultValue, EvaluationContext? context = null,
+            FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default) =>
+            (await this.GetObjectDetailsAsync(flagKey, defaultValue, context, config, cancellationToken).ConfigureAwait(false)).Value;
 
         /// <inheritdoc />
-        public async Task<FlagEvaluationDetails<Value>> GetObjectDetails(string flagKey, Value defaultValue,
-            EvaluationContext? context = null, FlagEvaluationOptions? config = null) =>
-            await this.EvaluateFlag(this.ExtractProvider<Value>(provider => provider.ResolveStructureValue),
+        public async Task<FlagEvaluationDetails<Value>> GetObjectDetailsAsync(string flagKey, Value defaultValue,
+            EvaluationContext? context = null, FlagEvaluationOptions? config = null, CancellationToken cancellationToken = default) =>
+            await this.EvaluateFlagAsync(this.ExtractProvider<Value>(provider => provider.ResolveStructureValueAsync),
                 FlagValueType.Object, flagKey,
-                defaultValue, context, config).ConfigureAwait(false);
+                defaultValue, context, config, cancellationToken).ConfigureAwait(false);
 
-        private async Task<FlagEvaluationDetails<T>> EvaluateFlag<T>(
-            (Func<string, T, EvaluationContext, Task<ResolutionDetails<T>>>, FeatureProvider) providerInfo,
+        private async Task<FlagEvaluationDetails<T>> EvaluateFlagAsync<T>(
+            (Func<string, T, EvaluationContext, CancellationToken, Task<ResolutionDetails<T>>>, FeatureProvider) providerInfo,
             FlagValueType flagValueType, string flagKey, T defaultValue, EvaluationContext? context = null,
-            FlagEvaluationOptions? options = null)
+            FlagEvaluationOptions? options = null,
+            CancellationToken cancellationToken = default)
         {
             var resolveValueDelegate = providerInfo.Item1;
             var provider = providerInfo.Item2;
@@ -242,45 +244,45 @@ namespace OpenFeature
             FlagEvaluationDetails<T> evaluation;
             try
             {
-                var contextFromHooks = await this.TriggerBeforeHooks(allHooks, hookContext, options).ConfigureAwait(false);
+                var contextFromHooks = await this.TriggerBeforeHooksAsync(allHooks, hookContext, options, cancellationToken).ConfigureAwait(false);
 
                 evaluation =
-                    (await resolveValueDelegate.Invoke(flagKey, defaultValue, contextFromHooks.EvaluationContext).ConfigureAwait(false))
+                    (await resolveValueDelegate.Invoke(flagKey, defaultValue, contextFromHooks.EvaluationContext, cancellationToken).ConfigureAwait(false))
                     .ToFlagEvaluationDetails();
 
-                await this.TriggerAfterHooks(allHooksReversed, hookContext, evaluation, options).ConfigureAwait(false);
+                await this.TriggerAfterHooksAsync(allHooksReversed, hookContext, evaluation, options, cancellationToken).ConfigureAwait(false);
             }
             catch (FeatureProviderException ex)
             {
                 this.FlagEvaluationErrorWithDescription(flagKey, ex.ErrorType.GetDescription(), ex);
                 evaluation = new FlagEvaluationDetails<T>(flagKey, defaultValue, ex.ErrorType, Reason.Error,
                     string.Empty, ex.Message);
-                await this.TriggerErrorHooks(allHooksReversed, hookContext, ex, options).ConfigureAwait(false);
+                await this.TriggerErrorHooksAsync(allHooksReversed, hookContext, ex, options, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 this.FlagEvaluationError(flagKey, ex);
                 var errorCode = ex is InvalidCastException ? ErrorType.TypeMismatch : ErrorType.General;
                 evaluation = new FlagEvaluationDetails<T>(flagKey, defaultValue, errorCode, Reason.Error, string.Empty, ex.Message);
-                await this.TriggerErrorHooks(allHooksReversed, hookContext, ex, options).ConfigureAwait(false);
+                await this.TriggerErrorHooksAsync(allHooksReversed, hookContext, ex, options, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
-                await this.TriggerFinallyHooks(allHooksReversed, hookContext, options).ConfigureAwait(false);
+                await this.TriggerFinallyHooksAsync(allHooksReversed, hookContext, options, cancellationToken).ConfigureAwait(false);
             }
 
             return evaluation;
         }
 
-        private async Task<HookContext<T>> TriggerBeforeHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
-            FlagEvaluationOptions? options)
+        private async ValueTask<HookContext<T>> TriggerBeforeHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+            FlagEvaluationOptions? options, CancellationToken cancellationToken = default)
         {
             var evalContextBuilder = EvaluationContext.Builder();
             evalContextBuilder.Merge(context.EvaluationContext);
 
             foreach (var hook in hooks)
             {
-                var resp = await hook.Before(context, options?.HookHints).ConfigureAwait(false);
+                var resp = await hook.BeforeAsync(context, options?.HookHints, cancellationToken).ConfigureAwait(false);
                 if (resp != null)
                 {
                     evalContextBuilder.Merge(resp);
@@ -295,23 +297,23 @@ namespace OpenFeature
             return context.WithNewEvaluationContext(evalContextBuilder.Build());
         }
 
-        private async Task TriggerAfterHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
-            FlagEvaluationDetails<T> evaluationDetails, FlagEvaluationOptions? options)
+        private async ValueTask TriggerAfterHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+            FlagEvaluationDetails<T> evaluationDetails, FlagEvaluationOptions? options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)
             {
-                await hook.After(context, evaluationDetails, options?.HookHints).ConfigureAwait(false);
+                await hook.AfterAsync(context, evaluationDetails, options?.HookHints, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task TriggerErrorHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context, Exception exception,
-            FlagEvaluationOptions? options)
+        private async ValueTask TriggerErrorHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context, Exception exception,
+            FlagEvaluationOptions? options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)
             {
                 try
                 {
-                    await hook.Error(context, exception, options?.HookHints).ConfigureAwait(false);
+                    await hook.ErrorAsync(context, exception, options?.HookHints, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -320,14 +322,14 @@ namespace OpenFeature
             }
         }
 
-        private async Task TriggerFinallyHooks<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
-            FlagEvaluationOptions? options)
+        private async ValueTask TriggerFinallyHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+            FlagEvaluationOptions? options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)
             {
                 try
                 {
-                    await hook.Finally(context, options?.HookHints).ConfigureAwait(false);
+                    await hook.FinallyAsync(context, options?.HookHints, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -274,7 +274,7 @@ namespace OpenFeature
             return evaluation;
         }
 
-        private async ValueTask<HookContext<T>> TriggerBeforeHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+        private async Task<HookContext<T>> TriggerBeforeHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
             FlagEvaluationOptions? options, CancellationToken cancellationToken = default)
         {
             var evalContextBuilder = EvaluationContext.Builder();
@@ -297,7 +297,7 @@ namespace OpenFeature
             return context.WithNewEvaluationContext(evalContextBuilder.Build());
         }
 
-        private async ValueTask TriggerAfterHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+        private async Task TriggerAfterHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
             FlagEvaluationDetails<T> evaluationDetails, FlagEvaluationOptions? options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)
@@ -306,7 +306,7 @@ namespace OpenFeature
             }
         }
 
-        private async ValueTask TriggerErrorHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context, Exception exception,
+        private async Task TriggerErrorHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context, Exception exception,
             FlagEvaluationOptions? options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)
@@ -322,7 +322,7 @@ namespace OpenFeature
             }
         }
 
-        private async ValueTask TriggerFinallyHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
+        private async Task TriggerFinallyHooksAsync<T>(IReadOnlyList<Hook> hooks, HookContext<T> context,
             FlagEvaluationOptions? options, CancellationToken cancellationToken = default)
         {
             foreach (var hook in hooks)

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -35,7 +35,7 @@ namespace OpenFeature
         {
             using (this._providersLock)
             {
-                await this.Shutdown().ConfigureAwait(false);
+                await this.ShutdownAsync().ConfigureAwait(false);
             }
         }
 
@@ -62,13 +62,15 @@ namespace OpenFeature
         /// initialization
         /// </param>
         /// <param name="afterShutdown">called after a provider is shutdown, can be used to remove event handlers</param>
-        public async Task SetProvider(
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public async ValueTask SetProviderAsync(
             FeatureProvider? featureProvider,
             EvaluationContext context,
             Action<FeatureProvider>? afterSet = null,
             Action<FeatureProvider>? afterInitialization = null,
             Action<FeatureProvider, Exception>? afterError = null,
-            Action<FeatureProvider>? afterShutdown = null)
+            Action<FeatureProvider>? afterShutdown = null,
+            CancellationToken cancellationToken = default)
         {
             // Cannot unset the feature provider.
             if (featureProvider == null)
@@ -92,7 +94,7 @@ namespace OpenFeature
                 // We want to allow shutdown to happen concurrently with initialization, and the caller to not
                 // wait for it.
 #pragma warning disable CS4014
-                this.ShutdownIfUnused(oldProvider, afterShutdown, afterError);
+                this.ShutdownIfUnusedAsync(oldProvider, afterShutdown, afterError, cancellationToken);
 #pragma warning restore CS4014
             }
             finally
@@ -100,15 +102,16 @@ namespace OpenFeature
                 this._providersLock.ExitWriteLock();
             }
 
-            await InitProvider(this._defaultProvider, context, afterInitialization, afterError)
+            await InitProviderAsync(this._defaultProvider, context, afterInitialization, afterError, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        private static async Task InitProvider(
+        private static async ValueTask InitProviderAsync(
             FeatureProvider? newProvider,
             EvaluationContext context,
             Action<FeatureProvider>? afterInitialization,
-            Action<FeatureProvider, Exception>? afterError)
+            Action<FeatureProvider, Exception>? afterError,
+            CancellationToken cancellationToken)
         {
             if (newProvider == null)
             {
@@ -118,7 +121,7 @@ namespace OpenFeature
             {
                 try
                 {
-                    await newProvider.Initialize(context).ConfigureAwait(false);
+                    await newProvider.InitializeAsync(context, cancellationToken).ConfigureAwait(false);
                     afterInitialization?.Invoke(newProvider);
                 }
                 catch (Exception ex)
@@ -152,13 +155,15 @@ namespace OpenFeature
         /// initialization
         /// </param>
         /// <param name="afterShutdown">called after a provider is shutdown, can be used to remove event handlers</param>
-        public async Task SetProvider(string? clientName,
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public async ValueTask SetProviderAsync(string clientName,
             FeatureProvider? featureProvider,
             EvaluationContext context,
             Action<FeatureProvider>? afterSet = null,
             Action<FeatureProvider>? afterInitialization = null,
             Action<FeatureProvider, Exception>? afterError = null,
-            Action<FeatureProvider>? afterShutdown = null)
+            Action<FeatureProvider>? afterShutdown = null,
+            CancellationToken cancellationToken = default)
         {
             // Cannot set a provider for a null clientName.
             if (clientName == null)
@@ -187,7 +192,7 @@ namespace OpenFeature
                 // We want to allow shutdown to happen concurrently with initialization, and the caller to not
                 // wait for it.
 #pragma warning disable CS4014
-                this.ShutdownIfUnused(oldProvider, afterShutdown, afterError);
+                this.ShutdownIfUnusedAsync(oldProvider, afterShutdown, afterError, cancellationToken);
 #pragma warning restore CS4014
             }
             finally
@@ -195,16 +200,17 @@ namespace OpenFeature
                 this._providersLock.ExitWriteLock();
             }
 
-            await InitProvider(featureProvider, context, afterInitialization, afterError).ConfigureAwait(false);
+            await InitProviderAsync(featureProvider, context, afterInitialization, afterError, cancellationToken).ConfigureAwait(false);
         }
 
         /// <remarks>
         /// Shutdown the feature provider if it is unused. This must be called within a write lock of the _providersLock.
         /// </remarks>
-        private async Task ShutdownIfUnused(
+        private async ValueTask ShutdownIfUnusedAsync(
             FeatureProvider? targetProvider,
             Action<FeatureProvider>? afterShutdown,
-            Action<FeatureProvider, Exception>? afterError)
+            Action<FeatureProvider, Exception>? afterError,
+            CancellationToken cancellationToken)
         {
             if (ReferenceEquals(this._defaultProvider, targetProvider))
             {
@@ -216,7 +222,7 @@ namespace OpenFeature
                 return;
             }
 
-            await SafeShutdownProvider(targetProvider, afterShutdown, afterError).ConfigureAwait(false);
+            await SafeShutdownProviderAsync(targetProvider, afterShutdown, afterError, cancellationToken).ConfigureAwait(false);
         }
 
         /// <remarks>
@@ -228,9 +234,10 @@ namespace OpenFeature
         /// it would not be meaningful to emit an error.
         /// </para>
         /// </remarks>
-        private static async Task SafeShutdownProvider(FeatureProvider? targetProvider,
+        private static async ValueTask SafeShutdownProviderAsync(FeatureProvider? targetProvider,
             Action<FeatureProvider>? afterShutdown,
-            Action<FeatureProvider, Exception>? afterError)
+            Action<FeatureProvider, Exception>? afterError,
+            CancellationToken cancellationToken)
         {
             if (targetProvider == null)
             {
@@ -239,7 +246,7 @@ namespace OpenFeature
 
             try
             {
-                await targetProvider.Shutdown().ConfigureAwait(false);
+                await targetProvider.ShutdownAsync(cancellationToken).ConfigureAwait(false);
                 afterShutdown?.Invoke(targetProvider);
             }
             catch (Exception ex)
@@ -281,7 +288,7 @@ namespace OpenFeature
                 : this.GetProvider();
         }
 
-        public async Task Shutdown(Action<FeatureProvider, Exception>? afterError = null)
+        public async ValueTask ShutdownAsync(Action<FeatureProvider, Exception>? afterError = null, CancellationToken cancellationToken = default)
         {
             var providers = new HashSet<FeatureProvider>();
             this._providersLock.EnterWriteLock();
@@ -305,7 +312,7 @@ namespace OpenFeature
             foreach (var targetProvider in providers)
             {
                 // We don't need to take any actions after shutdown.
-                await SafeShutdownProvider(targetProvider, null, afterError).ConfigureAwait(false);
+                await SafeShutdownProviderAsync(targetProvider, null, afterError, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -62,7 +62,7 @@ namespace OpenFeature
         /// initialization
         /// </param>
         /// <param name="afterShutdown">called after a provider is shutdown, can be used to remove event handlers</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel any async side effects.</param>
         public async ValueTask SetProviderAsync(
             FeatureProvider? featureProvider,
             EvaluationContext context,
@@ -155,7 +155,7 @@ namespace OpenFeature
         /// initialization
         /// </param>
         /// <param name="afterShutdown">called after a provider is shutdown, can be used to remove event handlers</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel any async side effects.</param>
         public async ValueTask SetProviderAsync(string clientName,
             FeatureProvider? featureProvider,
             EvaluationContext context,

--- a/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
+++ b/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Error;
@@ -45,7 +46,7 @@ namespace OpenFeature.Providers.Memory
         /// Updating provider flags configuration, replacing all flags.
         /// </summary>
         /// <param name="flags">the flags to use instead of the previous flags.</param>
-        public async ValueTask UpdateFlags(IDictionary<string, Flag>? flags = null)
+        public async Task UpdateFlags(IDictionary<string, Flag>? flags = null)
         {
             var changed = this._flags.Keys.ToList();
             if (flags == null)
@@ -68,46 +69,31 @@ namespace OpenFeature.Providers.Memory
         }
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<bool>> ResolveBooleanValue(
-            string flagKey,
-            bool defaultValue,
-            EvaluationContext? context = null)
+        public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(Resolve(flagKey, defaultValue, context));
         }
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<string>> ResolveStringValue(
-            string flagKey,
-            string defaultValue,
-            EvaluationContext? context = null)
+        public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(Resolve(flagKey, defaultValue, context));
         }
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<int>> ResolveIntegerValue(
-            string flagKey,
-            int defaultValue,
-            EvaluationContext? context = null)
+        public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(Resolve(flagKey, defaultValue, context));
         }
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<double>> ResolveDoubleValue(
-            string flagKey,
-            double defaultValue,
-            EvaluationContext? context = null)
+        public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(Resolve(flagKey, defaultValue, context));
         }
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<Value>> ResolveStructureValue(
-            string flagKey,
-            Value defaultValue,
-            EvaluationContext? context = null)
+        public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(Resolve(flagKey, defaultValue, context));
         }

--- a/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
+++ b/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
@@ -45,62 +45,62 @@ namespace OpenFeature.Benchmark
 
         [Benchmark]
         public async Task OpenFeatureClient_GetBooleanValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetBooleanValue(_flagName, _defaultBoolValue);
+            await _client.GetBooleanValueAsync(_flagName, _defaultBoolValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetBooleanValue(_flagName, _defaultBoolValue, EvaluationContext.Empty);
+            await _client.GetBooleanValueAsync(_flagName, _defaultBoolValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetBooleanValue(_flagName, _defaultBoolValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await _client.GetBooleanValueAsync(_flagName, _defaultBoolValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetStringValue(_flagName, _defaultStringValue);
+            await _client.GetStringValueAsync(_flagName, _defaultStringValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetStringValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetStringValue(_flagName, _defaultStringValue, EvaluationContext.Empty);
+            await _client.GetStringValueAsync(_flagName, _defaultStringValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetStringValue(_flagName, _defaultStringValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await _client.GetStringValueAsync(_flagName, _defaultStringValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetIntegerValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetIntegerValue(_flagName, _defaultIntegerValue);
+            await _client.GetIntegerValueAsync(_flagName, _defaultIntegerValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetIntegerValue(_flagName, _defaultIntegerValue, EvaluationContext.Empty);
+            await _client.GetIntegerValueAsync(_flagName, _defaultIntegerValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetIntegerValue(_flagName, _defaultIntegerValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await _client.GetIntegerValueAsync(_flagName, _defaultIntegerValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetDoubleValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetDoubleValue(_flagName, _defaultDoubleValue);
+            await _client.GetDoubleValueAsync(_flagName, _defaultDoubleValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetDoubleValue(_flagName, _defaultDoubleValue, EvaluationContext.Empty);
+            await _client.GetDoubleValueAsync(_flagName, _defaultDoubleValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetDoubleValue(_flagName, _defaultDoubleValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await _client.GetDoubleValueAsync(_flagName, _defaultDoubleValue, EvaluationContext.Empty, _emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetObjectValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetObjectValue(_flagName, _defaultStructureValue);
+            await _client.GetObjectValueAsync(_flagName, _defaultStructureValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetObjectValue(_flagName, _defaultStructureValue, EvaluationContext.Empty);
+            await _client.GetObjectValueAsync(_flagName, _defaultStructureValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetObjectValue(_flagName, _defaultStructureValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await _client.GetObjectValueAsync(_flagName, _defaultStructureValue, EvaluationContext.Empty, _emptyFlagOptions);
     }
 }

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -39,10 +39,10 @@ namespace OpenFeature.E2ETests
         }
 
         [Given(@"a provider is registered")]
-        public async Task GivenAProviderIsRegistered()
+        public void GivenAProviderIsRegistered()
         {
             var memProvider = new InMemoryProvider(e2eFlagConfig);
-            await Api.Instance.SetProviderAsync(memProvider).ConfigureAwait(false);
+            Api.Instance.SetProviderAsync(memProvider).Wait();
             client = Api.Instance.GetClient("TestClient", "1.0.0");
         }
 

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Extension;
@@ -39,10 +40,10 @@ namespace OpenFeature.E2ETests
         }
 
         [Given(@"a provider is registered")]
-        public void GivenAProviderIsRegistered()
+        public async void GivenAProviderIsRegistered()
         {
             var memProvider = new InMemoryProvider(e2eFlagConfig);
-            Api.Instance.SetProviderAsync(memProvider).Wait();
+            await Api.Instance.SetProviderAsync(memProvider).ConfigureAwait(false);
             client = Api.Instance.GetClient("TestClient", "1.0.0");
         }
 
@@ -218,7 +219,7 @@ namespace OpenFeature.E2ETests
         [Then(@"the resolved flag value is ""(.*)"" when the context is empty")]
         public void Giventheresolvedflagvalueiswhenthecontextisempty(string expected)
         {
-            string? emptyContextValue = client?.GetStringValueAsync(contextAwareFlagKey, contextAwareDefaultValue, new EvaluationContext(new Structure(ImmutableDictionary<string, Value>.Empty))).Result;
+            string? emptyContextValue = client?.GetStringValueAsync(contextAwareFlagKey!, contextAwareDefaultValue!, new EvaluationContext(new Structure(ImmutableDictionary<string, Value>.Empty))).Result;
             Assert.Equal(expected, emptyContextValue);
         }
 

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -39,7 +39,7 @@ namespace OpenFeature.E2ETests
         }
 
         [Given(@"a provider is registered")]
-        public async void GivenAProviderIsRegistered()
+        public async Task GivenAProviderIsRegistered()
         {
             var memProvider = new InMemoryProvider(e2eFlagConfig);
             await Api.Instance.SetProviderAsync(memProvider).ConfigureAwait(false);

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -49,7 +49,7 @@ namespace OpenFeature.E2ETests
         [When(@"a boolean flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Whenabooleanflagwithkeyisevaluatedwithdefaultvalue(string flagKey, bool defaultValue)
         {
-            this.booleanFlagValue = client?.GetBooleanValue(flagKey, defaultValue);
+            this.booleanFlagValue = client?.GetBooleanValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved boolean value should be ""(.*)""")]
@@ -61,7 +61,7 @@ namespace OpenFeature.E2ETests
         [When(@"a string flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Whenastringflagwithkeyisevaluatedwithdefaultvalue(string flagKey, string defaultValue)
         {
-            this.stringFlagValue = client?.GetStringValue(flagKey, defaultValue);
+            this.stringFlagValue = client?.GetStringValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved string value should be ""(.*)""")]
@@ -73,7 +73,7 @@ namespace OpenFeature.E2ETests
         [When(@"an integer flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void Whenanintegerflagwithkeyisevaluatedwithdefaultvalue(string flagKey, int defaultValue)
         {
-            this.intFlagValue = client?.GetIntegerValue(flagKey, defaultValue);
+            this.intFlagValue = client?.GetIntegerValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved integer value should be (.*)")]
@@ -85,7 +85,7 @@ namespace OpenFeature.E2ETests
         [When(@"a float flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void Whenafloatflagwithkeyisevaluatedwithdefaultvalue(string flagKey, double defaultValue)
         {
-            this.doubleFlagValue = client?.GetDoubleValue(flagKey, defaultValue);
+            this.doubleFlagValue = client?.GetDoubleValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved float value should be (.*)")]
@@ -97,7 +97,7 @@ namespace OpenFeature.E2ETests
         [When(@"an object flag with key ""(.*)"" is evaluated with a null default value")]
         public void Whenanobjectflagwithkeyisevaluatedwithanulldefaultvalue(string flagKey)
         {
-            this.objectFlagValue = client?.GetObjectValue(flagKey, new Value());
+            this.objectFlagValue = client?.GetObjectValueAsync(flagKey, new Value());
         }
 
         [Then(@"the resolved object value should be contain fields ""(.*)"", ""(.*)"", and ""(.*)"", with values ""(.*)"", ""(.*)"" and (.*), respectively")]
@@ -112,7 +112,7 @@ namespace OpenFeature.E2ETests
         [When(@"a boolean flag with key ""(.*)"" is evaluated with details and default value ""(.*)""")]
         public void Whenabooleanflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, bool defaultValue)
         {
-            this.booleanFlagDetails = client?.GetBooleanDetails(flagKey, defaultValue);
+            this.booleanFlagDetails = client?.GetBooleanDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved boolean details value should be ""(.*)"", the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -127,7 +127,7 @@ namespace OpenFeature.E2ETests
         [When(@"a string flag with key ""(.*)"" is evaluated with details and default value ""(.*)""")]
         public void Whenastringflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, string defaultValue)
         {
-            this.stringFlagDetails = client?.GetStringDetails(flagKey, defaultValue);
+            this.stringFlagDetails = client?.GetStringDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved string details value should be ""(.*)"", the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -142,7 +142,7 @@ namespace OpenFeature.E2ETests
         [When(@"an integer flag with key ""(.*)"" is evaluated with details and default value (.*)")]
         public void Whenanintegerflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, int defaultValue)
         {
-            this.intFlagDetails = client?.GetIntegerDetails(flagKey, defaultValue);
+            this.intFlagDetails = client?.GetIntegerDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved integer details value should be (.*), the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -157,7 +157,7 @@ namespace OpenFeature.E2ETests
         [When(@"a float flag with key ""(.*)"" is evaluated with details and default value (.*)")]
         public void Whenafloatflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, double defaultValue)
         {
-            this.doubleFlagDetails = client?.GetDoubleDetails(flagKey, defaultValue);
+            this.doubleFlagDetails = client?.GetDoubleDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved float details value should be (.*), the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -172,7 +172,7 @@ namespace OpenFeature.E2ETests
         [When(@"an object flag with key ""(.*)"" is evaluated with details and a null default value")]
         public void Whenanobjectflagwithkeyisevaluatedwithdetailsandanulldefaultvalue(string flagKey)
         {
-            this.objectFlagDetails = client?.GetObjectDetails(flagKey, new Value());
+            this.objectFlagDetails = client?.GetObjectDetailsAsync(flagKey, new Value());
         }
 
         [Then(@"the resolved object details value should be contain fields ""(.*)"", ""(.*)"", and ""(.*)"", with values ""(.*)"", ""(.*)"" and (.*), respectively")]
@@ -206,7 +206,7 @@ namespace OpenFeature.E2ETests
         {
             contextAwareFlagKey = flagKey;
             contextAwareDefaultValue = defaultValue;
-            contextAwareValue = client?.GetStringValue(flagKey, contextAwareDefaultValue, context)?.Result;
+            contextAwareValue = client?.GetStringValueAsync(flagKey, contextAwareDefaultValue, context)?.Result;
         }
 
         [Then(@"the resolved string response should be ""(.*)""")]
@@ -218,7 +218,7 @@ namespace OpenFeature.E2ETests
         [Then(@"the resolved flag value is ""(.*)"" when the context is empty")]
         public void Giventheresolvedflagvalueiswhenthecontextisempty(string expected)
         {
-            string? emptyContextValue = client?.GetStringValue(contextAwareFlagKey!, contextAwareDefaultValue!, new EvaluationContextBuilder().Build()).Result;
+            string? emptyContextValue = client?.GetStringValueAsync(contextAwareFlagKey, contextAwareDefaultValue, new EvaluationContext(new Structure(ImmutableDictionary<string, Value>.Empty))).Result;
             Assert.Equal(expected, emptyContextValue);
         }
 
@@ -227,7 +227,7 @@ namespace OpenFeature.E2ETests
         {
             this.notFoundFlagKey = flagKey;
             this.notFoundDefaultValue = defaultValue;
-            this.notFoundDetails = client?.GetStringDetails(this.notFoundFlagKey, this.notFoundDefaultValue).Result;
+            this.notFoundDetails = client?.GetStringDetailsAsync(this.notFoundFlagKey, this.notFoundDefaultValue).Result;
         }
 
         [Then(@"the default string value should be returned")]
@@ -248,7 +248,7 @@ namespace OpenFeature.E2ETests
         {
             this.typeErrorFlagKey = flagKey;
             this.typeErrorDefaultValue = defaultValue;
-            this.typeErrorDetails = client?.GetIntegerDetails(this.typeErrorFlagKey, this.typeErrorDefaultValue).Result;
+            this.typeErrorDetails = client?.GetIntegerDetailsAsync(this.typeErrorFlagKey, this.typeErrorDefaultValue).Result;
         }
 
         [Then(@"the default integer value should be returned")]

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Extension;
@@ -219,7 +218,7 @@ namespace OpenFeature.E2ETests
         [Then(@"the resolved flag value is ""(.*)"" when the context is empty")]
         public void Giventheresolvedflagvalueiswhenthecontextisempty(string expected)
         {
-            string? emptyContextValue = client?.GetStringValueAsync(contextAwareFlagKey!, contextAwareDefaultValue!, new EvaluationContext(new Structure(ImmutableDictionary<string, Value>.Empty))).Result;
+            string? emptyContextValue = client?.GetStringValueAsync(contextAwareFlagKey!, contextAwareDefaultValue!, EvaluationContext.Empty).Result;
             Assert.Equal(expected, emptyContextValue);
         }
 

--- a/test/OpenFeature.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderTests.cs
@@ -44,27 +44,27 @@ namespace OpenFeature.Tests
 
             var boolResolutionDetails = new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.None,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveBooleanValue(flagName, defaultBoolValue)).Should()
+            (await provider.ResolveBooleanValueAsync(flagName, defaultBoolValue)).Should()
                 .BeEquivalentTo(boolResolutionDetails);
 
             var integerResolutionDetails = new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.None,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveIntegerValue(flagName, defaultIntegerValue)).Should()
+            (await provider.ResolveIntegerValueAsync(flagName, defaultIntegerValue)).Should()
                 .BeEquivalentTo(integerResolutionDetails);
 
             var doubleResolutionDetails = new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.None,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveDoubleValue(flagName, defaultDoubleValue)).Should()
+            (await provider.ResolveDoubleValueAsync(flagName, defaultDoubleValue)).Should()
                 .BeEquivalentTo(doubleResolutionDetails);
 
             var stringResolutionDetails = new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.None,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveStringValue(flagName, defaultStringValue)).Should()
+            (await provider.ResolveStringValueAsync(flagName, defaultStringValue)).Should()
                 .BeEquivalentTo(stringResolutionDetails);
 
             var structureResolutionDetails = new ResolutionDetails<Value>(flagName, defaultStructureValue,
                 ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await provider.ResolveStructureValue(flagName, defaultStructureValue)).Should()
+            (await provider.ResolveStructureValueAsync(flagName, defaultStructureValue)).Should()
                 .BeEquivalentTo(structureResolutionDetails);
         }
 
@@ -84,59 +84,59 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             const string testMessage = "An error message";
 
-            providerMock.ResolveBooleanValue(flagName, defaultBoolValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveBooleanValueAsync(flagName, defaultBoolValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.General,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveIntegerValue(flagName, defaultIntegerValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveIntegerValueAsync(flagName, defaultIntegerValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.ParseError,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveDoubleValue(flagName, defaultDoubleValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveDoubleValueAsync(flagName, defaultDoubleValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.InvalidContext,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveStringValue(flagName, defaultStringValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveStringValueAsync(flagName, defaultStringValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.TypeMismatch,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveStructureValue(flagName, defaultStructureValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveStructureValueAsync(flagName, defaultStructureValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<Value>(flagName, defaultStructureValue, ErrorType.FlagNotFound,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveStructureValue(flagName2, defaultStructureValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveStructureValueAsync(flagName2, defaultStructureValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<Value>(flagName2, defaultStructureValue, ErrorType.ProviderNotReady,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-            providerMock.ResolveBooleanValue(flagName2, defaultBoolValue, Arg.Any<EvaluationContext>())
+            providerMock.ResolveBooleanValueAsync(flagName2, defaultBoolValue, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<bool>(flagName2, defaultBoolValue, ErrorType.TargetingKeyMissing,
                     NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
-            var boolRes = await providerMock.ResolveBooleanValue(flagName, defaultBoolValue);
+            var boolRes = await providerMock.ResolveBooleanValueAsync(flagName, defaultBoolValue);
             boolRes.ErrorType.Should().Be(ErrorType.General);
             boolRes.ErrorMessage.Should().Be(testMessage);
 
-            var intRes = await providerMock.ResolveIntegerValue(flagName, defaultIntegerValue);
+            var intRes = await providerMock.ResolveIntegerValueAsync(flagName, defaultIntegerValue);
             intRes.ErrorType.Should().Be(ErrorType.ParseError);
             intRes.ErrorMessage.Should().Be(testMessage);
 
-            var doubleRes = await providerMock.ResolveDoubleValue(flagName, defaultDoubleValue);
+            var doubleRes = await providerMock.ResolveDoubleValueAsync(flagName, defaultDoubleValue);
             doubleRes.ErrorType.Should().Be(ErrorType.InvalidContext);
             doubleRes.ErrorMessage.Should().Be(testMessage);
 
-            var stringRes = await providerMock.ResolveStringValue(flagName, defaultStringValue);
+            var stringRes = await providerMock.ResolveStringValueAsync(flagName, defaultStringValue);
             stringRes.ErrorType.Should().Be(ErrorType.TypeMismatch);
             stringRes.ErrorMessage.Should().Be(testMessage);
 
-            var structRes1 = await providerMock.ResolveStructureValue(flagName, defaultStructureValue);
+            var structRes1 = await providerMock.ResolveStructureValueAsync(flagName, defaultStructureValue);
             structRes1.ErrorType.Should().Be(ErrorType.FlagNotFound);
             structRes1.ErrorMessage.Should().Be(testMessage);
 
-            var structRes2 = await providerMock.ResolveStructureValue(flagName2, defaultStructureValue);
+            var structRes2 = await providerMock.ResolveStructureValueAsync(flagName2, defaultStructureValue);
             structRes2.ErrorType.Should().Be(ErrorType.ProviderNotReady);
             structRes2.ErrorMessage.Should().Be(testMessage);
 
-            var boolRes2 = await providerMock.ResolveBooleanValue(flagName2, defaultBoolValue);
+            var boolRes2 = await providerMock.ResolveBooleanValueAsync(flagName2, defaultBoolValue);
             boolRes2.ErrorType.Should().Be(ErrorType.TargetingKeyMissing);
             boolRes2.ErrorMessage.Should().BeNull();
         }

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -78,25 +78,25 @@ namespace OpenFeature.Tests
             await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetBooleanValue(flagName, defaultBoolValue)).Should().Be(defaultBoolValue);
-            (await client.GetBooleanValue(flagName, defaultBoolValue, EvaluationContext.Empty)).Should().Be(defaultBoolValue);
-            (await client.GetBooleanValue(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultBoolValue);
+            (await client.GetBooleanValueAsync(flagName, defaultBoolValue)).Should().Be(defaultBoolValue);
+            (await client.GetBooleanValueAsync(flagName, defaultBoolValue, EvaluationContext.Empty)).Should().Be(defaultBoolValue);
+            (await client.GetBooleanValueAsync(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultBoolValue);
 
-            (await client.GetIntegerValue(flagName, defaultIntegerValue)).Should().Be(defaultIntegerValue);
-            (await client.GetIntegerValue(flagName, defaultIntegerValue, EvaluationContext.Empty)).Should().Be(defaultIntegerValue);
-            (await client.GetIntegerValue(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultIntegerValue);
+            (await client.GetIntegerValueAsync(flagName, defaultIntegerValue)).Should().Be(defaultIntegerValue);
+            (await client.GetIntegerValueAsync(flagName, defaultIntegerValue, EvaluationContext.Empty)).Should().Be(defaultIntegerValue);
+            (await client.GetIntegerValueAsync(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultIntegerValue);
 
-            (await client.GetDoubleValue(flagName, defaultDoubleValue)).Should().Be(defaultDoubleValue);
-            (await client.GetDoubleValue(flagName, defaultDoubleValue, EvaluationContext.Empty)).Should().Be(defaultDoubleValue);
-            (await client.GetDoubleValue(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultDoubleValue);
+            (await client.GetDoubleValueAsync(flagName, defaultDoubleValue)).Should().Be(defaultDoubleValue);
+            (await client.GetDoubleValueAsync(flagName, defaultDoubleValue, EvaluationContext.Empty)).Should().Be(defaultDoubleValue);
+            (await client.GetDoubleValueAsync(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultDoubleValue);
 
-            (await client.GetStringValue(flagName, defaultStringValue)).Should().Be(defaultStringValue);
-            (await client.GetStringValue(flagName, defaultStringValue, EvaluationContext.Empty)).Should().Be(defaultStringValue);
-            (await client.GetStringValue(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultStringValue);
+            (await client.GetStringValueAsync(flagName, defaultStringValue)).Should().Be(defaultStringValue);
+            (await client.GetStringValueAsync(flagName, defaultStringValue, EvaluationContext.Empty)).Should().Be(defaultStringValue);
+            (await client.GetStringValueAsync(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions)).Should().Be(defaultStringValue);
 
-            (await client.GetObjectValue(flagName, defaultStructureValue)).Should().BeEquivalentTo(defaultStructureValue);
-            (await client.GetObjectValue(flagName, defaultStructureValue, EvaluationContext.Empty)).Should().BeEquivalentTo(defaultStructureValue);
-            (await client.GetObjectValue(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(defaultStructureValue);
+            (await client.GetObjectValueAsync(flagName, defaultStructureValue)).Should().BeEquivalentTo(defaultStructureValue);
+            (await client.GetObjectValueAsync(flagName, defaultStructureValue, EvaluationContext.Empty)).Should().BeEquivalentTo(defaultStructureValue);
+            (await client.GetObjectValueAsync(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(defaultStructureValue);
         }
 
         [Fact]
@@ -125,29 +125,29 @@ namespace OpenFeature.Tests
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
             var boolFlagEvaluationDetails = new FlagEvaluationDetails<bool>(flagName, defaultBoolValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await client.GetBooleanDetails(flagName, defaultBoolValue)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
-            (await client.GetBooleanDetails(flagName, defaultBoolValue, EvaluationContext.Empty)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
-            (await client.GetBooleanDetails(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
+            (await client.GetBooleanDetailsAsync(flagName, defaultBoolValue)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
+            (await client.GetBooleanDetailsAsync(flagName, defaultBoolValue, EvaluationContext.Empty)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
+            (await client.GetBooleanDetailsAsync(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
 
             var integerFlagEvaluationDetails = new FlagEvaluationDetails<int>(flagName, defaultIntegerValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await client.GetIntegerDetails(flagName, defaultIntegerValue)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
-            (await client.GetIntegerDetails(flagName, defaultIntegerValue, EvaluationContext.Empty)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
-            (await client.GetIntegerDetails(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
+            (await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
+            (await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue, EvaluationContext.Empty)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
+            (await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(integerFlagEvaluationDetails);
 
             var doubleFlagEvaluationDetails = new FlagEvaluationDetails<double>(flagName, defaultDoubleValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await client.GetDoubleDetails(flagName, defaultDoubleValue)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
-            (await client.GetDoubleDetails(flagName, defaultDoubleValue, EvaluationContext.Empty)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
-            (await client.GetDoubleDetails(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
+            (await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
+            (await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue, EvaluationContext.Empty)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
+            (await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(doubleFlagEvaluationDetails);
 
             var stringFlagEvaluationDetails = new FlagEvaluationDetails<string>(flagName, defaultStringValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await client.GetStringDetails(flagName, defaultStringValue)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
-            (await client.GetStringDetails(flagName, defaultStringValue, EvaluationContext.Empty)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
-            (await client.GetStringDetails(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
+            (await client.GetStringDetailsAsync(flagName, defaultStringValue)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
+            (await client.GetStringDetailsAsync(flagName, defaultStringValue, EvaluationContext.Empty)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
+            (await client.GetStringDetailsAsync(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(stringFlagEvaluationDetails);
 
             var structureFlagEvaluationDetails = new FlagEvaluationDetails<Value>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-            (await client.GetObjectDetails(flagName, defaultStructureValue)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
-            (await client.GetObjectDetails(flagName, defaultStructureValue, EvaluationContext.Empty)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
-            (await client.GetObjectDetails(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
+            (await client.GetObjectDetailsAsync(flagName, defaultStructureValue)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
+            (await client.GetObjectDetailsAsync(flagName, defaultStructureValue, EvaluationContext.Empty)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
+            (await client.GetObjectDetailsAsync(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions)).Should().BeEquivalentTo(structureFlagEvaluationDetails);
         }
 
         [Fact]
@@ -168,18 +168,18 @@ namespace OpenFeature.Tests
             var mockedLogger = Substitute.For<ILogger<Api>>();
 
             // This will fail to case a String to TestStructure
-            mockedFeatureProvider.ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Throws<InvalidCastException>();
+            mockedFeatureProvider.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Throws<InvalidCastException>();
             mockedFeatureProvider.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             mockedFeatureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(mockedFeatureProvider);
             var client = Api.Instance.GetClient(clientName, clientVersion, mockedLogger);
 
-            var evaluationDetails = await client.GetObjectDetails(flagName, defaultValue);
+            var evaluationDetails = await client.GetObjectDetailsAsync(flagName, defaultValue);
             evaluationDetails.ErrorType.Should().Be(ErrorType.TypeMismatch);
             evaluationDetails.ErrorMessage.Should().Be(new InvalidCastException().Message);
 
-            _ = mockedFeatureProvider.Received(1).ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = mockedFeatureProvider.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
 
             mockedLogger.Received(1).IsEnabled(LogLevel.Error);
         }
@@ -194,16 +194,16 @@ namespace OpenFeature.Tests
             var defaultValue = fixture.Create<bool>();
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveBooleanValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>(flagName, defaultValue));
+            featureProviderMock.ResolveBooleanValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>(flagName, defaultValue));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetBooleanValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetBooleanValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
-            _ = featureProviderMock.Received(1).ResolveBooleanValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveBooleanValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -216,16 +216,16 @@ namespace OpenFeature.Tests
             var defaultValue = fixture.Create<string>();
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveStringValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<string>(flagName, defaultValue));
+            featureProviderMock.ResolveStringValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<string>(flagName, defaultValue));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetStringValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetStringValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
-            _ = featureProviderMock.Received(1).ResolveStringValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveStringValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -238,16 +238,16 @@ namespace OpenFeature.Tests
             var defaultValue = fixture.Create<int>();
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveIntegerValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<int>(flagName, defaultValue));
+            featureProviderMock.ResolveIntegerValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<int>(flagName, defaultValue));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetIntegerValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetIntegerValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
-            _ = featureProviderMock.Received(1).ResolveIntegerValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveIntegerValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -260,16 +260,16 @@ namespace OpenFeature.Tests
             var defaultValue = fixture.Create<double>();
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveDoubleValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<double>(flagName, defaultValue));
+            featureProviderMock.ResolveDoubleValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<double>(flagName, defaultValue));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetDoubleValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetDoubleValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
-            _ = featureProviderMock.Received(1).ResolveDoubleValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveDoubleValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -282,16 +282,16 @@ namespace OpenFeature.Tests
             var defaultValue = fixture.Create<Value>();
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<Value>(flagName, defaultValue));
+            featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<Value>(flagName, defaultValue));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
 
-            (await client.GetObjectValue(flagName, defaultValue)).Should().Be(defaultValue);
+            (await client.GetObjectValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
-            _ = featureProviderMock.Received(1).ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -305,18 +305,18 @@ namespace OpenFeature.Tests
             const string testMessage = "Couldn't parse flag data.";
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(Task.FromResult(new ResolutionDetails<Value>(flagName, defaultValue, ErrorType.ParseError, "ERROR", null, testMessage)));
+            featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(Task.FromResult(new ResolutionDetails<Value>(flagName, defaultValue, ErrorType.ParseError, "ERROR", null, testMessage)));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
-            var response = await client.GetObjectDetails(flagName, defaultValue);
+            var response = await client.GetObjectDetailsAsync(flagName, defaultValue);
 
             response.ErrorType.Should().Be(ErrorType.ParseError);
             response.Reason.Should().Be(Reason.Error);
             response.ErrorMessage.Should().Be(testMessage);
-            _ = featureProviderMock.Received(1).ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -330,18 +330,18 @@ namespace OpenFeature.Tests
             const string testMessage = "Couldn't parse flag data.";
 
             var featureProviderMock = Substitute.For<FeatureProvider>();
-            featureProviderMock.ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>()).Throws(new FeatureProviderException(ErrorType.ParseError, testMessage));
+            featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Throws(new FeatureProviderException(ErrorType.ParseError, testMessage));
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
             var client = Api.Instance.GetClient(clientName, clientVersion);
-            var response = await client.GetObjectDetails(flagName, defaultValue);
+            var response = await client.GetObjectDetailsAsync(flagName, defaultValue);
 
             response.ErrorType.Should().Be(ErrorType.ParseError);
             response.Reason.Should().Be(Reason.Error);
             response.ErrorMessage.Should().Be(testMessage);
-            _ = featureProviderMock.Received(1).ResolveStructureValue(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -349,7 +349,7 @@ namespace OpenFeature.Tests
         {
             await Api.Instance.SetProviderAsync(null);
             var client = new FeatureClient("test", "test");
-            (await client.GetIntegerValue("some-key", 12)).Should().Be(12);
+            (await client.GetIntegerValueAsync("some-key", 12)).Should().Be(12);
         }
 
         [Fact]

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -345,14 +345,6 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        public async Task Should_Use_No_Op_When_Provider_Is_Null()
-        {
-            await Api.Instance.SetProviderAsync(null);
-            var client = new FeatureClient("test", "test");
-            (await client.GetIntegerValueAsync("some-key", 12)).Should().Be(12);
-        }
-
-        [Fact]
         public void Should_Get_And_Set_Context()
         {
             var fixture = new Fixture();

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -148,7 +148,7 @@ namespace OpenFeature.Tests
 
             var testProvider = new TestProvider();
 #pragma warning disable CS0618// Type or member is obsolete
-            Api.Instance.SetProvider(testProvider);
+            await Api.Instance.SetProviderAsync(testProvider);
 #pragma warning restore CS0618// Type or member is obsolete
 
             Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -46,7 +46,7 @@ namespace OpenFeature.Tests
             eventHandler.Received().Invoke(Arg.Is<ProviderEventPayload>(payload => payload == myEvent.EventPayload));
 
             // shut down the event executor
-            await eventExecutor.Shutdown();
+            await eventExecutor.ShutdownAsync();
 
             // the next event should not be propagated to the event handler
             var newEventPayload = new ProviderEventPayload
@@ -78,9 +78,9 @@ namespace OpenFeature.Tests
             var testProvider = new TestProvider();
             await Api.Instance.SetProviderAsync(testProvider);
 
-            testProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
-            testProvider.SendEvent(ProviderEventTypes.ProviderError);
-            testProvider.SendEvent(ProviderEventTypes.ProviderStale);
+            await testProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
+            await testProvider.SendEventAsync(ProviderEventTypes.ProviderError);
+            await testProvider.SendEventAsync(ProviderEventTypes.ProviderStale);
 
             await Utils.AssertUntilAsync(_ => eventHandler
                 .Received()
@@ -228,12 +228,12 @@ namespace OpenFeature.Tests
             var testProvider = new TestProvider();
             await Api.Instance.SetProviderAsync(testProvider);
 
-            testProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
+            await testProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
 
             var newTestProvider = new TestProvider();
             await Api.Instance.SetProviderAsync(newTestProvider);
 
-            newTestProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
+            await newTestProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
 
             await Utils.AssertUntilAsync(
                 _ => eventHandler.Received(2).Invoke(Arg.Is<ProviderEventPayload>(payload => payload.ProviderName == testProvider.GetMetadata().Name && payload.Type == ProviderEventTypes.ProviderReady))
@@ -407,7 +407,7 @@ namespace OpenFeature.Tests
 
             client.AddHandler(ProviderEventTypes.ProviderConfigurationChanged, clientEventHandler);
 
-            defaultProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
+            await defaultProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
 
             // verify that the client received the event from the default provider as there is no named provider registered yet
             await Utils.AssertUntilAsync(
@@ -419,8 +419,8 @@ namespace OpenFeature.Tests
             await Api.Instance.SetProviderAsync(client.GetMetadata().Name!, clientProvider);
 
             // now, send another event for the default handler
-            defaultProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
-            clientProvider.SendEvent(ProviderEventTypes.ProviderConfigurationChanged);
+            await defaultProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
+            await clientProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
 
             // now the client should have received only the event from the named provider
             await Utils.AssertUntilAsync(
@@ -479,7 +479,7 @@ namespace OpenFeature.Tests
             await Utils.AssertUntilAsync(_ => myClient.RemoveHandler(ProviderEventTypes.ProviderReady, eventHandler));
 
             // send another event from the provider - this one should not be received
-            testProvider.SendEvent(ProviderEventTypes.ProviderReady);
+            await testProvider.SendEventAsync(ProviderEventTypes.ProviderReady);
 
             // wait a bit and make sure we only have received the first event, but nothing after removing the event handler
             await Utils.AssertUntilAsync(

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -35,18 +35,18 @@ namespace OpenFeature.Tests
             var providerHook = Substitute.For<Hook>();
 
             // Sequence
-            apiHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-            clientHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-            invocationHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-            providerHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-            providerHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            invocationHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            clientHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            apiHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            providerHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            invocationHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            clientHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
-            apiHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(Task.CompletedTask);
+            apiHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
+            clientHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
+            invocationHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
+            providerHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
+            providerHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
 
             var testProvider = new TestProvider();
             testProvider.AddHook(providerHook);
@@ -55,37 +55,37 @@ namespace OpenFeature.Tests
             var client = Api.Instance.GetClient(clientName, clientVersion);
             client.AddHooks(clientHook);
 
-            await client.GetBooleanValue(flagName, defaultValue, EvaluationContext.Empty,
+            await client.GetBooleanValueAsync(flagName, defaultValue, EvaluationContext.Empty,
                 new FlagEvaluationOptions(invocationHook, ImmutableDictionary<string, object>.Empty));
 
             Received.InOrder(() =>
             {
-                apiHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                clientHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                invocationHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                providerHook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                providerHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                invocationHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                clientHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                apiHook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                providerHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                invocationHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                clientHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                apiHook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                apiHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                clientHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                invocationHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                providerHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                providerHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
             });
 
-            _ = apiHook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = clientHook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = invocationHook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = providerHook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = providerHook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = invocationHook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = clientHook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = apiHook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = providerHook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = invocationHook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = clientHook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = apiHook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = apiHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = clientHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = invocationHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = providerHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = providerHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = invocationHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = clientHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = apiHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = providerHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = invocationHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = clientHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = apiHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
         }
 
         [Fact]
@@ -139,15 +139,15 @@ namespace OpenFeature.Tests
                 FlagValueType.Boolean, new ClientMetadata("test", "1.0.0"), new Metadata(NoOpProvider.NoOpProviderName),
                 evaluationContext);
 
-            hook1.Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>()).Returns(evaluationContext);
-            hook2.Before(hookContext, Arg.Any<ImmutableDictionary<string, object>>()).Returns(evaluationContext);
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>()).Returns(evaluationContext);
+            hook2.BeforeAsync(hookContext, Arg.Any<ImmutableDictionary<string, object>>()).Returns(evaluationContext);
 
             var client = Api.Instance.GetClient("test", "1.0.0");
-            await client.GetBooleanValue("test", false, EvaluationContext.Empty,
+            await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty,
                 new FlagEvaluationOptions(ImmutableList.Create(hook1, hook2), ImmutableDictionary<string, object>.Empty));
 
-            _ = hook1.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-            _ = hook2.Received(1).Before(Arg.Is<HookContext<bool>>(a => a.EvaluationContext.GetValue("test").AsString == "test"), Arg.Any<ImmutableDictionary<string, object>>());
+            _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+            _ = hook2.Received(1).BeforeAsync(Arg.Is<HookContext<bool>>(a => a.EvaluationContext.GetValue("test").AsString == "test"), Arg.Any<ImmutableDictionary<string, object>>());
         }
 
         [Fact]
@@ -195,19 +195,19 @@ namespace OpenFeature.Tests
 
             provider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            provider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", true));
+            provider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", true));
 
             await Api.Instance.SetProviderAsync(provider);
 
             var hook = Substitute.For<Hook>();
-            hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>()).Returns(hookContext);
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>()).Returns(hookContext);
 
 
             var client = Api.Instance.GetClient("test", "1.0.0", null, clientContext);
-            await client.GetBooleanValue("test", false, invocationContext, new FlagEvaluationOptions(ImmutableList.Create(hook), ImmutableDictionary<string, object>.Empty));
+            await client.GetBooleanValueAsync("test", false, invocationContext, new FlagEvaluationOptions(ImmutableList.Create(hook), ImmutableDictionary<string, object>.Empty));
 
             // after proper merging, all properties should equal true
-            _ = provider.Received(1).ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Is<EvaluationContext>(y =>
+            _ = provider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Is<EvaluationContext>(y =>
                 (y.GetValue(propGlobal).AsBoolean ?? false)
                 && (y.GetValue(propClient).AsBoolean ?? false)
                 && (y.GetValue(propGlobalToOverwrite).AsBoolean ?? false)
@@ -238,10 +238,10 @@ namespace OpenFeature.Tests
             var hookContext = new HookContext<bool>("test", false, FlagValueType.Boolean,
                 new ClientMetadata(null, null), new Metadata(null), EvaluationContext.Empty);
 
-            await hook.Before(hookContext, hookHints);
-            await hook.After(hookContext, new FlagEvaluationDetails<bool>("test", false, ErrorType.None, "testing", "testing"), hookHints);
-            await hook.Finally(hookContext, hookHints);
-            await hook.Error(hookContext, new Exception(), hookHints);
+            await hook.BeforeAsync(hookContext, hookHints);
+            await hook.AfterAsync(hookContext, new FlagEvaluationDetails<bool>("test", false, ErrorType.None, "testing", "testing"), hookHints);
+            await hook.FinallyAsync(hookContext, hookHints);
+            await hook.ErrorAsync(hookContext, new Exception(), hookHints);
 
             hookContext.ClientMetadata.Name.Should().BeNull();
             hookContext.ClientMetadata.Version.Should().BeNull();
@@ -264,29 +264,29 @@ namespace OpenFeature.Tests
             featureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             // Sequence
-            hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Returns(EvaluationContext.Empty);
-            featureProvider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
-            _ = hook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Returns(EvaluationContext.Empty);
+            featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
+            _ = hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
 
             await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(hook);
 
-            await client.GetBooleanValue("test", false);
+            await client.GetBooleanValueAsync("test", false);
 
             Received.InOrder(() =>
             {
-                hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-                featureProvider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-                hook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-                hook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+                hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+                featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
+                hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
+                hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
             });
 
-            _ = hook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = featureProvider.Received(1).ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
+            _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = featureProvider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
         }
 
         [Fact]
@@ -304,7 +304,7 @@ namespace OpenFeature.Tests
             await Api.Instance.SetProviderAsync(testProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(hook2);
-            await client.GetBooleanValue("test", false, null,
+            await client.GetBooleanValueAsync("test", false, null,
                 new FlagEvaluationOptions(hook3, ImmutableDictionary<string, object>.Empty));
 
             Assert.Single(Api.Instance.GetHooks());
@@ -324,39 +324,39 @@ namespace OpenFeature.Tests
             featureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             // Sequence
-            hook1.Before(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-            hook2.Before(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-            featureProvider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
-            hook2.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(Task.CompletedTask);
-            hook1.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(Task.CompletedTask);
-            hook2.Finally(Arg.Any<HookContext<bool>>(), null).Returns(Task.CompletedTask);
-            hook1.Finally(Arg.Any<HookContext<bool>>(), null).Throws(new Exception());
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
+            hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
+            featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
+            hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
+            hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
+            hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Returns(new ValueTask());
+            hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Throws(new Exception());
 
             await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(new[] { hook1, hook2 });
             client.GetHooks().Count().Should().Be(2);
 
-            await client.GetBooleanValue("test", false);
+            await client.GetBooleanValueAsync("test", false);
 
             Received.InOrder(() =>
             {
-                hook1.Before(Arg.Any<HookContext<bool>>(), null);
-                hook2.Before(Arg.Any<HookContext<bool>>(), null);
-                featureProvider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-                hook2.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-                hook1.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-                hook2.Finally(Arg.Any<HookContext<bool>>(), null);
-                hook1.Finally(Arg.Any<HookContext<bool>>(), null);
+                hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+                hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+                featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
+                hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+                hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+                hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), null);
+                hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), null);
             });
 
-            _ = hook1.Received(1).Before(Arg.Any<HookContext<bool>>(), null);
-            _ = hook2.Received(1).Before(Arg.Any<HookContext<bool>>(), null);
-            _ = featureProvider.Received(1).ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-            _ = hook2.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-            _ = hook1.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-            _ = hook2.Received(1).Finally(Arg.Any<HookContext<bool>>(), null);
-            _ = hook1.Received(1).Finally(Arg.Any<HookContext<bool>>(), null);
+            _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook2.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = featureProvider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
+            _ = hook2.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+            _ = hook1.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+            _ = hook2.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook1.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), null);
         }
 
         [Fact]
@@ -371,31 +371,31 @@ namespace OpenFeature.Tests
             featureProvider1.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             // Sequence
-            hook1.Before(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-            hook2.Before(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-            featureProvider1.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Throws(new Exception());
-            hook2.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
-            hook1.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
+            hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
+            featureProvider1.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Throws(new Exception());
+            hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(new ValueTask());
+            hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(new ValueTask());
 
             await Api.Instance.SetProviderAsync(featureProvider1);
             var client = Api.Instance.GetClient();
             client.AddHooks(new[] { hook1, hook2 });
 
-            await client.GetBooleanValue("test", false);
+            await client.GetBooleanValueAsync("test", false);
 
             Received.InOrder(() =>
             {
-                hook1.Before(Arg.Any<HookContext<bool>>(), null);
-                hook2.Before(Arg.Any<HookContext<bool>>(), null);
-                featureProvider1.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-                hook2.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-                hook1.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+                hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+                hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+                featureProvider1.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
+                hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+                hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
             });
 
-            _ = hook1.Received(1).Before(Arg.Any<HookContext<bool>>(), null);
-            _ = hook2.Received(1).Before(Arg.Any<HookContext<bool>>(), null);
-            _ = hook1.Received(1).Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-            _ = hook2.Received(1).Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook2.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook1.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            _ = hook2.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
         }
 
         [Fact]
@@ -410,27 +410,27 @@ namespace OpenFeature.Tests
             featureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             // Sequence
-            hook1.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).ThrowsAsync(new Exception());
-            _ = hook1.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-            _ = hook2.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Throws(new Exception());
+            _ = hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            _ = hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
 
             await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
             client.AddHooks(new[] { hook1, hook2 });
 
-            await client.GetBooleanValue("test", false);
+            await client.GetBooleanValueAsync("test", false);
 
             Received.InOrder(() =>
             {
-                hook1.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-                hook2.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-                hook1.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+                hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+                hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+                hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
             });
 
-            _ = hook1.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook2.DidNotReceive().Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook1.Received(1).Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-            _ = hook2.Received(1).Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook2.DidNotReceive().BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook1.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            _ = hook2.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
         }
 
         [Fact]
@@ -447,29 +447,29 @@ namespace OpenFeature.Tests
             featureProvider.GetProviderHooks()
                 .Returns(ImmutableList<Hook>.Empty);
 
-            hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(EvaluationContext.Empty);
 
-            featureProvider.ResolveBooleanValue("test", false, Arg.Any<EvaluationContext>())
+            featureProvider.ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<bool>("test", false));
 
-            hook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-                .Returns(Task.FromResult(Task.CompletedTask));
+            hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+                .Returns(new ValueTask());
 
-            hook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-                .Returns(Task.CompletedTask);
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+                .Returns(new ValueTask());
 
             await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
 
-            await client.GetBooleanValue("test", false, EvaluationContext.Empty, flagOptions);
+            await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty, flagOptions);
 
             Received.InOrder(() =>
             {
-                hook.Received().Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-                featureProvider.Received().ResolveBooleanValue("test", false, Arg.Any<EvaluationContext>());
-                hook.Received().After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-                hook.Received().Finally(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received().BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                featureProvider.Received().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>());
+                hook.Received().AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received().FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
             });
         }
 
@@ -485,26 +485,26 @@ namespace OpenFeature.Tests
             featureProvider.GetMetadata().Returns(new Metadata(null));
 
             // Sequence
-            hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).ThrowsAsync(exceptionToThrow);
-            hook.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(Task.CompletedTask);
-            hook.Finally(Arg.Any<HookContext<bool>>(), null).Returns(Task.CompletedTask);
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Throws(exceptionToThrow);
+            hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(new ValueTask());
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Returns(new ValueTask());
 
             var client = Api.Instance.GetClient();
             client.AddHooks(hook);
 
-            var resolvedFlag = await client.GetBooleanValue("test", true);
+            var resolvedFlag = await client.GetBooleanValueAsync("test", true);
 
             Received.InOrder(() =>
             {
-                hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-                hook.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-                hook.Finally(Arg.Any<HookContext<bool>>(), null);
+                hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+                hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+                hook.FinallyAsync(Arg.Any<HookContext<bool>>(), null);
             });
 
             resolvedFlag.Should().BeTrue();
-            _ = hook.Received(1).Before(Arg.Any<HookContext<bool>>(), null);
-            _ = hook.Received(1).Error(Arg.Any<HookContext<bool>>(), exceptionToThrow, null);
-            _ = hook.Received(1).Finally(Arg.Any<HookContext<bool>>(), null);
+            _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), exceptionToThrow, null);
+            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), null);
         }
 
         [Fact]
@@ -522,36 +522,36 @@ namespace OpenFeature.Tests
             featureProvider.GetProviderHooks()
                 .Returns(ImmutableList<Hook>.Empty);
 
-            hook.Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(EvaluationContext.Empty);
 
-            featureProvider.ResolveBooleanValue(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>())
+            featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>())
                 .Returns(new ResolutionDetails<bool>("test", false));
 
-            hook.After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-                .ThrowsAsync(exceptionToThrow);
+            hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+                .Throws(exceptionToThrow);
 
-            hook.Error(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>())
-                .Returns(Task.CompletedTask);
+            hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>())
+                .Returns(new ValueTask());
 
-            hook.Finally(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-                .Returns(Task.CompletedTask);
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+                .Returns(new ValueTask());
 
             await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
 
-            var resolvedFlag = await client.GetBooleanValue("test", true, config: flagOptions);
+            var resolvedFlag = await client.GetBooleanValueAsync("test", true, config: flagOptions);
 
             resolvedFlag.Should().BeTrue();
 
             Received.InOrder(() =>
             {
-                hook.Received(1).Before(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-                hook.Received(1).After(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-                hook.Received(1).Finally(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
             });
 
-            await featureProvider.DidNotReceive().ResolveBooleanValue("test", false, Arg.Any<EvaluationContext>());
+            await featureProvider.DidNotReceive().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>());
         }
 
         [Fact]

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
@@ -15,8 +13,6 @@ namespace OpenFeature.Tests
     [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
     public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
     {
-        static ValueTask EmptyShutdown(CancellationToken cancellationToken) => new ValueTask();
-
         [Fact]
         [Specification("1.1.1", "The `API`, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the `API` are present at runtime.")]
         public void OpenFeature_Should_Be_Singleton()
@@ -34,14 +30,14 @@ namespace OpenFeature.Tests
             var providerMockDefault = Substitute.For<FeatureProvider>();
             providerMockDefault.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync(providerMockDefault).ConfigureAwait(false);
-            await providerMockDefault.Received(1).InitializeAsync(Api.Instance.GetContext()).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerMockDefault);
+            await providerMockDefault.Received(1).InitializeAsync(Api.Instance.GetContext());
 
             var providerMockNamed = Substitute.For<FeatureProvider>();
             providerMockNamed.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync("the-name", providerMockNamed).ConfigureAwait(false);
-            await providerMockNamed.Received(1).InitializeAsync(Api.Instance.GetContext()).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync("the-name", providerMockNamed);
+            await providerMockNamed.Received(1).InitializeAsync(Api.Instance.GetContext());
         }
 
         [Fact]
@@ -52,28 +48,28 @@ namespace OpenFeature.Tests
             var providerA = Substitute.For<FeatureProvider>();
             providerA.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync(providerA).ConfigureAwait(false);
-            await providerA.Received(1).InitializeAsync(Api.Instance.GetContext()).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerA);
+            await providerA.Received(1).InitializeAsync(Api.Instance.GetContext());
 
             var providerB = Substitute.For<FeatureProvider>();
             providerB.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync(providerB).ConfigureAwait(false);
-            await providerB.Received(1).InitializeAsync(Api.Instance.GetContext()).ConfigureAwait(false);
-            await providerA.Received(1).ShutdownAsync().ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerB);
+            await providerB.Received(1).InitializeAsync(Api.Instance.GetContext());
+            await providerA.Received(1).ShutdownAsync();
 
             var providerC = Substitute.For<FeatureProvider>();
             providerC.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync("named", providerC).ConfigureAwait(false);
-            await providerC.Received(1).InitializeAsync(Api.Instance.GetContext()).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync("named", providerC);
+            await providerC.Received(1).InitializeAsync(Api.Instance.GetContext());
 
             var providerD = Substitute.For<FeatureProvider>();
             providerD.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync("named", providerD).ConfigureAwait(false);
-            await providerD.Received(1).InitializeAsync(Api.Instance.GetContext()).ConfigureAwait(false);
-            await providerC.Received(1).ShutdownAsync().ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync("named", providerD);
+            await providerD.Received(1).InitializeAsync(Api.Instance.GetContext());
+            await providerC.Received(1).ShutdownAsync();
         }
 
         [Fact]
@@ -86,13 +82,13 @@ namespace OpenFeature.Tests
             var providerB = Substitute.For<FeatureProvider>();
             providerB.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await Api.Instance.SetProviderAsync(providerA).ConfigureAwait(false);
-            await Api.Instance.SetProviderAsync("named", providerB).ConfigureAwait(false);
+            await Api.Instance.SetProviderAsync(providerA);
+            await Api.Instance.SetProviderAsync("named", providerB);
 
-            await Api.Instance.ShutdownAsync().ConfigureAwait(false);
+            await Api.Instance.ShutdownAsync();
 
-            await providerA.Received(1).ShutdownAsync().ConfigureAwait(false);
-            await providerB.Received(1).ShutdownAsync().ConfigureAwait(false);
+            await providerA.Received(1).ShutdownAsync();
+            await providerB.Received(1).ShutdownAsync();
         }
 
         [Fact]
@@ -101,8 +97,8 @@ namespace OpenFeature.Tests
         {
             var openFeature = Api.Instance;
 
-            await openFeature.SetProviderAsync(new NoOpFeatureProvider()).ConfigureAwait(false);
-            await openFeature.SetProviderAsync(TestProvider.DefaultName, new TestProvider()).ConfigureAwait(false);
+            await openFeature.SetProviderAsync(new NoOpFeatureProvider());
+            await openFeature.SetProviderAsync(TestProvider.DefaultName, new TestProvider());
 
             var defaultClient = openFeature.GetProviderMetadata();
             var namedClient = openFeature.GetProviderMetadata(TestProvider.DefaultName);
@@ -117,7 +113,7 @@ namespace OpenFeature.Tests
         {
             var openFeature = Api.Instance;
 
-            await openFeature.SetProviderAsync(new TestProvider()).ConfigureAwait(false);
+            await openFeature.SetProviderAsync(new TestProvider());
 
             var defaultClient = openFeature.GetProviderMetadata();
 
@@ -131,8 +127,8 @@ namespace OpenFeature.Tests
             const string name = "new-client";
             var openFeature = Api.Instance;
 
-            await openFeature.SetProviderAsync(name, new TestProvider()).ConfigureAwait(false);
-            await openFeature.SetProviderAsync(name, new NoOpFeatureProvider()).ConfigureAwait(false);
+            await openFeature.SetProviderAsync(name, new TestProvider());
+            await openFeature.SetProviderAsync(name, new NoOpFeatureProvider());
 
             openFeature.GetProviderMetadata(name).Name.Should().Be(NoOpProvider.NoOpProviderName);
         }
@@ -144,8 +140,8 @@ namespace OpenFeature.Tests
             var openFeature = Api.Instance;
             var provider = new TestProvider();
 
-            await openFeature.SetProviderAsync("a", provider).ConfigureAwait(false);
-            await openFeature.SetProviderAsync("b", provider).ConfigureAwait(false);
+            await openFeature.SetProviderAsync("a", provider);
+            await openFeature.SetProviderAsync("b", provider);
 
             var clientA = openFeature.GetProvider("a");
             var clientB = openFeature.GetProvider("b");
@@ -186,7 +182,7 @@ namespace OpenFeature.Tests
         [Specification("1.1.5", "The API MUST provide a function for retrieving the metadata field of the configured `provider`.")]
         public async Task OpenFeature_Should_Get_Metadata()
         {
-            Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).GetAwaiter().GetResult();
+            await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
             var openFeature = Api.Instance;
             var metadata = openFeature.GetProviderMetadata();
 
@@ -236,8 +232,8 @@ namespace OpenFeature.Tests
         {
             var openFeature = Api.Instance;
 
-            await openFeature.SetProviderAsync("client1", new TestProvider()).ConfigureAwait(false);
-            await openFeature.SetProviderAsync("client2", new NoOpFeatureProvider()).ConfigureAwait(false);
+            await openFeature.SetProviderAsync("client1", new TestProvider());
+            await openFeature.SetProviderAsync("client2", new NoOpFeatureProvider());
 
             var client1 = openFeature.GetClient("client1");
             var client2 = openFeature.GetClient("client2");
@@ -245,8 +241,8 @@ namespace OpenFeature.Tests
             client1.GetMetadata().Name.Should().Be("client1");
             client2.GetMetadata().Name.Should().Be("client2");
 
-            client1.GetBooleanValueAsync("test", false).Result.Should().BeTrue();
-            client2.GetBooleanValueAsync("test", false).Result.Should().BeFalse();
+            (await client1.GetBooleanValueAsync("test", false)).Should().BeTrue();
+            (await client2.GetBooleanValueAsync("test", false)).Should().BeFalse();
         }
     }
 }

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -26,7 +26,7 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        public async void AfterSet_Is_Invoked_For_Setting_Default_Provider()
+        public async Task AfterSet_Is_Invoked_For_Setting_Default_Provider()
         {
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -22,7 +22,7 @@ namespace OpenFeature.Tests
             var provider = new NoOpFeatureProvider();
             var context = new EvaluationContextBuilder().Build();
             // TODO: huh?? await??
-            repository.SetProviderAsync(provider, context);
+            await repository.SetProviderAsync(provider, context);
             Assert.Equal(provider, repository.GetProvider());
         }
 
@@ -35,7 +35,7 @@ namespace OpenFeature.Tests
             var callCount = 0;
             // The setting of the provider is synchronous, so the afterSet should be as well.
             // TODO: huh?? await??
-            repository.SetProviderAsync(provider, context, afterSet: (theProvider) =>
+            await repository.SetProviderAsync(provider, context, afterSet: (theProvider) =>
             {
                 callCount++;
                 Assert.Equal(provider, theProvider);
@@ -191,7 +191,7 @@ namespace OpenFeature.Tests
             var context = new EvaluationContextBuilder().Build();
             // TODO: huh?? await??
 
-            repository.SetProviderAsync("the-name", provider, context);
+            await repository.SetProviderAsync("the-name", provider, context);
             Assert.Equal(provider, repository.GetProvider("the-name"));
         }
 
@@ -204,7 +204,7 @@ namespace OpenFeature.Tests
             var callCount = 0;
             // The setting of the provider is synchronous, so the afterSet should be as well.
             // TODO: huh?? await??
-            repository.SetProviderAsync("the-name", provider, context, afterSet: (theProvider) =>
+            await repository.SetProviderAsync("the-name", provider, context, afterSet: (theProvider) =>
             {
                 callCount++;
                 Assert.Equal(provider, theProvider);
@@ -579,27 +579,6 @@ namespace OpenFeature.Tests
             await repository.SetProviderAsync("named-provider", null, context);
 
             Assert.Equal(defaultProvider, repository.GetProvider("named-provider"));
-        }
-
-        [Fact]
-        public async Task Setting_Named_Provider_With_Null_Name_Has_No_Effect()
-        {
-            var repository = new ProviderRepository();
-            var context = new EvaluationContextBuilder().Build();
-
-            var defaultProvider = Substitute.For<FeatureProvider>();
-            defaultProvider.GetStatus().Returns(ProviderStatus.NotReady);
-            await repository.SetProviderAsync(defaultProvider, context);
-
-            var namedProvider = Substitute.For<FeatureProvider>();
-            namedProvider.GetStatus().Returns(ProviderStatus.NotReady);
-
-            await repository.SetProviderAsync(null, namedProvider, context);
-
-            namedProvider.DidNotReceive().InitializeAsync(context);
-            namedProvider.DidNotReceive().ShutdownAsync();
-
-            Assert.Equal(defaultProvider, repository.GetProvider(null));
         }
     }
 }

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -21,7 +21,6 @@ namespace OpenFeature.Tests
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();
             var context = new EvaluationContextBuilder().Build();
-            // TODO: huh?? await??
             await repository.SetProviderAsync(provider, context);
             Assert.Equal(provider, repository.GetProvider());
         }
@@ -34,7 +33,6 @@ namespace OpenFeature.Tests
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
             // The setting of the provider is synchronous, so the afterSet should be as well.
-            // TODO: huh?? await??
             await repository.SetProviderAsync(provider, context, afterSet: (theProvider) =>
             {
                 callCount++;
@@ -189,7 +187,6 @@ namespace OpenFeature.Tests
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();
             var context = new EvaluationContextBuilder().Build();
-            // TODO: huh?? await??
 
             await repository.SetProviderAsync("the-name", provider, context);
             Assert.Equal(provider, repository.GetProvider("the-name"));
@@ -203,7 +200,6 @@ namespace OpenFeature.Tests
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
             // The setting of the provider is synchronous, so the afterSet should be as well.
-            // TODO: huh?? await??
             await repository.SetProviderAsync("the-name", provider, context, afterSet: (theProvider) =>
             {
                 callCount++;
@@ -249,7 +245,6 @@ namespace OpenFeature.Tests
             var context = new EvaluationContextBuilder().Build();
             providerMock.When(x => x.InitializeAsync(context)).Throw(new Exception("BAD THINGS"));
             var callCount = 0;
-            // TODO: huh?? await??
             Exception? receivedError = null;
             await repository.SetProviderAsync("the-provider", providerMock, context, afterError: (theProvider, error) =>
             {
@@ -343,7 +338,6 @@ namespace OpenFeature.Tests
             var context = new EvaluationContextBuilder().Build();
             await repository.SetProviderAsync("the-name", provider1, context);
             var callCount = 0;
-            // TODO: huh?? await??
             Exception? errorThrown = null;
             await repository.SetProviderAsync("the-name", provider2, context, afterError: (provider, ex) =>
             {

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -21,7 +21,8 @@ namespace OpenFeature.Tests
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(provider, context);
+            // TODO: huh?? await??
+            repository.SetProviderAsync(provider, context);
             Assert.Equal(provider, repository.GetProvider());
         }
 
@@ -33,7 +34,8 @@ namespace OpenFeature.Tests
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
             // The setting of the provider is synchronous, so the afterSet should be as well.
-            await repository.SetProvider(provider, context, afterSet: (theProvider) =>
+            // TODO: huh?? await??
+            repository.SetProviderAsync(provider, context, afterSet: (theProvider) =>
             {
                 callCount++;
                 Assert.Equal(provider, theProvider);
@@ -48,9 +50,9 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(providerMock, context);
-            providerMock.Received(1).Initialize(context);
-            providerMock.DidNotReceive().Shutdown();
+            await repository.SetProviderAsync(providerMock, context);
+            providerMock.Received(1).InitializeAsync(context);
+            providerMock.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -61,7 +63,7 @@ namespace OpenFeature.Tests
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
-            await repository.SetProvider(providerMock, context, afterInitialization: (theProvider) =>
+            await repository.SetProviderAsync(providerMock, context, afterInitialization: (theProvider) =>
             {
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
@@ -76,10 +78,10 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            providerMock.When(x => x.Initialize(context)).Throw(new Exception("BAD THINGS"));
+            providerMock.When(x => x.InitializeAsync(context)).Throw(new Exception("BAD THINGS"));
             var callCount = 0;
             Exception? receivedError = null;
-            await repository.SetProvider(providerMock, context, afterError: (theProvider, error) =>
+            await repository.SetProviderAsync(providerMock, context, afterError: (theProvider, error) =>
             {
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
@@ -99,8 +101,8 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(status);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(providerMock, context);
-            providerMock.DidNotReceive().Initialize(context);
+            await repository.SetProviderAsync(providerMock, context);
+            providerMock.DidNotReceive().InitializeAsync(context);
         }
 
         [Theory]
@@ -114,7 +116,7 @@ namespace OpenFeature.Tests
             providerMock.GetStatus().Returns(status);
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
-            await repository.SetProvider(providerMock, context, afterInitialization: provider => { callCount++; });
+            await repository.SetProviderAsync(providerMock, context, afterInitialization: provider => { callCount++; });
             Assert.Equal(0, callCount);
         }
 
@@ -129,10 +131,10 @@ namespace OpenFeature.Tests
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(provider1, context);
-            await repository.SetProvider(provider2, context);
-            provider1.Received(1).Shutdown();
-            provider2.DidNotReceive().Shutdown();
+            await repository.SetProviderAsync(provider1, context);
+            await repository.SetProviderAsync(provider2, context);
+            provider1.Received(1).ShutdownAsync();
+            provider2.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -146,9 +148,9 @@ namespace OpenFeature.Tests
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(provider1, context);
+            await repository.SetProviderAsync(provider1, context);
             var callCount = 0;
-            await repository.SetProvider(provider2, context, afterShutdown: provider =>
+            await repository.SetProviderAsync(provider2, context, afterShutdown: provider =>
             {
                 Assert.Equal(provider, provider1);
                 callCount++;
@@ -161,17 +163,17 @@ namespace OpenFeature.Tests
         {
             var repository = new ProviderRepository();
             var provider1 = Substitute.For<FeatureProvider>();
-            provider1.Shutdown().Throws(new Exception("SHUTDOWN ERROR"));
+            provider1.ShutdownAsync().Throws(new Exception("SHUTDOWN ERROR"));
             provider1.GetStatus().Returns(ProviderStatus.NotReady);
 
             var provider2 = Substitute.For<FeatureProvider>();
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(provider1, context);
+            await repository.SetProviderAsync(provider1, context);
             var callCount = 0;
             Exception? errorThrown = null;
-            await repository.SetProvider(provider2, context, afterError: (provider, ex) =>
+            await repository.SetProviderAsync(provider2, context, afterError: (provider, ex) =>
             {
                 Assert.Equal(provider, provider1);
                 errorThrown = ex;
@@ -187,7 +189,9 @@ namespace OpenFeature.Tests
             var repository = new ProviderRepository();
             var provider = new NoOpFeatureProvider();
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider("the-name", provider, context);
+            // TODO: huh?? await??
+
+            repository.SetProviderAsync("the-name", provider, context);
             Assert.Equal(provider, repository.GetProvider("the-name"));
         }
 
@@ -199,7 +203,8 @@ namespace OpenFeature.Tests
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
             // The setting of the provider is synchronous, so the afterSet should be as well.
-            await repository.SetProvider("the-name", provider, context, afterSet: (theProvider) =>
+            // TODO: huh?? await??
+            repository.SetProviderAsync("the-name", provider, context, afterSet: (theProvider) =>
             {
                 callCount++;
                 Assert.Equal(provider, theProvider);
@@ -214,9 +219,9 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider("the-name", providerMock, context);
-            providerMock.Received(1).Initialize(context);
-            providerMock.DidNotReceive().Shutdown();
+            await repository.SetProviderAsync("the-name", providerMock, context);
+            providerMock.Received(1).InitializeAsync(context);
+            providerMock.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -227,7 +232,7 @@ namespace OpenFeature.Tests
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
-            await repository.SetProvider("the-name", providerMock, context, afterInitialization: (theProvider) =>
+            await repository.SetProviderAsync("the-name", providerMock, context, afterInitialization: (theProvider) =>
             {
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
@@ -242,10 +247,11 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            providerMock.When(x => x.Initialize(context)).Throw(new Exception("BAD THINGS"));
+            providerMock.When(x => x.InitializeAsync(context)).Throw(new Exception("BAD THINGS"));
             var callCount = 0;
+            // TODO: huh?? await??
             Exception? receivedError = null;
-            await repository.SetProvider("the-provider", providerMock, context, afterError: (theProvider, error) =>
+            await repository.SetProviderAsync("the-provider", providerMock, context, afterError: (theProvider, error) =>
             {
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
@@ -265,8 +271,8 @@ namespace OpenFeature.Tests
             var providerMock = Substitute.For<FeatureProvider>();
             providerMock.GetStatus().Returns(status);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider("the-name", providerMock, context);
-            providerMock.DidNotReceive().Initialize(context);
+            await repository.SetProviderAsync("the-name", providerMock, context);
+            providerMock.DidNotReceive().InitializeAsync(context);
         }
 
         [Theory]
@@ -280,7 +286,7 @@ namespace OpenFeature.Tests
             providerMock.GetStatus().Returns(status);
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
-            await repository.SetProvider("the-name", providerMock, context,
+            await repository.SetProviderAsync("the-name", providerMock, context,
                 afterInitialization: provider => { callCount++; });
             Assert.Equal(0, callCount);
         }
@@ -296,10 +302,10 @@ namespace OpenFeature.Tests
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider("the-name", provider1, context);
-            await repository.SetProvider("the-name", provider2, context);
-            provider1.Received(1).Shutdown();
-            provider2.DidNotReceive().Shutdown();
+            await repository.SetProviderAsync("the-name", provider1, context);
+            await repository.SetProviderAsync("the-name", provider2, context);
+            provider1.Received(1).ShutdownAsync();
+            provider2.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -313,9 +319,9 @@ namespace OpenFeature.Tests
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider("the-provider", provider1, context);
+            await repository.SetProviderAsync("the-provider", provider1, context);
             var callCount = 0;
-            await repository.SetProvider("the-provider", provider2, context, afterShutdown: provider =>
+            await repository.SetProviderAsync("the-provider", provider2, context, afterShutdown: provider =>
             {
                 Assert.Equal(provider, provider1);
                 callCount++;
@@ -328,17 +334,18 @@ namespace OpenFeature.Tests
         {
             var repository = new ProviderRepository();
             var provider1 = Substitute.For<FeatureProvider>();
-            provider1.Shutdown().Throws(new Exception("SHUTDOWN ERROR"));
+            provider1.ShutdownAsync().Throws(new Exception("SHUTDOWN ERROR"));
             provider1.GetStatus().Returns(ProviderStatus.NotReady);
 
             var provider2 = Substitute.For<FeatureProvider>();
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider("the-name", provider1, context);
+            await repository.SetProviderAsync("the-name", provider1, context);
             var callCount = 0;
+            // TODO: huh?? await??
             Exception? errorThrown = null;
-            await repository.SetProvider("the-name", provider2, context, afterError: (provider, ex) =>
+            await repository.SetProviderAsync("the-name", provider2, context, afterError: (provider, ex) =>
             {
                 Assert.Equal(provider, provider1);
                 errorThrown = ex;
@@ -360,12 +367,12 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider(provider1, context);
-            await repository.SetProvider("A", provider1, context);
+            await repository.SetProviderAsync(provider1, context);
+            await repository.SetProviderAsync("A", provider1, context);
             // Provider one is replaced for "A", but not default.
-            await repository.SetProvider("A", provider2, context);
+            await repository.SetProviderAsync("A", provider2, context);
 
-            provider1.DidNotReceive().Shutdown();
+            provider1.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -380,12 +387,12 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider("B", provider1, context);
-            await repository.SetProvider("A", provider1, context);
+            await repository.SetProviderAsync("B", provider1, context);
+            await repository.SetProviderAsync("A", provider1, context);
             // Provider one is replaced for "A", but not "B".
-            await repository.SetProvider("A", provider2, context);
+            await repository.SetProviderAsync("A", provider2, context);
 
-            provider1.DidNotReceive().Shutdown();
+            provider1.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -400,13 +407,13 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider("B", provider1, context);
-            await repository.SetProvider("A", provider1, context);
+            await repository.SetProviderAsync("B", provider1, context);
+            await repository.SetProviderAsync("A", provider1, context);
 
-            await repository.SetProvider("A", provider2, context);
-            await repository.SetProvider("B", provider2, context);
+            await repository.SetProviderAsync("A", provider2, context);
+            await repository.SetProviderAsync("B", provider2, context);
 
-            provider1.Received(1).Shutdown();
+            provider1.Received(1).ShutdownAsync();
         }
 
         [Fact]
@@ -421,8 +428,8 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider("A", provider1, context);
-            await repository.SetProvider("B", provider2, context);
+            await repository.SetProviderAsync("A", provider1, context);
+            await repository.SetProviderAsync("B", provider2, context);
 
             Assert.Equal(provider1, repository.GetProvider("A"));
             Assert.Equal(provider2, repository.GetProvider("B"));
@@ -440,8 +447,8 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider("A", provider1, context);
-            await repository.SetProvider("A", provider2, context);
+            await repository.SetProviderAsync("A", provider1, context);
+            await repository.SetProviderAsync("A", provider2, context);
 
             Assert.Equal(provider2, repository.GetProvider("A"));
         }
@@ -461,17 +468,17 @@ namespace OpenFeature.Tests
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider(provider1, context);
-            await repository.SetProvider("provider1", provider1, context);
-            await repository.SetProvider("provider2", provider2, context);
-            await repository.SetProvider("provider2a", provider2, context);
-            await repository.SetProvider("provider3", provider3, context);
+            await repository.SetProviderAsync(provider1, context);
+            await repository.SetProviderAsync("provider1", provider1, context);
+            await repository.SetProviderAsync("provider2", provider2, context);
+            await repository.SetProviderAsync("provider2a", provider2, context);
+            await repository.SetProviderAsync("provider3", provider3, context);
 
-            await repository.Shutdown();
+            await repository.ShutdownAsync();
 
-            provider1.Received(1).Shutdown();
-            provider2.Received(1).Shutdown();
-            provider3.Received(1).Shutdown();
+            provider1.Received(1).ShutdownAsync();
+            provider2.Received(1).ShutdownAsync();
+            provider3.Received(1).ShutdownAsync();
         }
 
         [Fact]
@@ -480,27 +487,27 @@ namespace OpenFeature.Tests
             var repository = new ProviderRepository();
             var provider1 = Substitute.For<FeatureProvider>();
             provider1.GetStatus().Returns(ProviderStatus.NotReady);
-            provider1.Shutdown().Throws(new Exception("SHUTDOWN ERROR 1"));
+            provider1.ShutdownAsync().Throws(new Exception("SHUTDOWN ERROR 1"));
 
             var provider2 = Substitute.For<FeatureProvider>();
             provider2.GetStatus().Returns(ProviderStatus.NotReady);
-            provider2.Shutdown().Throws(new Exception("SHUTDOWN ERROR 2"));
+            provider2.ShutdownAsync().Throws(new Exception("SHUTDOWN ERROR 2"));
 
             var provider3 = Substitute.For<FeatureProvider>();
             provider3.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
 
-            await repository.SetProvider(provider1, context);
-            await repository.SetProvider("provider1", provider1, context);
-            await repository.SetProvider("provider2", provider2, context);
-            await repository.SetProvider("provider2a", provider2, context);
-            await repository.SetProvider("provider3", provider3, context);
+            await repository.SetProviderAsync(provider1, context);
+            await repository.SetProviderAsync("provider1", provider1, context);
+            await repository.SetProviderAsync("provider2", provider2, context);
+            await repository.SetProviderAsync("provider2a", provider2, context);
+            await repository.SetProviderAsync("provider3", provider3, context);
 
             var callCountShutdown1 = 0;
             var callCountShutdown2 = 0;
             var totalCallCount = 0;
-            await repository.Shutdown(afterError: (provider, exception) =>
+            await repository.ShutdownAsync(afterError: (provider, exception) =>
             {
                 totalCallCount++;
                 if (provider == provider1)
@@ -519,9 +526,9 @@ namespace OpenFeature.Tests
             Assert.Equal(1, callCountShutdown1);
             Assert.Equal(1, callCountShutdown2);
 
-            provider1.Received(1).Shutdown();
-            provider2.Received(1).Shutdown();
-            provider3.Received(1).Shutdown();
+            provider1.Received(1).ShutdownAsync();
+            provider2.Received(1).ShutdownAsync();
+            provider3.Received(1).ShutdownAsync();
         }
 
         [Fact]
@@ -531,12 +538,12 @@ namespace OpenFeature.Tests
             var provider = Substitute.For<FeatureProvider>();
             provider.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(provider, context);
-            await repository.SetProvider(provider, context);
+            await repository.SetProviderAsync(provider, context);
+            await repository.SetProviderAsync(provider, context);
 
             Assert.Equal(provider, repository.GetProvider());
-            provider.Received(1).Initialize(context);
-            provider.DidNotReceive().Shutdown();
+            provider.Received(1).InitializeAsync(context);
+            provider.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -546,12 +553,12 @@ namespace OpenFeature.Tests
             var provider = Substitute.For<FeatureProvider>();
             provider.GetStatus().Returns(ProviderStatus.NotReady);
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(provider, context);
-            await repository.SetProvider(null, context);
+            await repository.SetProviderAsync(provider, context);
+            await repository.SetProviderAsync(null, context);
 
             Assert.Equal(provider, repository.GetProvider());
-            provider.Received(1).Initialize(context);
-            provider.DidNotReceive().Shutdown();
+            provider.Received(1).InitializeAsync(context);
+            provider.DidNotReceive().ShutdownAsync();
         }
 
         [Fact]
@@ -566,10 +573,10 @@ namespace OpenFeature.Tests
             defaultProvider.GetStatus().Returns(ProviderStatus.NotReady);
 
             var context = new EvaluationContextBuilder().Build();
-            await repository.SetProvider(defaultProvider, context);
+            await repository.SetProviderAsync(defaultProvider, context);
 
-            await repository.SetProvider("named-provider", namedProvider, context);
-            await repository.SetProvider("named-provider", null, context);
+            await repository.SetProviderAsync("named-provider", namedProvider, context);
+            await repository.SetProviderAsync("named-provider", null, context);
 
             Assert.Equal(defaultProvider, repository.GetProvider("named-provider"));
         }
@@ -582,15 +589,15 @@ namespace OpenFeature.Tests
 
             var defaultProvider = Substitute.For<FeatureProvider>();
             defaultProvider.GetStatus().Returns(ProviderStatus.NotReady);
-            await repository.SetProvider(defaultProvider, context);
+            await repository.SetProviderAsync(defaultProvider, context);
 
             var namedProvider = Substitute.For<FeatureProvider>();
             namedProvider.GetStatus().Returns(ProviderStatus.NotReady);
 
-            await repository.SetProvider(null, namedProvider, context);
+            await repository.SetProviderAsync(null, namedProvider, context);
 
-            namedProvider.DidNotReceive().Initialize(context);
-            namedProvider.DidNotReceive().Shutdown();
+            namedProvider.DidNotReceive().InitializeAsync(context);
+            namedProvider.DidNotReceive().ShutdownAsync();
 
             Assert.Equal(defaultProvider, repository.GetProvider(null));
         }

--- a/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
+++ b/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Error;
 using OpenFeature.Model;
@@ -118,7 +119,7 @@ namespace OpenFeature.Tests.Providers.Memory
         }
 
         [Fact]
-        public async void GetString_ShouldEvaluateWithReasonAndVariant()
+        public async Task GetString_ShouldEvaluateWithReasonAndVariant()
         {
             ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("string-flag", "nope", EvaluationContext.Empty);
             Assert.Equal("hi", details.Value);
@@ -127,7 +128,7 @@ namespace OpenFeature.Tests.Providers.Memory
         }
 
         [Fact]
-        public async void GetInt_ShouldEvaluateWithReasonAndVariant()
+        public async Task GetInt_ShouldEvaluateWithReasonAndVariant()
         {
             ResolutionDetails<int> details = await this.commonProvider.ResolveIntegerValueAsync("integer-flag", 13, EvaluationContext.Empty);
             Assert.Equal(10, details.Value);
@@ -136,7 +137,7 @@ namespace OpenFeature.Tests.Providers.Memory
         }
 
         [Fact]
-        public async void GetDouble_ShouldEvaluateWithReasonAndVariant()
+        public async Task GetDouble_ShouldEvaluateWithReasonAndVariant()
         {
             ResolutionDetails<double> details = await this.commonProvider.ResolveDoubleValueAsync("float-flag", 13, EvaluationContext.Empty);
             Assert.Equal(0.5, details.Value);
@@ -145,7 +146,7 @@ namespace OpenFeature.Tests.Providers.Memory
         }
 
         [Fact]
-        public async void GetStruct_ShouldEvaluateWithReasonAndVariant()
+        public async Task GetStruct_ShouldEvaluateWithReasonAndVariant()
         {
             ResolutionDetails<Value> details = await this.commonProvider.ResolveStructureValueAsync("object-flag", new Value(), EvaluationContext.Empty);
             Assert.Equal(true, details.Value.AsStructure?["showImages"].AsBoolean);
@@ -156,7 +157,7 @@ namespace OpenFeature.Tests.Providers.Memory
         }
 
         [Fact]
-        public async void GetString_ContextSensitive_ShouldEvaluateWithReasonAndVariant()
+        public async Task GetString_ContextSensitive_ShouldEvaluateWithReasonAndVariant()
         {
             EvaluationContext context = EvaluationContext.Builder().Set("email", "me@faas.com").Build();
             ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("context-aware", "nope", context);
@@ -166,7 +167,7 @@ namespace OpenFeature.Tests.Providers.Memory
         }
 
         [Fact]
-        public async void EmptyFlags_ShouldWork()
+        public async Task EmptyFlags_ShouldWork()
         {
             var provider = new InMemoryProvider();
             await provider.UpdateFlags();
@@ -174,31 +175,31 @@ namespace OpenFeature.Tests.Providers.Memory
         }
 
         [Fact]
-        public async void MissingFlag_ShouldThrow()
+        public async Task MissingFlag_ShouldThrow()
         {
             await Assert.ThrowsAsync<FlagNotFoundException>(() => this.commonProvider.ResolveBooleanValueAsync("missing-flag", false, EvaluationContext.Empty));
         }
 
         [Fact]
-        public async void MismatchedFlag_ShouldThrow()
+        public async Task MismatchedFlag_ShouldThrow()
         {
             await Assert.ThrowsAsync<TypeMismatchException>(() => this.commonProvider.ResolveStringValueAsync("boolean-flag", "nope", EvaluationContext.Empty));
         }
 
         [Fact]
-        public async void MissingDefaultVariant_ShouldThrow()
+        public async Task MissingDefaultVariant_ShouldThrow()
         {
             await Assert.ThrowsAsync<GeneralException>(() => this.commonProvider.ResolveBooleanValueAsync("invalid-flag", false, EvaluationContext.Empty));
         }
 
         [Fact]
-        public async void MissingEvaluatedVariant_ShouldThrow()
+        public async Task MissingEvaluatedVariant_ShouldThrow()
         {
             await Assert.ThrowsAsync<GeneralException>(() => this.commonProvider.ResolveBooleanValueAsync("invalid-evaluator-flag", false, EvaluationContext.Empty));
         }
 
         [Fact]
-        public async void PutConfiguration_shouldUpdateConfigAndRunHandlers()
+        public async Task PutConfiguration_shouldUpdateConfigAndRunHandlers()
         {
             var provider = new InMemoryProvider(new Dictionary<string, Flag>(){
             {

--- a/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
+++ b/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
@@ -109,7 +109,7 @@ namespace OpenFeature.Tests.Providers.Memory
         }
 
         [Fact]
-        public async void GetBoolean_ShouldEvaluateWithReasonAndVariant()
+        public async Task GetBoolean_ShouldEvaluateWithReasonAndVariant()
         {
             ResolutionDetails<bool> details = await this.commonProvider.ResolveBooleanValueAsync("boolean-flag", false, EvaluationContext.Empty);
             Assert.True(details.Value);

--- a/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
+++ b/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
@@ -111,7 +111,7 @@ namespace OpenFeature.Tests.Providers.Memory
         [Fact]
         public async void GetBoolean_ShouldEvaluateWithReasonAndVariant()
         {
-            ResolutionDetails<bool> details = await this.commonProvider.ResolveBooleanValue("boolean-flag", false, EvaluationContext.Empty);
+            ResolutionDetails<bool> details = await this.commonProvider.ResolveBooleanValueAsync("boolean-flag", false, EvaluationContext.Empty);
             Assert.True(details.Value);
             Assert.Equal(Reason.Static, details.Reason);
             Assert.Equal("on", details.Variant);
@@ -120,7 +120,7 @@ namespace OpenFeature.Tests.Providers.Memory
         [Fact]
         public async void GetString_ShouldEvaluateWithReasonAndVariant()
         {
-            ResolutionDetails<string> details = await this.commonProvider.ResolveStringValue("string-flag", "nope", EvaluationContext.Empty);
+            ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("string-flag", "nope", EvaluationContext.Empty);
             Assert.Equal("hi", details.Value);
             Assert.Equal(Reason.Static, details.Reason);
             Assert.Equal("greeting", details.Variant);
@@ -129,7 +129,7 @@ namespace OpenFeature.Tests.Providers.Memory
         [Fact]
         public async void GetInt_ShouldEvaluateWithReasonAndVariant()
         {
-            ResolutionDetails<int> details = await this.commonProvider.ResolveIntegerValue("integer-flag", 13, EvaluationContext.Empty);
+            ResolutionDetails<int> details = await this.commonProvider.ResolveIntegerValueAsync("integer-flag", 13, EvaluationContext.Empty);
             Assert.Equal(10, details.Value);
             Assert.Equal(Reason.Static, details.Reason);
             Assert.Equal("ten", details.Variant);
@@ -138,7 +138,7 @@ namespace OpenFeature.Tests.Providers.Memory
         [Fact]
         public async void GetDouble_ShouldEvaluateWithReasonAndVariant()
         {
-            ResolutionDetails<double> details = await this.commonProvider.ResolveDoubleValue("float-flag", 13, EvaluationContext.Empty);
+            ResolutionDetails<double> details = await this.commonProvider.ResolveDoubleValueAsync("float-flag", 13, EvaluationContext.Empty);
             Assert.Equal(0.5, details.Value);
             Assert.Equal(Reason.Static, details.Reason);
             Assert.Equal("half", details.Variant);
@@ -147,7 +147,7 @@ namespace OpenFeature.Tests.Providers.Memory
         [Fact]
         public async void GetStruct_ShouldEvaluateWithReasonAndVariant()
         {
-            ResolutionDetails<Value> details = await this.commonProvider.ResolveStructureValue("object-flag", new Value(), EvaluationContext.Empty);
+            ResolutionDetails<Value> details = await this.commonProvider.ResolveStructureValueAsync("object-flag", new Value(), EvaluationContext.Empty);
             Assert.Equal(true, details.Value.AsStructure?["showImages"].AsBoolean);
             Assert.Equal("Check out these pics!", details.Value.AsStructure?["title"].AsString);
             Assert.Equal(100, details.Value.AsStructure?["imagesPerPage"].AsInteger);
@@ -159,7 +159,7 @@ namespace OpenFeature.Tests.Providers.Memory
         public async void GetString_ContextSensitive_ShouldEvaluateWithReasonAndVariant()
         {
             EvaluationContext context = EvaluationContext.Builder().Set("email", "me@faas.com").Build();
-            ResolutionDetails<string> details = await this.commonProvider.ResolveStringValue("context-aware", "nope", context);
+            ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("context-aware", "nope", context);
             Assert.Equal("INTERNAL", details.Value);
             Assert.Equal(Reason.TargetingMatch, details.Reason);
             Assert.Equal("internal", details.Variant);
@@ -176,25 +176,25 @@ namespace OpenFeature.Tests.Providers.Memory
         [Fact]
         public async void MissingFlag_ShouldThrow()
         {
-            await Assert.ThrowsAsync<FlagNotFoundException>(() => this.commonProvider.ResolveBooleanValue("missing-flag", false, EvaluationContext.Empty));
+            await Assert.ThrowsAsync<FlagNotFoundException>(() => this.commonProvider.ResolveBooleanValueAsync("missing-flag", false, EvaluationContext.Empty));
         }
 
         [Fact]
         public async void MismatchedFlag_ShouldThrow()
         {
-            await Assert.ThrowsAsync<TypeMismatchException>(() => this.commonProvider.ResolveStringValue("boolean-flag", "nope", EvaluationContext.Empty));
+            await Assert.ThrowsAsync<TypeMismatchException>(() => this.commonProvider.ResolveStringValueAsync("boolean-flag", "nope", EvaluationContext.Empty));
         }
 
         [Fact]
         public async void MissingDefaultVariant_ShouldThrow()
         {
-            await Assert.ThrowsAsync<GeneralException>(() => this.commonProvider.ResolveBooleanValue("invalid-flag", false, EvaluationContext.Empty));
+            await Assert.ThrowsAsync<GeneralException>(() => this.commonProvider.ResolveBooleanValueAsync("invalid-flag", false, EvaluationContext.Empty));
         }
 
         [Fact]
         public async void MissingEvaluatedVariant_ShouldThrow()
         {
-            await Assert.ThrowsAsync<GeneralException>(() => this.commonProvider.ResolveBooleanValue("invalid-evaluator-flag", false, EvaluationContext.Empty));
+            await Assert.ThrowsAsync<GeneralException>(() => this.commonProvider.ResolveBooleanValueAsync("invalid-evaluator-flag", false, EvaluationContext.Empty));
         }
 
         [Fact]
@@ -211,7 +211,7 @@ namespace OpenFeature.Tests.Providers.Memory
                 )
             }});
 
-            ResolutionDetails<bool> details = await provider.ResolveBooleanValue("old-flag", false, EvaluationContext.Empty);
+            ResolutionDetails<bool> details = await provider.ResolveBooleanValueAsync("old-flag", false, EvaluationContext.Empty);
             Assert.True(details.Value);
 
             // update flags
@@ -229,10 +229,10 @@ namespace OpenFeature.Tests.Providers.Memory
             var res = await provider.GetEventChannel().Reader.ReadAsync() as ProviderEventPayload;
             Assert.Equal(ProviderEventTypes.ProviderConfigurationChanged, res?.Type);
 
-            await Assert.ThrowsAsync<FlagNotFoundException>(() => provider.ResolveBooleanValue("old-flag", false, EvaluationContext.Empty));
+            await Assert.ThrowsAsync<FlagNotFoundException>(() => provider.ResolveBooleanValueAsync("old-flag", false, EvaluationContext.Empty));
 
             // new flag should be present, old gone (defaults), handler run.
-            ResolutionDetails<string> detailsAfter = await provider.ResolveStringValue("new-flag", "nope", EvaluationContext.Empty);
+            ResolutionDetails<string> detailsAfter = await provider.ResolveStringValueAsync("new-flag", "nope", EvaluationContext.Empty);
             Assert.True(details.Value);
             Assert.Equal("hi", detailsAfter.Value);
         }

--- a/test/OpenFeature.Tests/TestImplementations.cs
+++ b/test/OpenFeature.Tests/TestImplementations.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Model;
@@ -11,25 +12,25 @@ namespace OpenFeature.Tests
 
     public class TestHook : Hook
     {
-        public override Task<EvaluationContext> Before<T>(HookContext<T> context, IReadOnlyDictionary<string, object>? hints = null)
+        public override ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(EvaluationContext.Empty);
+            return new ValueTask<EvaluationContext>(EvaluationContext.Empty);
         }
 
-        public override Task After<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
-            IReadOnlyDictionary<string, object>? hints = null)
+        public override ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+            IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
-        public override Task Error<T>(HookContext<T> context, Exception error, IReadOnlyDictionary<string, object>? hints = null)
+        public override ValueTask ErrorAsync<T>(HookContext<T> context, Exception error, IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
 
-        public override Task Finally<T>(HookContext<T> context, IReadOnlyDictionary<string, object>? hints = null)
+        public override ValueTask FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return new ValueTask();
         }
     }
 
@@ -64,32 +65,32 @@ namespace OpenFeature.Tests
             return new Metadata(this.Name);
         }
 
-        public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
-            EvaluationContext? context = null)
+        public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue,
+            EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new ResolutionDetails<bool>(flagKey, !defaultValue));
         }
 
-        public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
-            EvaluationContext? context = null)
+        public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue,
+            EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new ResolutionDetails<string>(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
-            EvaluationContext? context = null)
+        public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue,
+            EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new ResolutionDetails<int>(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
-            EvaluationContext? context = null)
+        public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue,
+            EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new ResolutionDetails<double>(flagKey, defaultValue));
         }
 
-        public override Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue,
-            EvaluationContext? context = null)
+        public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue,
+            EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new ResolutionDetails<Value>(flagKey, defaultValue));
         }
@@ -104,16 +105,16 @@ namespace OpenFeature.Tests
             this._status = status;
         }
 
-        public override Task Initialize(EvaluationContext context)
+        public override async ValueTask InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
         {
             this._status = ProviderStatus.Ready;
-            this.EventChannel.Writer.WriteAsync(new ProviderEventPayload { Type = ProviderEventTypes.ProviderReady, ProviderName = this.GetMetadata().Name });
-            return base.Initialize(context);
+            await this.EventChannel.Writer.WriteAsync(new ProviderEventPayload { Type = ProviderEventTypes.ProviderReady, ProviderName = this.GetMetadata().Name }, cancellationToken).ConfigureAwait(false);
+            await base.InitializeAsync(context, cancellationToken).ConfigureAwait(false);
         }
 
-        internal void SendEvent(ProviderEventTypes eventType)
+        internal ValueTask SendEventAsync(ProviderEventTypes eventType, CancellationToken cancellationToken = default)
         {
-            this.EventChannel.Writer.WriteAsync(new ProviderEventPayload { Type = eventType, ProviderName = this.GetMetadata().Name });
+            return this.EventChannel.Writer.WriteAsync(new ProviderEventPayload { Type = eventType, ProviderName = this.GetMetadata().Name }, cancellationToken);
         }
     }
 }

--- a/test/OpenFeature.Tests/TestImplementations.cs
+++ b/test/OpenFeature.Tests/TestImplementations.cs
@@ -105,7 +105,7 @@ namespace OpenFeature.Tests
             this._status = status;
         }
 
-        public override async ValueTask InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
+        public override async Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
         {
             this._status = ProviderStatus.Ready;
             await this.EventChannel.Writer.WriteAsync(new ProviderEventPayload { Type = ProviderEventTypes.ProviderReady, ProviderName = this.GetMetadata().Name }, cancellationToken).ConfigureAwait(false);

--- a/test/OpenFeature.Tests/TestUtilsTest.cs
+++ b/test/OpenFeature.Tests/TestUtilsTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace OpenFeature.Tests
@@ -8,13 +9,13 @@ namespace OpenFeature.Tests
     public class TestUtilsTest
     {
         [Fact]
-        public async void Should_Fail_If_Assertion_Fails()
+        public async Task Should_Fail_If_Assertion_Fails()
         {
             await Assert.ThrowsAnyAsync<Exception>(() => Utils.AssertUntilAsync(_ => Assert.True(1.Equals(2)), 100, 10));
         }
 
         [Fact]
-        public async void Should_Pass_If_Assertion_Fails()
+        public async Task Should_Pass_If_Assertion_Fails()
         {
             await Utils.AssertUntilAsync(_ => Assert.True(1.Equals(1)));
         }


### PR DESCRIPTION
This PR is a combination of https://github.com/open-feature/dotnet-sdk/pull/184 and https://github.com/open-feature/dotnet-sdk/pull/185. Changes include:

- adding cancellation tokens
  - in all cases where async operations include side-effects (`setProviderAsync`, `InitializeAsync`, I've specified in the in-line doc that the cancellation token's purpose is to cancel such side-effects - so setting a provider and canceling that operation still results in that provider's being set, but async side-effect should be cancelled. I'm interested in feedback here, I think we need to consider the semantics around this... I suppose the alternative would be to always ensure any state changes only occur after async side-effects, if they weren't cancelled beforehand. 
- adding "Async" suffix to all async methods
- remove deprecated sync `SetProvider` methods 
- Using `ValueTask` for hook methods
  - I've decided against converting all `Tasks` to `ValueTasks`, from the [official .NET docs](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.valuetask?view=net-8.0):
  > the default choice for any asynchronous method that does not return a result should be to return a [Task](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task?view=net-8.0). Only if performance analysis proves it worthwhile should a ValueTask be used instead of a [Task](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task?view=net-8.0). 
  - I think for hooks, `ValueTask` especially makes sense since often hooks are synchronous, in fact async hooks are probably the less likely variant.
  - I've kept the resolver methods as `Task`, but there could be an argument for making them `ValueTask`, since some providers resolve asynchronously. 
  - I'm still a bit dubious on the entire idea of `ValueTask`, so I'm really interested in feedback here
- associated test updates

UPDATE:

After chewing on this for a night, I'm starting to feel:
- We should simply remove cancellation tokens from Init/Shutdown. We can always add them later, which would be non-breaking. I think the value is low and the complexity is potentially high.
- ValueTask is only a good idea for hooks, because:
  - Hooks will very often be synchronous under the hood
  - We (SDK authors) await the hooks, not consumer code, so we can be careful of the potential pitfalls of ValueTask. I think everywhere else we should stick to Task.
