### PR TITLE
feat: Drop net7 TFM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            7.0.x
             8.0.x
           source-url: https://nuget.pkg.github.com/open-feature/index.json
 
@@ -68,7 +67,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            7.0.x
             8.0.x
           source-url: https://nuget.pkg.github.com/open-feature/index.json
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -30,7 +30,6 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
-          7.0.x
           8.0.x
         source-url: https://nuget.pkg.github.com/open-feature/index.json
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            7.0.x
             8.0.x
           source-url: https://nuget.pkg.github.com/open-feature/index.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            7.0.x
             8.0.x
           source-url: https://nuget.pkg.github.com/open-feature/index.json
 

--- a/src/OpenFeature/OpenFeature.csproj
+++ b/src/OpenFeature/OpenFeature.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net462</TargetFrameworks>
     <RootNamespace>OpenFeature</RootNamespace>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj
+++ b/test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <RootNamespace>OpenFeature.Benchmark</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
+++ b/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <RootNamespace>OpenFeature.E2ETests</RootNamespace>
   </PropertyGroup>

--- a/test/OpenFeature.Tests/OpenFeature.Tests.csproj
+++ b/test/OpenFeature.Tests/OpenFeature.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <RootNamespace>OpenFeature.Tests</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
## This PR

.net7 was EOL on May 14, 2024

https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core


