### PR TITLE
feat!: internally maintain provider status

### DIFF
--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -269,7 +269,6 @@ namespace OpenFeature
 
         /// <summary>
         /// Update the provider state to READY and emit a READY event after successful init.
-
         /// </summary>
         private async Task AfterInitialization(FeatureProvider provider)
         {

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -269,7 +269,8 @@ namespace OpenFeature
         /// <summary>
         /// Update the provider state to READY and emit an READY after successful init.
         /// </summary>
-        private void afterInitialization(FeatureProvider provider)
+        private void AfterInitialization(FeatureProvider provider)
+
         {
             provider.Status = ProviderStatus.Ready;
             var eventPayload = new ProviderEventPayload

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -286,7 +286,8 @@ namespace OpenFeature
         /// <summary>
         /// Update the provider state to ERROR and emit an ERROR after failed init.
         /// </summary>
-        private void afterError(FeatureProvider provider, Exception ex)
+        private void AfterError(FeatureProvider provider, Exception ex)
+
         {
             provider.Status = typeof(ProviderFatalException) == ex.GetType() ? ProviderStatus.Fatal : ProviderStatus.Error;
             var eventPayload = new ProviderEventPayload

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OpenFeature.Constant;
+using OpenFeature.Error;
 using OpenFeature.Model;
 
 namespace OpenFeature
@@ -37,7 +38,7 @@ namespace OpenFeature
         private Api() { }
 
         /// <summary>
-        /// Sets the feature provider. In order to wait for the provider to be set, and initialization to complete,
+        /// Sets the default feature provider. In order to wait for the provider to be set, and initialization to complete,
         /// await the returned task.
         /// </summary>
         /// <remarks>The provider cannot be set to null. Attempting to set the provider to null has no effect.</remarks>
@@ -45,9 +46,8 @@ namespace OpenFeature
         public async Task SetProviderAsync(FeatureProvider featureProvider)
         {
             this._eventExecutor.RegisterDefaultFeatureProvider(featureProvider);
-            await this._repository.SetProviderAsync(featureProvider, this.GetContext()).ConfigureAwait(false);
+            await this._repository.SetProviderAsync(featureProvider, this.GetContext(), afterInitialization, afterError).ConfigureAwait(false);
         }
-
 
         /// <summary>
         /// Sets the feature provider to given clientName. In order to wait for the provider to be set, and
@@ -62,7 +62,7 @@ namespace OpenFeature
                 throw new ArgumentNullException(nameof(clientName));
             }
             this._eventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
-            await this._repository.SetProviderAsync(clientName, featureProvider, this.GetContext()).ConfigureAwait(false);
+            await this._repository.SetProviderAsync(clientName, featureProvider, this.GetContext(), afterInitialization, afterError).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace OpenFeature
         /// <returns><see cref="FeatureClient"/></returns>
         public FeatureClient GetClient(string? name = null, string? version = null, ILogger? logger = null,
             EvaluationContext? context = null) =>
-            new FeatureClient(name, version, logger, context);
+            new FeatureClient(() => _repository.GetProvider(name), name, version, logger, context);
 
         /// <summary>
         /// Appends list of hooks to global hooks list
@@ -265,5 +265,37 @@ namespace OpenFeature
 
         internal void RemoveClientHandler(string client, ProviderEventTypes eventType, EventHandlerDelegate handler)
             => this._eventExecutor.RemoveClientHandler(client, eventType, handler);
+
+        /// <summary>
+        /// Update the provider state to READY and emit an READY after successful init.
+        /// </summary>
+        private void afterInitialization(FeatureProvider provider)
+        {
+            provider.Status = ProviderStatus.Ready;
+            var eventPayload = new ProviderEventPayload
+            {
+                Type = ProviderEventTypes.ProviderReady,
+                Message = "Provider initialization complete",
+                ProviderName = provider.GetMetadata().Name,
+            };
+
+            this._eventExecutor.EventChannel.Writer.WriteAsync(new Event { Provider = provider, EventPayload = eventPayload });
+        }
+
+        /// <summary>
+        /// Update the provider state to ERROR and emit an ERROR after failed init.
+        /// </summary>
+        private void afterError(FeatureProvider provider, Exception ex)
+        {
+            provider.Status = typeof(ProviderFatalException) == ex.GetType() ? ProviderStatus.Fatal : ProviderStatus.Error;
+            var eventPayload = new ProviderEventPayload
+            {
+                Type = ProviderEventTypes.ProviderError,
+                Message = $"Provider initialization error: {ex?.Message}",
+                ProviderName = provider.GetMetadata()?.Name,
+            };
+
+            this._eventExecutor.EventChannel.Writer.WriteAsync(new Event { Provider = provider, EventPayload = eventPayload });
+        }
     }
 }

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -268,7 +268,8 @@ namespace OpenFeature
             => this._eventExecutor.RemoveClientHandler(client, eventType, handler);
 
         /// <summary>
