### PR TITLE
chore: cleanup code

### DIFF
--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -101,7 +101,7 @@ namespace OpenFeature
         /// </para>
         /// </summary>
         /// <returns><see cref="ClientMetadata"/></returns>
-        public Metadata GetProviderMetadata() => this.GetProvider().GetMetadata();
+        public Metadata? GetProviderMetadata() => this.GetProvider().GetMetadata();
 
         /// <summary>
         /// Gets providers metadata assigned to the given clientName. If the clientName has no provider
@@ -109,7 +109,7 @@ namespace OpenFeature
         /// </summary>
         /// <param name="clientName">Name of client</param>
         /// <returns>Metadata assigned to provider</returns>
-        public Metadata GetProviderMetadata(string clientName) => this.GetProvider(clientName).GetMetadata();
+        public Metadata? GetProviderMetadata(string clientName) => this.GetProvider(clientName).GetMetadata();
 
         /// <summary>
         /// Create a new instance of <see cref="FeatureClient"/> using the current provider
@@ -277,7 +277,7 @@ namespace OpenFeature
             {
                 Type = ProviderEventTypes.ProviderReady,
                 Message = "Provider initialization complete",
-                ProviderName = provider.GetMetadata().Name,
+                ProviderName = provider.GetMetadata()?.Name,
             };
 
             await this._eventExecutor.EventChannel.Writer.WriteAsync(new Event { Provider = provider, EventPayload = eventPayload }).ConfigureAwait(false);
@@ -287,14 +287,13 @@ namespace OpenFeature
         /// Update the provider state to ERROR and emit an ERROR after failed init.
         /// </summary>
         private async Task AfterError(FeatureProvider provider, Exception? ex)
