### PR TITLE
fix: Should map metadata when converting from ResolutionDetails to FlagEvaluationDetails

### DIFF
--- a/src/OpenFeature/Extension/ResolutionDetailsExtensions.cs
+++ b/src/OpenFeature/Extension/ResolutionDetailsExtensions.cs
@@ -7,7 +7,7 @@ namespace OpenFeature.Extension
         public static FlagEvaluationDetails<T> ToFlagEvaluationDetails<T>(this ResolutionDetails<T> details)
         {
             return new FlagEvaluationDetails<T>(details.FlagKey, details.Value, details.ErrorType, details.Reason,
-                details.Variant, details.ErrorMessage);
+                details.Variant, details.ErrorMessage, details.FlagMetadata);
         }
     }
 }

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -497,7 +497,7 @@ namespace OpenFeature.Tests
             var flagData = fixture
                 .CreateMany<KeyValuePair<string, object>>(10)
                 .ToDictionary(x => x.Key, x => x.Value);
-            var flagMetadata = new FlagMetadata(flagData);
+            var flagMetadata = new ImmutableMetadata(flagData);
 
             var expected = new ResolutionDetails<bool>(flagName, boolValue, errorType, reason, variant, errorMessage, flagMetadata);
             var result = expected.ToFlagEvaluationDetails();

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -11,6 +12,7 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using OpenFeature.Constant;
 using OpenFeature.Error;
+using OpenFeature.Extension;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
 using Xunit;
@@ -479,6 +481,28 @@ namespace OpenFeature.Tests
             FeatureClient client = Api.Instance.GetClient(clientName, clientVersion);
             client.SetContext(new EvaluationContextBuilder().Set(KEY, VAL).Build());
             Assert.Equal(VAL, client.GetContext().GetValue(KEY).AsInteger);
+        }
+
+
+        [Fact]
+        public void ToFlagEvaluationDetails_Should_Convert_All_Properties()
+        {
+            var fixture = new Fixture();
+            var flagName = fixture.Create<string>();
+            var boolValue = fixture.Create<bool>();
+            var errorType = fixture.Create<ErrorType>();
+            var reason = fixture.Create<string>();
+            var variant = fixture.Create<string>();
+            var errorMessage = fixture.Create<string>();
+            var flagData = fixture
+                .CreateMany<KeyValuePair<string, object>>(10)
+                .ToDictionary(x => x.Key, x => x.Value);
+            var flagMetadata = new FlagMetadata(flagData);
+
+            var expected = new ResolutionDetails<bool>(flagName, boolValue, errorType, reason, variant, errorMessage, flagMetadata);
+            var result = expected.ToFlagEvaluationDetails();
+
+            result.Should().BeEquivalentTo(expected);
         }
     }
 }


### PR DESCRIPTION
## This PR

When converting the ResolutionDetails to FlagEvalutionDetails we aren't passing the ImmutableMetadata to the new object.

### Related Issues

Fixes [#281](https://github.com/open-feature/dotnet-sdk/issues/281)

### Notes
This PR is done on a common merge base so we can merge it into v1 as well

### Follow-up Tasks
N/A

### How to test
Unit test added to covert the missing test case