-        /// Update the provider state to READY and emit an READY after successful init.
+        /// Update the provider state to READY and emit a READY event after successful init.
+
         /// </summary>
         private async Task AfterInitialization(FeatureProvider provider)
         {

--- a/src/OpenFeature/Constant/ErrorType.cs
+++ b/src/OpenFeature/Constant/ErrorType.cs
@@ -47,5 +47,10 @@ namespace OpenFeature.Constant
         /// Context does not contain a targeting key and the provider requires one.
         /// </summary>
         [Description("TARGETING_KEY_MISSING")] TargetingKeyMissing,
+
+        /// <summary>
+        /// The provider has entered an irrecoverable error state.
+        /// </summary>
+        [Description("PROVIDER_FATAL")] ProviderFatal,
     }
 }

--- a/src/OpenFeature/Constant/ProviderStatus.cs
+++ b/src/OpenFeature/Constant/ProviderStatus.cs
@@ -26,6 +26,11 @@ namespace OpenFeature.Constant
         /// <summary>
         /// The provider is in an error state and unable to evaluate flags.
         /// </summary>
-        [Description("ERROR")] Error
+        [Description("ERROR")] Error,
+
+        /// <summary>
+        /// The provider has entered an irrecoverable error state.
+        /// </summary>
+        [Description("FATAL")] Fatal,
     }
 }

--- a/src/OpenFeature/Error/ProviderFatalException.cs
+++ b/src/OpenFeature/Error/ProviderFatalException.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using OpenFeature.Constant;
+
+namespace OpenFeature.Error
+{
+    /// <summary> the
+    /// An exception that signals the provider has entered an irrecoverable error state.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class ProviderFatalException : FeatureProviderException
+    {
+        /// <summary>
+        /// Initialize a new instance of the <see cref="ProviderFatalException"/> class
+        /// </summary>
+        /// <param name="message">Exception message</param>
+        /// <param name="innerException">Optional inner exception</param>
+        public ProviderFatalException(string? message = null, Exception? innerException = null)
+            : base(ErrorType.ProviderFatal, message, innerException)
+        {
+        }
+    }
+}

--- a/src/OpenFeature/Error/ProviderNotReadyException.cs
+++ b/src/OpenFeature/Error/ProviderNotReadyException.cs
@@ -5,7 +5,7 @@ using OpenFeature.Constant;
 namespace OpenFeature.Error
 {
     /// <summary>
-    /// Provider has yet been initialized when evaluating a flag.
+    /// Provider has not yet been initialized when evaluating a flag.
     /// </summary>
     [ExcludeFromCodeCoverage]
     public class ProviderNotReadyException : FeatureProviderException

--- a/src/OpenFeature/EventExecutor.cs
+++ b/src/OpenFeature/EventExecutor.cs
@@ -320,7 +320,7 @@ namespace OpenFeature
                     provider.Status = ProviderStatus.Stale;
                     break;
                 case ProviderEventTypes.ProviderError:
-                    provider.Status = eventPayload.errorType == ErrorType.ProviderFatal ? ProviderStatus.Fatal : ProviderStatus.Error;
+                    provider.Status = eventPayload.ErrorType == ErrorType.ProviderFatal ? ProviderStatus.Fatal : ProviderStatus.Error;
                     break;
                 default: break;
             }

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -1,6 +1,6 @@
 using System.Collections.Immutable;