-
         {
             provider.Status = typeof(ProviderFatalException) == ex?.GetType() ? ProviderStatus.Fatal : ProviderStatus.Error;
             var eventPayload = new ProviderEventPayload
             {
                 Type = ProviderEventTypes.ProviderError,
                 Message = $"Provider initialization error: {ex?.Message}",
-                ProviderName = provider.GetMetadata().Name,
+                ProviderName = provider.GetMetadata()?.Name,
             };
 
             await this._eventExecutor.EventChannel.Writer.WriteAsync(new Event { Provider = provider, EventPayload = eventPayload }).ConfigureAwait(false);

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -286,14 +286,14 @@ namespace OpenFeature
         /// <summary>
         /// Update the provider state to ERROR and emit an ERROR after failed init.
         /// </summary>
-        private async Task AfterError(FeatureProvider provider, Exception ex)
+        private async Task AfterError(FeatureProvider provider, Exception? ex)
 
         {
-            provider.Status = typeof(ProviderFatalException) == ex.GetType() ? ProviderStatus.Fatal : ProviderStatus.Error;
+            provider.Status = typeof(ProviderFatalException) == ex?.GetType() ? ProviderStatus.Fatal : ProviderStatus.Error;
             var eventPayload = new ProviderEventPayload
             {
                 Type = ProviderEventTypes.ProviderError,
-                Message = $"Provider initialization error: {ex.Message}",
+                Message = $"Provider initialization error: {ex?.Message}",
                 ProviderName = provider.GetMetadata().Name,
             };
 

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -46,7 +46,7 @@ namespace OpenFeature
         public async Task SetProviderAsync(FeatureProvider featureProvider)
         {
             this._eventExecutor.RegisterDefaultFeatureProvider(featureProvider);
-            await this._repository.SetProviderAsync(featureProvider, this.GetContext(), AfterInitialization, AfterError).ConfigureAwait(false);
+            await this._repository.SetProviderAsync(featureProvider, this.GetContext(), this.AfterInitialization, this.AfterError).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace OpenFeature
                 throw new ArgumentNullException(nameof(clientName));
             }
             this._eventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
-            await this._repository.SetProviderAsync(clientName, featureProvider, this.GetContext(), AfterInitialization, AfterError).ConfigureAwait(false);
+            await this._repository.SetProviderAsync(clientName, featureProvider, this.GetContext(), this.AfterInitialization, this.AfterError).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace OpenFeature
         /// <returns><see cref="FeatureClient"/></returns>
         public FeatureClient GetClient(string? name = null, string? version = null, ILogger? logger = null,
             EvaluationContext? context = null) =>
-            new FeatureClient(() => _repository.GetProvider(name), name, version, logger, context);
+            new FeatureClient(() => this._repository.GetProvider(name), name, version, logger, context);
 
         /// <summary>
         /// Appends list of hooks to global hooks list

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -32,7 +32,7 @@ namespace OpenFeature
         public static Api Instance { get; } = new Api();
 
         // Explicit static constructor to tell C# compiler
-        // not to mark type as beforefieldinit
+        // not to mark type as beforeFieldInit
         // IE Lazy way of ensuring this is thread safe without using locks
         static Api() { }
         private Api() { }
@@ -293,8 +293,8 @@ namespace OpenFeature
             var eventPayload = new ProviderEventPayload
             {
                 Type = ProviderEventTypes.ProviderError,
-                Message = $"Provider initialization error: {ex?.Message}",
-                ProviderName = provider.GetMetadata()?.Name,
+                Message = $"Provider initialization error: {ex.Message}",
+                ProviderName = provider.GetMetadata().Name,
             };
 
             await this._eventExecutor.EventChannel.Writer.WriteAsync(new Event { Provider = provider, EventPayload = eventPayload }).ConfigureAwait(false);

--- a/src/OpenFeature/Constant/Reason.cs
+++ b/src/OpenFeature/Constant/Reason.cs
@@ -9,42 +9,42 @@ namespace OpenFeature.Constant
         /// <summary>
         /// Use when the flag is matched based on the evaluation context user data
         /// </summary>
-        public static string TargetingMatch = "TARGETING_MATCH";
+        public const string TargetingMatch = "TARGETING_MATCH";
 
         /// <summary>
         /// Use when the flag is matched based on a split rule in the feature flag provider
         /// </summary>
-        public static string Split = "SPLIT";
+        public const string Split = "SPLIT";
 
         /// <summary>
         /// Use when the flag is disabled in the feature flag provider
         /// </summary>
-        public static string Disabled = "DISABLED";
+        public const string Disabled = "DISABLED";
 
         /// <summary>
         /// Default reason when evaluating flag
         /// </summary>
-        public static string Default = "DEFAULT";
+        public const string Default = "DEFAULT";
 
         /// <summary>
         /// The resolved value is static (no dynamic evaluation)
         /// </summary>
-        public static string Static = "STATIC";
+        public const string Static = "STATIC";
 
         /// <summary>
         /// The resolved value was retrieved from cache
         /// </summary>
-        public static string Cached = "CACHED";
+        public const string Cached = "CACHED";
 
         /// <summary>
         /// Use when an unknown reason is encountered when evaluating flag.
         /// An example of this is if the feature provider returns a reason that is not defined in the spec
         /// </summary>
-        public static string Unknown = "UNKNOWN";
+        public const string Unknown = "UNKNOWN";
 
         /// <summary>
         /// Use this flag when abnormal execution is encountered.
         /// </summary>
-        public static string Error = "ERROR";
+        public const string Error = "ERROR";
     }
 }