-using System.Threading;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using OpenFeature.Constant;

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -1,10 +1,12 @@
 using System.Collections.Immutable;
 using System.Threading;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")] // required to allow NSubstitute mocking of internal methods
 namespace OpenFeature
 {
     /// <summary>
@@ -94,22 +96,17 @@ namespace OpenFeature
             EvaluationContext? context = null, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Get the status of the provider.
+        /// Internally-managed provider status.
+        /// The SDK uses this field to track the status of the provider.
+        /// Not visible outside OpenFeature assembly
         /// </summary>
-        /// <returns>The current <see cref="ProviderStatus"/></returns>
-        /// <remarks>
-        /// If a provider does not override this method, then its status will be assumed to be
-        /// <see cref="ProviderStatus.Ready"/>. If a provider implements this method, and supports initialization,
-        /// then it should start in the <see cref="ProviderStatus.NotReady"/>status . If the status is
-        /// <see cref="ProviderStatus.NotReady"/>, then the Api will call the <see cref="InitializeAsync" /> when the
-        /// provider is set.
-        /// </remarks>
-        public virtual ProviderStatus GetStatus() => ProviderStatus.Ready;
+        internal virtual ProviderStatus Status { get; set; } = ProviderStatus.NotReady;
 
         /// <summary>
         /// <para>
         /// This method is called before a provider is used to evaluate flags. Providers can overwrite this method,
         /// if they have special initialization needed prior being called for flag evaluation.
+        /// When this method completes, the provider will be considered ready for use.
         /// </para>
         /// </summary>
         /// <param name="context"><see cref="EvaluationContext"/></param>
@@ -117,12 +114,7 @@ namespace OpenFeature
         /// <returns>A task that completes when the initialization process is complete.</returns>
         /// <remarks>
         /// <para>
-        /// A provider which supports initialization should override this method as well as
-        /// <see cref="GetStatus"/>.
-        /// </para>
-        /// <para>
-        /// The provider should return <see cref="ProviderStatus.Ready"/> or <see cref="ProviderStatus.Error"/> from
-        /// the <see cref="GetStatus"/> method after initialization is complete.
+        /// Providers not implementing this method will be considered ready immediately.
         /// </para>
         /// </remarks>
         public virtual Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)

--- a/src/OpenFeature/IFeatureClient.cs
+++ b/src/OpenFeature/IFeatureClient.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using OpenFeature.Constant;
 using OpenFeature.Model;
 
 namespace OpenFeature
@@ -52,6 +53,12 @@ namespace OpenFeature
         /// </summary>
         /// <returns>Client metadata <see cref="ClientMetadata"/></returns>
         ClientMetadata GetMetadata();
+
+        /// <summary>
+        /// Returns the current status of the associated provider.
+        /// </summary>
+        /// <returns><see cref="ProviderStatus"/></returns>
+        ProviderStatus ProviderStatus { get; }
 
         /// <summary>
         /// Resolves a boolean feature flag

--- a/src/OpenFeature/Model/ProviderEvents.cs
+++ b/src/OpenFeature/Model/ProviderEvents.cs
@@ -31,7 +31,7 @@ namespace OpenFeature.Model
         /// <summary>
         /// Optional error associated with the event. 
         /// </summary>
-        public ErrorType? errorType { get; set; }
+        public ErrorType? ErrorType { get; set; }
 
         /// <summary>
         /// A List of flags that have been changed.

--- a/src/OpenFeature/Model/ProviderEvents.cs
+++ b/src/OpenFeature/Model/ProviderEvents.cs
@@ -29,6 +29,11 @@ namespace OpenFeature.Model
         public string? Message { get; set; }
 
         /// <summary>
+        /// Optional error associated with the event. 
+        /// </summary>
+        public ErrorType? errorType { get; set; }
+
+        /// <summary>
         /// A List of flags that have been changed.
         /// </summary>
         public List<string>? FlagsChanged { get; set; }

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -44,31 +44,18 @@ namespace OpenFeature
         /// </summary>
         /// <param name="featureProvider">the provider to set as the default, passing null has no effect</param>
         /// <param name="context">the context to initialize the provider with</param>
-        /// <param name="afterSet">
-        /// <para>
-        /// Called after the provider is set, but before any actions are taken on it.
-        /// </para>
-        /// This can be used for tasks such as registering event handlers. It should be noted that this can be called
-        /// several times for a single provider. For instance registering a provider with multiple names or as the
-        /// default and named provider.
-        /// <para>
-        /// </para>
-        /// </param>
-        /// <param name="afterInitialization">
+        /// <param name="afterInitSuccess">
         /// called after the provider has initialized successfully, only called if the provider needed initialization
         /// </param>
-        /// <param name="afterError">
+        /// <param name="afterInitError">
         /// called if an error happens during the initialization of the provider, only called if the provider needed
         /// initialization
         /// </param>