--- a/src/OpenFeature/Error/ProviderFatalException.cs
+++ b/src/OpenFeature/Error/ProviderFatalException.cs
@@ -4,7 +4,7 @@ using OpenFeature.Constant;
 
 namespace OpenFeature.Error
 {
-    /// <summary> the
+    /// <summary>
     /// An exception that signals the provider has entered an irrecoverable error state.
     /// </summary>
     [ExcludeFromCodeCoverage]

--- a/src/OpenFeature/EventExecutor.cs
+++ b/src/OpenFeature/EventExecutor.cs
@@ -206,7 +206,7 @@ namespace OpenFeature
                 {
                     handler.Invoke(new ProviderEventPayload
                     {
-                        ProviderName = provider.GetMetadata().Name,
+                        ProviderName = provider.GetMetadata()?.Name,
                         Type = eventType,
                         Message = message
                     });

--- a/src/OpenFeature/EventExecutor.cs
+++ b/src/OpenFeature/EventExecutor.cs
@@ -322,6 +322,7 @@ namespace OpenFeature
                 case ProviderEventTypes.ProviderError:
                     provider.Status = eventPayload.ErrorType == ErrorType.ProviderFatal ? ProviderStatus.Fatal : ProviderStatus.Error;
                     break;
+                case ProviderEventTypes.ProviderConfigurationChanged:
                 default: break;
             }
         }

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -11,14 +11,14 @@ namespace OpenFeature
 {
     /// <summary>
     /// The provider interface describes the abstraction layer for a feature flag provider.
-    /// A provider acts as the translates layer between the generic feature flag structure to a target feature flag system.
+    /// A provider acts as it translates layer between the generic feature flag structure to a target feature flag system.
     /// </summary>
     /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/sections/02-providers.md">Provider specification</seealso>
     public abstract class FeatureProvider
     {
         /// <summary>
-        /// Gets a immutable list of hooks that belong to the provider.
-        /// By default return a empty list
+        /// Gets an immutable list of hooks that belong to the provider.
+        /// By default, return an empty list
         ///
         /// Executed in the order of hooks
         /// before: API, Client, Invocation, Provider

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -38,7 +38,7 @@ namespace OpenFeature
         /// Metadata describing the provider.
         /// </summary>
         /// <returns><see cref="Metadata"/></returns>
-        public abstract Metadata GetMetadata();
+        public abstract Metadata? GetMetadata();
 
         /// <summary>
         /// Resolves a boolean feature flag

--- a/src/OpenFeature/Model/EvaluationContextBuilder.cs
+++ b/src/OpenFeature/Model/EvaluationContextBuilder.cs
@@ -140,9 +140,9 @@ namespace OpenFeature.Model
         {
             string? newTargetingKey = "";
 
-            if (!string.IsNullOrWhiteSpace(TargetingKey))
+            if (!string.IsNullOrWhiteSpace(this.TargetingKey))
             {
-                newTargetingKey = TargetingKey;
+                newTargetingKey = this.TargetingKey;
             }
 
             if (!string.IsNullOrWhiteSpace(context.TargetingKey))

--- a/src/OpenFeature/Model/FlagEvaluationOptions.cs
+++ b/src/OpenFeature/Model/FlagEvaluationOptions.cs
@@ -10,12 +10,12 @@ namespace OpenFeature.Model
     public sealed class FlagEvaluationOptions
     {
         /// <summary>
-        /// A immutable list of <see cref="Hook"/>
+        /// An immutable list of <see cref="Hook"/>
         /// </summary>
         public IImmutableList<Hook> Hooks { get; }
 
         /// <summary>
-        /// A immutable dictionary of hook hints
+        /// An immutable dictionary of hook hints
         /// </summary>
         public IImmutableDictionary<string, object> HookHints { get; }
 

--- a/src/OpenFeature/Model/ImmutableMetadata.cs
+++ b/src/OpenFeature/Model/ImmutableMetadata.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
-#nullable enable
 namespace OpenFeature.Model;
 
 /// <summary>

--- a/src/OpenFeature/Model/Value.cs
+++ b/src/OpenFeature/Model/Value.cs
@@ -139,49 +139,49 @@ namespace OpenFeature.Model
         public object? AsObject => this._innerValue;
 
         /// <summary>
-        /// Returns the underlying int value
-        /// Value will be null if it isn't a integer
+        /// Returns the underlying int value.
+        /// Value will be null if it isn't an integer
         /// </summary>
         /// <returns>Value as int</returns>
-        public int? AsInteger => this.IsNumber ? (int?)Convert.ToInt32((double?)this._innerValue) : null;
+        public int? AsInteger => this.IsNumber ? Convert.ToInt32((double?)this._innerValue) : null;
 
         /// <summary>
-        /// Returns the underlying bool value
+        /// Returns the underlying bool value.
         /// Value will be null if it isn't a bool
         /// </summary>
         /// <returns>Value as bool</returns>
         public bool? AsBoolean => this.IsBoolean ? (bool?)this._innerValue : null;
 
         /// <summary>
-        /// Returns the underlying double value
+        /// Returns the underlying double value.
         /// Value will be null if it isn't a double
         /// </summary>
         /// <returns>Value as int</returns>
         public double? AsDouble => this.IsNumber ? (double?)this._innerValue : null;
 
         /// <summary>
-        /// Returns the underlying string value
+        /// Returns the underlying string value.
         /// Value will be null if it isn't a string
         /// </summary>
         /// <returns>Value as string</returns>
         public string? AsString => this.IsString ? (string?)this._innerValue : null;
 
         /// <summary>
-        /// Returns the underlying Structure value
+        /// Returns the underlying Structure value.
         /// Value will be null if it isn't a Structure
         /// </summary>
         /// <returns>Value as Structure</returns>
         public Structure? AsStructure => this.IsStructure ? (Structure?)this._innerValue : null;
 
         /// <summary>
-        /// Returns the underlying List value
+        /// Returns the underlying List value.
         /// Value will be null if it isn't a List
         /// </summary>
         /// <returns>Value as List</returns>
         public IImmutableList<Value>? AsList => this.IsList ? (IImmutableList<Value>?)this._innerValue : null;
 
         /// <summary>
-        /// Returns the underlying DateTime value
+        /// Returns the underlying DateTime value.
         /// Value will be null if it isn't a DateTime
         /// </summary>
         /// <returns>Value as DateTime</returns>

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -349,7 +349,7 @@ namespace OpenFeature
                 }
                 catch (Exception e)
                 {
-                    this._logger.LogError(e, "Error while executing Finally hook {HookName}", hook.GetType().Name);
+                    this.FinallyHookError(hook.GetType().Name, e);
                 }
             }
         }

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -212,11 +212,8 @@ namespace OpenFeature
             var resolveValueDelegate = providerInfo.Item1;
             var provider = providerInfo.Item2;
 
-            // New up a evaluation context if one was not provided.
-            if (context == null)
-            {
-                context = EvaluationContext.Empty;
-            }
+            // New up an evaluation context if one was not provided.
+            context ??= EvaluationContext.Empty;
 
             // merge api, client, and invocation context.
             var evaluationContext = Api.Instance.GetContext();

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -26,13 +26,13 @@ namespace OpenFeature
         /// The reader/writer locks is not disposed because the singleton instance should never be disposed.
         ///
         /// Mutations of the _defaultProvider or _featureProviders are done within this lock even though
-        /// _featureProvider is a concurrent collection. This is for a couple reasons, the first is that
+        /// _featureProvider is a concurrent collection. This is for a couple of reasons, the first is that
         /// a provider should only be shutdown if it is not in use, and it could be in use as either a named or
         /// default provider.
         ///
-        /// The second is that a concurrent collection doesn't provide any ordering so we could check a provider
+        /// The second is that a concurrent collection doesn't provide any ordering, so we could check a provider
         /// as it was being added or removed such as two concurrent calls to SetProvider replacing multiple instances
-        /// of that provider under different names..
+        /// of that provider under different names.
         private readonly ReaderWriterLockSlim _providersLock = new ReaderWriterLockSlim();
 
         public async ValueTask DisposeAsync()
@@ -204,7 +204,7 @@ namespace OpenFeature
         /// Shut down the provider and capture any exceptions thrown.
         /// </para>
         /// <para>
-        /// The provider is set either to a name or default before the old provider it shutdown, so
+        /// The provider is set either to a name or default before the old provider it shut down, so
         /// it would not be meaningful to emit an error.
         /// </para>
         /// </remarks>

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -221,7 +221,7 @@ namespace OpenFeature
             }
             catch (Exception ex)
             {
-                this.ErrorShuttingDownProvider(targetProvider.GetMetadata().Name, ex);
+                this.ErrorShuttingDownProvider(targetProvider.GetMetadata()?.Name, ex);
             }
         }
 

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -201,7 +201,7 @@ namespace OpenFeature
                 return;
             }
 