-        /// <param name="afterShutdown">called after a provider is shutdown, can be used to remove event handlers</param>
         public async Task SetProviderAsync(
             FeatureProvider? featureProvider,
             EvaluationContext context,
-            Action<FeatureProvider>? afterSet = null,
-            Action<FeatureProvider>? afterInitialization = null,
-            Action<FeatureProvider, Exception>? afterError = null,
-            Action<FeatureProvider>? afterShutdown = null)
+            Action<FeatureProvider>? afterInitSuccess = null,
+            Action<FeatureProvider, Exception>? afterInitError = null)
         {
             // Cannot unset the feature provider.
             if (featureProvider == null)
@@ -88,19 +75,16 @@ namespace OpenFeature
 
                 var oldProvider = this._defaultProvider;
                 this._defaultProvider = featureProvider;
-                afterSet?.Invoke(featureProvider);
                 // We want to allow shutdown to happen concurrently with initialization, and the caller to not
                 // wait for it.
-#pragma warning disable CS4014
-                this.ShutdownIfUnusedAsync(oldProvider, afterShutdown, afterError);
-#pragma warning restore CS4014
+                _ = this.ShutdownIfUnusedAsync(oldProvider);
             }
             finally
             {
                 this._providersLock.ExitWriteLock();
             }
 
-            await InitProviderAsync(this._defaultProvider, context, afterInitialization, afterError)
+            await InitProviderAsync(this._defaultProvider, context, afterInitSuccess, afterInitError)
                 .ConfigureAwait(false);
         }
 
@@ -114,7 +98,7 @@ namespace OpenFeature
             {
                 return;
             }