-            await SafeShutdownProviderAsync(targetProvider).ConfigureAwait(false);
+            await this.SafeShutdownProviderAsync(targetProvider).ConfigureAwait(false);
         }
 
         /// <remarks>
@@ -287,7 +287,7 @@ namespace OpenFeature
             foreach (var targetProvider in providers)
             {
                 // We don't need to take any actions after shutdown.
-                await SafeShutdownProviderAsync(targetProvider).ConfigureAwait(false);
+                await this.SafeShutdownProviderAsync(targetProvider).ConfigureAwait(false);
             }
         }
     }

--- a/src/OpenFeature/Providers/Memory/Flag.cs
+++ b/src/OpenFeature/Providers/Memory/Flag.cs
@@ -9,19 +9,16 @@ namespace OpenFeature.Providers.Memory
     /// <summary>
     /// Flag representation for the in-memory provider.
     /// </summary>
-    public interface Flag
-    {
-
-    }
+    public interface Flag;
 
     /// <summary>
     /// Flag representation for the in-memory provider.
     /// </summary>
     public sealed class Flag<T> : Flag
     {
-        private Dictionary<string, T> Variants;
-        private string DefaultVariant;
-        private Func<EvaluationContext, string>? ContextEvaluator;
+        private readonly Dictionary<string, T> _variants;
+        private readonly string _defaultVariant;
+        private readonly Func<EvaluationContext, string>? _contextEvaluator;
 
         /// <summary>
         /// Flag representation for the in-memory provider.
@@ -31,34 +28,34 @@ namespace OpenFeature.Providers.Memory
         /// <param name="contextEvaluator">optional context-sensitive evaluation function</param>
         public Flag(Dictionary<string, T> variants, string defaultVariant, Func<EvaluationContext, string>? contextEvaluator = null)
         {
-            this.Variants = variants;
-            this.DefaultVariant = defaultVariant;
-            this.ContextEvaluator = contextEvaluator;
+            this._variants = variants;
+            this._defaultVariant = defaultVariant;
+            this._contextEvaluator = contextEvaluator;
         }
 
         internal ResolutionDetails<T> Evaluate(string flagKey, T _, EvaluationContext? evaluationContext)
         {
-            T? value = default;
-            if (this.ContextEvaluator == null)
+            T? value;
+            if (this._contextEvaluator == null)
             {
-                if (this.Variants.TryGetValue(this.DefaultVariant, out value))
+                if (this._variants.TryGetValue(this._defaultVariant, out value))
                 {
                     return new ResolutionDetails<T>(
                         flagKey,
                         value,
-                        variant: this.DefaultVariant,
+                        variant: this._defaultVariant,
                         reason: Reason.Static
                     );
                 }
                 else
                 {
-                    throw new GeneralException($"variant {this.DefaultVariant} not found");
+                    throw new GeneralException($"variant {this._defaultVariant} not found");
                 }
             }
             else
             {
-                var variant = this.ContextEvaluator.Invoke(evaluationContext ?? EvaluationContext.Empty);
-                if (!this.Variants.TryGetValue(variant, out value))
+                var variant = this._contextEvaluator.Invoke(evaluationContext ?? EvaluationContext.Empty);
+                if (!this._variants.TryGetValue(variant, out value))
                 {
                     throw new GeneralException($"variant {variant} not found");
                 }

--- a/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
+++ b/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
@@ -61,7 +61,7 @@ namespace OpenFeature.Providers.Memory
             var @event = new ProviderEventPayload
             {
                 Type = ProviderEventTypes.ProviderConfigurationChanged,
-                ProviderName = _metadata.Name,
+                ProviderName = this._metadata.Name,
                 FlagsChanged = changed, // emit all
                 Message = "flags changed",
             };
@@ -71,31 +71,31 @@ namespace OpenFeature.Providers.Memory
         /// <inheritdoc/>
         public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(Resolve(flagKey, defaultValue, context));
+            return Task.FromResult(this.Resolve(flagKey, defaultValue, context));
         }
 
         /// <inheritdoc/>
         public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(Resolve(flagKey, defaultValue, context));
+            return Task.FromResult(this.Resolve(flagKey, defaultValue, context));
         }
 
         /// <inheritdoc/>
         public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(Resolve(flagKey, defaultValue, context));
+            return Task.FromResult(this.Resolve(flagKey, defaultValue, context));
         }
 
         /// <inheritdoc/>
         public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(Resolve(flagKey, defaultValue, context));