-            if (newProvider.GetStatus() == ProviderStatus.NotReady)
+            if (newProvider.Status == ProviderStatus.NotReady)
             {
                 try
                 {
@@ -134,32 +118,19 @@ namespace OpenFeature
         /// <param name="clientName">the name to associate with the provider</param>
         /// <param name="featureProvider">the provider to set as the default, passing null has no effect</param>
         /// <param name="context">the context to initialize the provider with</param>
-        /// <param name="afterSet">
-        /// <para>
-        /// Called after the provider is set, but before any actions are taken on it.
-        /// </para>
-        /// This can be used for tasks such as registering event handlers. It should be noted that this can be called
-        /// several times for a single provider. For instance registering a provider with multiple names or as the
-        /// default and named provider.
-        /// <para>
-        /// </para>
-        /// </param>
-        /// <param name="afterInitialization">
+        /// <param name="afterInitSuccess">
         /// called after the provider has initialized successfully, only called if the provider needed initialization
         /// </param>
-        /// <param name="afterError">
+        /// <param name="afterInitError">
         /// called if an error happens during the initialization of the provider, only called if the provider needed
         /// initialization
         /// </param>
-        /// <param name="afterShutdown">called after a provider is shutdown, can be used to remove event handlers</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel any async side effects.</param>
-        public async Task SetProviderAsync(string clientName,
+        public async Task SetProviderAsync(string? clientName,
             FeatureProvider? featureProvider,
             EvaluationContext context,
-            Action<FeatureProvider>? afterSet = null,
-            Action<FeatureProvider>? afterInitialization = null,
-            Action<FeatureProvider, Exception>? afterError = null,
-            Action<FeatureProvider>? afterShutdown = null,
+            Action<FeatureProvider>? afterInitSuccess = null,
+            Action<FeatureProvider, Exception>? afterInitError = null,
             CancellationToken cancellationToken = default)
         {
             // Cannot set a provider for a null clientName.
@@ -177,7 +148,6 @@ namespace OpenFeature
                 {
                     this._featureProviders.AddOrUpdate(clientName, featureProvider,
                         (key, current) => featureProvider);
-                    afterSet?.Invoke(featureProvider);
                 }
                 else
                 {
@@ -188,25 +158,21 @@ namespace OpenFeature
 
                 // We want to allow shutdown to happen concurrently with initialization, and the caller to not
                 // wait for it.
-#pragma warning disable CS4014
-                this.ShutdownIfUnusedAsync(oldProvider, afterShutdown, afterError);
-#pragma warning restore CS4014
+                _ = this.ShutdownIfUnusedAsync(oldProvider);
             }
             finally
             {
                 this._providersLock.ExitWriteLock();
             }
 
-            await InitProviderAsync(featureProvider, context, afterInitialization, afterError).ConfigureAwait(false);
+            await InitProviderAsync(featureProvider, context, afterInitSuccess, afterInitError).ConfigureAwait(false);
         }
 
         /// <remarks>
         /// Shutdown the feature provider if it is unused. This must be called within a write lock of the _providersLock.
         /// </remarks>
         private async Task ShutdownIfUnusedAsync(
-            FeatureProvider? targetProvider,
-            Action<FeatureProvider>? afterShutdown,
-            Action<FeatureProvider, Exception>? afterError)
+            FeatureProvider? targetProvider)
         {
             if (ReferenceEquals(this._defaultProvider, targetProvider))
             {
@@ -218,7 +184,7 @@ namespace OpenFeature
                 return;
             }
 
-            await SafeShutdownProviderAsync(targetProvider, afterShutdown, afterError).ConfigureAwait(false);
+            await SafeShutdownProviderAsync(targetProvider).ConfigureAwait(false);
         }
 
         /// <remarks>
@@ -230,9 +196,7 @@ namespace OpenFeature
         /// it would not be meaningful to emit an error.
         /// </para>
         /// </remarks>
-        private static async Task SafeShutdownProviderAsync(FeatureProvider? targetProvider,
-            Action<FeatureProvider>? afterShutdown,
-            Action<FeatureProvider, Exception>? afterError)
+        private async Task SafeShutdownProviderAsync(FeatureProvider? targetProvider)
         {
             if (targetProvider == null)
             {
@@ -242,11 +206,9 @@ namespace OpenFeature
             try
             {
                 await targetProvider.ShutdownAsync().ConfigureAwait(false);
-                afterShutdown?.Invoke(targetProvider);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                afterError?.Invoke(targetProvider, ex);
             }
         }
 
@@ -307,7 +269,7 @@ namespace OpenFeature
             foreach (var targetProvider in providers)
             {
                 // We don't need to take any actions after shutdown.
-                await SafeShutdownProviderAsync(targetProvider, null, afterError).ConfigureAwait(false);
+                await SafeShutdownProviderAsync(targetProvider).ConfigureAwait(false);
             }
         }
     }

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -12,7 +12,6 @@ using NSubstitute.ExceptionExtensions;
 using OpenFeature.Constant;
 using OpenFeature.Error;
 using OpenFeature.Model;
-using OpenFeature.Providers.Memory;
 using OpenFeature.Tests.Internal;
 using Xunit;
 

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -235,7 +235,7 @@ namespace OpenFeature.Tests
 
         [Fact]
         [Specification("1.7.6", "The client MUST default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in NOT_READY.")]
-        public async void Must_Short_Circuit_Not_Ready()
+        public async Task Must_Short_Circuit_Not_Ready()
         {
             var name = "1.7.6";
             var defaultStr = "123-default";
@@ -254,7 +254,7 @@ namespace OpenFeature.Tests
 
         [Fact]
         [Specification("1.7.7", "The client MUST default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in NOT_READY.")]
-        public async void Must_Short_Circuit_Fatal()
+        public async Task Must_Short_Circuit_Fatal()
         {
             var name = "1.7.6";
             var defaultStr = "456-default";

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -28,13 +28,13 @@ namespace OpenFeature.Tests
         public async Task OpenFeature_Should_Initialize_Provider()
         {
             var providerMockDefault = Substitute.For<FeatureProvider>();
-            providerMockDefault.GetStatus().Returns(ProviderStatus.NotReady);
+            providerMockDefault.Status.Returns(ProviderStatus.NotReady);
 
             await Api.Instance.SetProviderAsync(providerMockDefault);
             await providerMockDefault.Received(1).InitializeAsync(Api.Instance.GetContext());
 
             var providerMockNamed = Substitute.For<FeatureProvider>();
-            providerMockNamed.GetStatus().Returns(ProviderStatus.NotReady);
+            providerMockNamed.Status.Returns(ProviderStatus.NotReady);
 
             await Api.Instance.SetProviderAsync("the-name", providerMockNamed);
             await providerMockNamed.Received(1).InitializeAsync(Api.Instance.GetContext());
@@ -46,26 +46,26 @@ namespace OpenFeature.Tests
         public async Task OpenFeature_Should_Shutdown_Unused_Provider()
         {
             var providerA = Substitute.For<FeatureProvider>();
-            providerA.GetStatus().Returns(ProviderStatus.NotReady);
+            providerA.Status.Returns(ProviderStatus.NotReady);
 
             await Api.Instance.SetProviderAsync(providerA);
             await providerA.Received(1).InitializeAsync(Api.Instance.GetContext());
 
             var providerB = Substitute.For<FeatureProvider>();
-            providerB.GetStatus().Returns(ProviderStatus.NotReady);
+            providerB.Status.Returns(ProviderStatus.NotReady);
 
             await Api.Instance.SetProviderAsync(providerB);
             await providerB.Received(1).InitializeAsync(Api.Instance.GetContext());
             await providerA.Received(1).ShutdownAsync();
 
             var providerC = Substitute.For<FeatureProvider>();
-            providerC.GetStatus().Returns(ProviderStatus.NotReady);
+            providerC.Status.Returns(ProviderStatus.NotReady);
 
             await Api.Instance.SetProviderAsync("named", providerC);
             await providerC.Received(1).InitializeAsync(Api.Instance.GetContext());
 
             var providerD = Substitute.For<FeatureProvider>();
-            providerD.GetStatus().Returns(ProviderStatus.NotReady);
+            providerD.Status.Returns(ProviderStatus.NotReady);
 
             await Api.Instance.SetProviderAsync("named", providerD);
             await providerD.Received(1).InitializeAsync(Api.Instance.GetContext());
@@ -77,10 +77,10 @@ namespace OpenFeature.Tests
         public async Task OpenFeature_Should_Support_Shutdown()
         {
             var providerA = Substitute.For<FeatureProvider>();
-            providerA.GetStatus().Returns(ProviderStatus.NotReady);
+            providerA.Status.Returns(ProviderStatus.NotReady);
 
             var providerB = Substitute.For<FeatureProvider>();
-            providerB.GetStatus().Returns(ProviderStatus.NotReady);
+            providerB.Status.Returns(ProviderStatus.NotReady);
 
             await Api.Instance.SetProviderAsync(providerA);
             await Api.Instance.SetProviderAsync("named", providerB);

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -48,6 +48,7 @@ namespace OpenFeature.Tests
             {
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
+                return Task.CompletedTask;
             });
             Assert.Equal(1, callCount);
         }
@@ -67,6 +68,7 @@ namespace OpenFeature.Tests
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
                 receivedError = error;
+                return Task.CompletedTask;
             });
             Assert.Equal("BAD THINGS", receivedError?.Message);
             Assert.Equal(1, callCount);
@@ -97,7 +99,11 @@ namespace OpenFeature.Tests
             providerMock.Status.Returns(status);
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
-            await repository.SetProviderAsync(providerMock, context, afterInitSuccess: provider => { callCount++; });
+            await repository.SetProviderAsync(providerMock, context, afterInitSuccess: provider =>
+            {
+                callCount++;
+                return Task.CompletedTask;
+            });
             Assert.Equal(0, callCount);
         }
 
@@ -153,6 +159,7 @@ namespace OpenFeature.Tests
             {
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
+                return Task.CompletedTask;
             });
             Assert.Equal(1, callCount);
         }