+            return Task.FromResult(this.Resolve(flagKey, defaultValue, context));
         }
 
         /// <inheritdoc/>
         public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(Resolve(flagKey, defaultValue, context));
+            return Task.FromResult(this.Resolve(flagKey, defaultValue, context));
         }
 
         private ResolutionDetails<T> Resolve<T>(string flagKey, T defaultValue, EvaluationContext? context)

--- a/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
+++ b/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
@@ -104,19 +104,15 @@ namespace OpenFeature.Providers.Memory
             {
                 throw new FlagNotFoundException($"flag {flagKey} not found");
             }
-            else
+
+            // This check returns False if a floating point flag is evaluated as an integer flag, and vice-versa.
+            // In a production provider, such behavior is probably not desirable; consider supporting conversion.
+            if (flag is Flag<T> value)
             {
-                // This check returns False if a floating point flag is evaluated as an integer flag, and vice-versa.
-                // In a production provider, such behavior is probably not desirable; consider supporting conversion.
-                if (typeof(Flag<T>).Equals(flag.GetType()))
-                {
-                    return ((Flag<T>)flag).Evaluate(flagKey, defaultValue, context);
-                }
-                else
-                {
-                    throw new TypeMismatchException($"flag {flagKey} is not of type ${typeof(T)}");
-                }
+                return value.Evaluate(flagKey, defaultValue, context);
             }
+
+            throw new TypeMismatchException($"flag {flagKey} is not of type ${typeof(T)}");
         }
     }
 }

--- a/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
+++ b/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
@@ -30,77 +30,77 @@ namespace OpenFeature.Benchmark
         public OpenFeatureClientBenchmarks()
         {
             var fixture = new Fixture();
-            _clientName = fixture.Create<string>();
-            _clientVersion = fixture.Create<string>();
-            _flagName = fixture.Create<string>();
-            _defaultBoolValue = fixture.Create<bool>();
-            _defaultStringValue = fixture.Create<string>();
-            _defaultIntegerValue = fixture.Create<int>();
-            _defaultDoubleValue = fixture.Create<double>();
-            _defaultStructureValue = fixture.Create<Value>();
-            _emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
+            this._clientName = fixture.Create<string>();
+            this._clientVersion = fixture.Create<string>();
+            this._flagName = fixture.Create<string>();
+            this._defaultBoolValue = fixture.Create<bool>();
+            this._defaultStringValue = fixture.Create<string>();
+            this._defaultIntegerValue = fixture.Create<int>();
+            this._defaultDoubleValue = fixture.Create<double>();
+            this._defaultStructureValue = fixture.Create<Value>();
+            this._emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
-            _client = Api.Instance.GetClient(_clientName, _clientVersion);
+            this._client = Api.Instance.GetClient(this._clientName, this._clientVersion);
         }
 
         [Benchmark]
         public async Task OpenFeatureClient_GetBooleanValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetBooleanValueAsync(_flagName, _defaultBoolValue);