@@ -172,6 +179,7 @@ namespace OpenFeature.Tests
                 Assert.Equal(providerMock, theProvider);
                 callCount++;
                 receivedError = error;
+                return Task.CompletedTask;
             });
             Assert.Equal("BAD THINGS", receivedError?.Message);
             Assert.Equal(1, callCount);
@@ -203,7 +211,11 @@ namespace OpenFeature.Tests
             var context = new EvaluationContextBuilder().Build();
             var callCount = 0;
             await repository.SetProviderAsync("the-name", providerMock, context,
-                afterInitSuccess: provider => { callCount++; });
+                afterInitSuccess: provider =>
+                {
+                    callCount++;
+                    return Task.CompletedTask;
+                });
             Assert.Equal(0, callCount);
         }
 


### PR DESCRIPTION
This PR implements a few things from spec 0.8.0:

- implements internal provider status (already implemented in JS)
  - the provider no longer updates its status to READY/ERROR, etc after init (the SDK does this automatically)
  - the provider's state is updated according to the last event it fired
- adds `PROVIDER_FATAL` error and code
- adds "short circuit" feature when evaluations are skipped if provider is `NOT_READY` or `FATAL`
- removes some deprecations that were making the work harder since we already have pending breaking changes.


Fixes: https://github.com/open-feature/dotnet-sdk/issues/250