+            await this._client.GetBooleanValueAsync(this._flagName, this._defaultBoolValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetBooleanValueAsync(_flagName, _defaultBoolValue, EvaluationContext.Empty);
+            await this._client.GetBooleanValueAsync(this._flagName, this._defaultBoolValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetBooleanValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetBooleanValueAsync(_flagName, _defaultBoolValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await this._client.GetBooleanValueAsync(this._flagName, this._defaultBoolValue, EvaluationContext.Empty, this._emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetStringValueAsync(_flagName, _defaultStringValue);
+            await this._client.GetStringValueAsync(this._flagName, this._defaultStringValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetStringValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetStringValueAsync(_flagName, _defaultStringValue, EvaluationContext.Empty);
+            await this._client.GetStringValueAsync(this._flagName, this._defaultStringValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetStringValue_WithoutEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetStringValueAsync(_flagName, _defaultStringValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await this._client.GetStringValueAsync(this._flagName, this._defaultStringValue, EvaluationContext.Empty, this._emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetIntegerValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetIntegerValueAsync(_flagName, _defaultIntegerValue);
+            await this._client.GetIntegerValueAsync(this._flagName, this._defaultIntegerValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetIntegerValueAsync(_flagName, _defaultIntegerValue, EvaluationContext.Empty);
+            await this._client.GetIntegerValueAsync(this._flagName, this._defaultIntegerValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetIntegerValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetIntegerValueAsync(_flagName, _defaultIntegerValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await this._client.GetIntegerValueAsync(this._flagName, this._defaultIntegerValue, EvaluationContext.Empty, this._emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetDoubleValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetDoubleValueAsync(_flagName, _defaultDoubleValue);
+            await this._client.GetDoubleValueAsync(this._flagName, this._defaultDoubleValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetDoubleValueAsync(_flagName, _defaultDoubleValue, EvaluationContext.Empty);
+            await this._client.GetDoubleValueAsync(this._flagName, this._defaultDoubleValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetDoubleValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetDoubleValueAsync(_flagName, _defaultDoubleValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await this._client.GetDoubleValueAsync(this._flagName, this._defaultDoubleValue, EvaluationContext.Empty, this._emptyFlagOptions);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetObjectValue_WithoutEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetObjectValueAsync(_flagName, _defaultStructureValue);
+            await this._client.GetObjectValueAsync(this._flagName, this._defaultStructureValue);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithoutFlagEvaluationOptions() =>
-            await _client.GetObjectValueAsync(_flagName, _defaultStructureValue, EvaluationContext.Empty);
+            await this._client.GetObjectValueAsync(this._flagName, this._defaultStructureValue, EvaluationContext.Empty);
 
         [Benchmark]
         public async Task OpenFeatureClient_GetObjectValue_WithEmptyEvaluationContext_WithEmptyFlagEvaluationOptions() =>
-            await _client.GetObjectValueAsync(_flagName, _defaultStructureValue, EvaluationContext.Empty, _emptyFlagOptions);
+            await this._client.GetObjectValueAsync(this._flagName, this._defaultStructureValue, EvaluationContext.Empty, this._emptyFlagOptions);
     }
 }

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -41,7 +41,7 @@ namespace OpenFeature.E2ETests
         [Given(@"a provider is registered")]
         public void GivenAProviderIsRegistered()
         {
-            var memProvider = new InMemoryProvider(e2eFlagConfig);
+            var memProvider = new InMemoryProvider(this.e2eFlagConfig);
             Api.Instance.SetProviderAsync(memProvider).Wait();
             client = Api.Instance.GetClient("TestClient", "1.0.0");
         }
@@ -204,9 +204,9 @@ namespace OpenFeature.E2ETests
         [When(@"a flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Givenaflagwithkeyisevaluatedwithdefaultvalue(string flagKey, string defaultValue)
         {
-            contextAwareFlagKey = flagKey;
-            contextAwareDefaultValue = defaultValue;
-            contextAwareValue = client?.GetStringValueAsync(flagKey, contextAwareDefaultValue, context)?.Result;
+            this.contextAwareFlagKey = flagKey;
+            this.contextAwareDefaultValue = defaultValue;
+            this.contextAwareValue = client?.GetStringValueAsync(flagKey, this.contextAwareDefaultValue, this.context)?.Result;
         }
 
         [Then(@"the resolved string response should be ""(.*)""")]
@@ -218,7 +218,7 @@ namespace OpenFeature.E2ETests
         [Then(@"the resolved flag value is ""(.*)"" when the context is empty")]
         public void Giventheresolvedflagvalueiswhenthecontextisempty(string expected)
         {
-            string? emptyContextValue = client?.GetStringValueAsync(contextAwareFlagKey!, contextAwareDefaultValue!, EvaluationContext.Empty).Result;
+            string? emptyContextValue = client?.GetStringValueAsync(this.contextAwareFlagKey!, this.contextAwareDefaultValue!, EvaluationContext.Empty).Result;
             Assert.Equal(expected, emptyContextValue);
         }
 
@@ -239,8 +239,8 @@ namespace OpenFeature.E2ETests
         [Then(@"the reason should indicate an error and the error code should indicate a missing flag with ""(.*)""")]
         public void Giventhereasonshouldindicateanerrorandtheerrorcodeshouldindicateamissingflagwith(string errorCode)
         {
-            Assert.Equal(Reason.Error.ToString(), notFoundDetails?.Reason);
-            Assert.Equal(errorCode, notFoundDetails?.ErrorType.GetDescription());
+            Assert.Equal(Reason.Error.ToString(), this.notFoundDetails?.Reason);
+            Assert.Equal(errorCode, this.notFoundDetails?.ErrorType.GetDescription());
         }
 
         [When(@"a string flag with key ""(.*)"" is evaluated as an integer, with details and a default value (.*)")]
@@ -260,8 +260,8 @@ namespace OpenFeature.E2ETests
         [Then(@"the reason should indicate an error and the error code should indicate a type mismatch with ""(.*)""")]
         public void Giventhereasonshouldindicateanerrorandtheerrorcodeshouldindicateatypemismatchwith(string errorCode)
         {
-            Assert.Equal(Reason.Error.ToString(), typeErrorDetails?.Reason);
-            Assert.Equal(errorCode, typeErrorDetails?.ErrorType.GetDescription());
+            Assert.Equal(Reason.Error.ToString(), this.typeErrorDetails?.Reason);
+            Assert.Equal(errorCode, this.typeErrorDetails?.ErrorType.GetDescription());
         }
 
         private IDictionary<string, Flag> e2eFlagConfig = new Dictionary<string, Flag>(){

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -103,8 +103,8 @@ namespace OpenFeature.Tests
             var defaultClient = openFeature.GetProviderMetadata();
             var namedClient = openFeature.GetProviderMetadata(TestProvider.DefaultName);
 
-            defaultClient.Name.Should().Be(NoOpProvider.NoOpProviderName);
-            namedClient.Name.Should().Be(TestProvider.DefaultName);
+            defaultClient?.Name.Should().Be(NoOpProvider.NoOpProviderName);
+            namedClient?.Name.Should().Be(TestProvider.DefaultName);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace OpenFeature.Tests
 
             var defaultClient = openFeature.GetProviderMetadata();
 
-            defaultClient.Name.Should().Be(TestProvider.DefaultName);
+            defaultClient?.Name.Should().Be(TestProvider.DefaultName);
         }
 
         [Fact]
@@ -130,7 +130,7 @@ namespace OpenFeature.Tests
             await openFeature.SetProviderAsync(name, new TestProvider());
             await openFeature.SetProviderAsync(name, new NoOpFeatureProvider());
 
-            openFeature.GetProviderMetadata(name).Name.Should().Be(NoOpProvider.NoOpProviderName);
+            openFeature.GetProviderMetadata(name)?.Name.Should().Be(NoOpProvider.NoOpProviderName);
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace OpenFeature.Tests
             var metadata = openFeature.GetProviderMetadata();
 
             metadata.Should().NotBeNull();
-            metadata.Name.Should().Be(NoOpProvider.NoOpProviderName);
+            metadata?.Name.Should().Be(NoOpProvider.NoOpProviderName);
         }
 
         [Theory]

--- a/test/OpenFeature.Tests/TestImplementations.cs
+++ b/test/OpenFeature.Tests/TestImplementations.cs
@@ -103,10 +103,10 @@ namespace OpenFeature.Tests
 
         public override async Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
         {
-            await Task.Delay(initDelay).ConfigureAwait(false);
-            if (initException != null)
+            await Task.Delay(this.initDelay).ConfigureAwait(false);
+            if (this.initException != null)
             {
-                throw initException;
+                throw this.initException;
             }
         }
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This PR fixes some of the warnings and typos that I recently found.
More interestingly, it addresses these issues:
- Missing the `.this`
- Usage of `ILogger` vs `Source generator log`
- `const` vs `static`
- Fix nullability for some methods and properties.
And a few more changes.

### Follow-up Tasks
We need to do more cleanup tasks.

### How to test
All of these changes are recommended by the IDE and "tested" by the compiler when it executes.

