### PR TITLE
feat: back targetingKey with internal map

### DIFF
--- a/src/OpenFeature/Model/EvaluationContext.cs
+++ b/src/OpenFeature/Model/EvaluationContext.cs
@@ -14,7 +14,8 @@ namespace OpenFeature.Model
         /// <summary>
         /// The index for the "targeting key" property when the EvaluationContext is serialized or expressed as a dictionary.
         /// </summary>
-        public readonly static string TargetingKeyIndex = "targetingKey";
+        internal const string TargetingKeyIndex = "targetingKey";
+
 
         private readonly Structure _structure;
 

--- a/src/OpenFeature/Model/EvaluationContext.cs
+++ b/src/OpenFeature/Model/EvaluationContext.cs
@@ -11,18 +11,18 @@ namespace OpenFeature.Model
     /// <seealso href="https://github.com/open-feature/spec/blob/v0.5.2/specification/sections/03-evaluation-context.md">Evaluation context</seealso>
     public sealed class EvaluationContext
     {
+        /// <summary>
+        /// The index for the "targeting key" property when the EvaluationContext is serialized or expressed as a dictionary.
+        /// </summary>
+        public readonly static string TargetingKeyIndex = "targetingKey";
+
         private readonly Structure _structure;
 
-        /// <summary>
-        /// Internal constructor used by the builder.
-        /// </summary>
-        /// <param name="targetingKey">The targeting key</param>
-        /// <param name="content">The content of the context.</param>
-        internal EvaluationContext(string? targetingKey, Structure content)
+        internal EvaluationContext(Structure content)
         {
-            this.TargetingKey = targetingKey;
             this._structure = content;
         }
+
 
         /// <summary>
         /// Private constructor for making an empty <see cref="EvaluationContext"/>.
@@ -30,7 +30,6 @@ namespace OpenFeature.Model
         private EvaluationContext()
         {
             this._structure = Structure.Empty;
-            this.TargetingKey = string.Empty;
         }
 
         /// <summary>
@@ -89,7 +88,14 @@ namespace OpenFeature.Model
         /// <summary>
         /// Returns the targeting key for the context.
         /// </summary>
-        public string? TargetingKey { get; }
+        public string? TargetingKey
+        {
+            get
+            {
+                this._structure.TryGetValue(TargetingKeyIndex, out Value? targetingKey);
+                return targetingKey?.AsString;
+            }
+        }
 
         /// <summary>
         /// Return an enumerator for all values

--- a/src/OpenFeature/Model/EvaluationContext.cs
+++ b/src/OpenFeature/Model/EvaluationContext.cs
@@ -18,6 +18,10 @@ namespace OpenFeature.Model
 
         private readonly Structure _structure;
 
+        /// <summary>
+        /// Internal constructor used by the builder.
+        /// </summary>
+        /// <param name="content"></param>
         internal EvaluationContext(Structure content)
         {
             this._structure = content;

--- a/src/OpenFeature/Model/EvaluationContextBuilder.cs
+++ b/src/OpenFeature/Model/EvaluationContextBuilder.cs
@@ -14,8 +14,6 @@ namespace OpenFeature.Model
     {
         private readonly StructureBuilder _attributes = Structure.Builder();
 
-        internal string? TargetingKey { get; private set; }
-
         /// <summary>
         /// Internal to only allow direct creation by <see cref="EvaluationContext.Builder()"/>.
         /// </summary>
@@ -28,7 +26,7 @@ namespace OpenFeature.Model
         /// <returns>This builder</returns>
         public EvaluationContextBuilder SetTargetingKey(string targetingKey)
         {
-            this.TargetingKey = targetingKey;
+            this._attributes.Set(EvaluationContext.TargetingKeyIndex, targetingKey);
             return this;
         }
 
@@ -138,22 +136,22 @@ namespace OpenFeature.Model
         /// <returns>This builder</returns>
         public EvaluationContextBuilder Merge(EvaluationContext context)
         {
-            string? newTargetingKey = "";
+            // string? newTargetingKey = "";
 
-            if (!string.IsNullOrWhiteSpace(this.TargetingKey))
-            {
-                newTargetingKey = this.TargetingKey;
-            }
+            // if (!string.IsNullOrWhiteSpace(this.TargetingKey))
+            // {
+            //     newTargetingKey = this.TargetingKey;
+            // }
 
-            if (!string.IsNullOrWhiteSpace(context.TargetingKey))
-            {
-                newTargetingKey = context.TargetingKey;
-            }
+            // if (!string.IsNullOrWhiteSpace(context.TargetingKey))
+            // {
+            //     newTargetingKey = context.TargetingKey;
+            // }
 
-            if (!string.IsNullOrWhiteSpace(newTargetingKey))
-            {
-                this.TargetingKey = newTargetingKey;
-            }
+            // if (!string.IsNullOrWhiteSpace(newTargetingKey))
+            // {
+            //     this.TargetingKey = newTargetingKey;
+            // }
 
             foreach (var kvp in context)
             {
@@ -169,7 +167,7 @@ namespace OpenFeature.Model
         /// <returns>An immutable <see cref="EvaluationContext"/></returns>
         public EvaluationContext Build()
         {
-            return new EvaluationContext(this.TargetingKey, this._attributes.Build());
+            return new EvaluationContext(this._attributes.Build());
         }
     }
 }

--- a/src/OpenFeature/Model/EvaluationContextBuilder.cs
+++ b/src/OpenFeature/Model/EvaluationContextBuilder.cs
@@ -136,23 +136,6 @@ namespace OpenFeature.Model
         /// <returns>This builder</returns>
         public EvaluationContextBuilder Merge(EvaluationContext context)
         {
-            // string? newTargetingKey = "";
-
-            // if (!string.IsNullOrWhiteSpace(this.TargetingKey))
-            // {
-            //     newTargetingKey = this.TargetingKey;
-            // }
-
-            // if (!string.IsNullOrWhiteSpace(context.TargetingKey))
-            // {
-            //     newTargetingKey = context.TargetingKey;
-            // }
-
-            // if (!string.IsNullOrWhiteSpace(newTargetingKey))
-            // {
-            //     this.TargetingKey = newTargetingKey;
-            // }
-
             foreach (var kvp in context)
             {
                 this.Set(kvp.Key, kvp.Value);

--- a/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
@@ -171,12 +171,28 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        public void GetValueOnTargetingKey_Equals_TargetingKey()
+        public void GetValueOnTargetingKeySetWithStructure_Equals_TargetingKey()
         {
             // Arrange
             var value = "my_targeting_key";
-            var structure = new Structure(new Dictionary<string, Value> { { EvaluationContext.TargetingKeyIndex, new Value(value) } });
-            var evaluationContext = new EvaluationContext(structure);
+            var evaluationContext = EvaluationContext.Builder().Set(EvaluationContext.TargetingKeyIndex, new Value(value)).Build();
+
+            // Act
+            var result = evaluationContext.TryGetValue(EvaluationContext.TargetingKeyIndex, out var actualValue);
+            var targetingKeyvalue = evaluationContext.TargetingKey;
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(value, actualValue?.AsString);
+            Assert.Equal(value, targetingKeyvalue);
+        }
+
+        [Fact]
+        public void GetValueOnTargetingKeySetWithTargetingKey_Equals_TargetingKey()
+        {
+            // Arrange
+            var value = "my_targeting_key";
+            var evaluationContext = EvaluationContext.Builder().SetTargetingKey(value).Build();
 
             // Act
             var result = evaluationContext.TryGetValue(EvaluationContext.TargetingKeyIndex, out var actualValue);

--- a/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
@@ -160,7 +160,7 @@ namespace OpenFeature.Tests
             var key = "testKey";
             var expectedValue = new Value("testValue");
             var structure = new Structure(new Dictionary<string, Value> { { key, expectedValue } });
-            var evaluationContext = new EvaluationContext("targetingKey", structure);
+            var evaluationContext = new EvaluationContext(structure);
 
             // Act
             var result = evaluationContext.TryGetValue(key, out var actualValue);
@@ -168,6 +168,24 @@ namespace OpenFeature.Tests
             // Assert
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void GetValueOnTargetingKey_Equals_TargetingKey()
+        {
+            // Arrange
+            var value = "my_targeting_key";
+            var structure = new Structure(new Dictionary<string, Value> { { EvaluationContext.TargetingKeyIndex, new Value(value) } });
+            var evaluationContext = new EvaluationContext(structure);
+
+            // Act
+            var result = evaluationContext.TryGetValue(EvaluationContext.TargetingKeyIndex, out var actualValue);
+            var targetingKeyvalue = evaluationContext.TargetingKey;
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(value, actualValue?.AsString);
+            Assert.Equal(value, targetingKeyvalue);
         }
     }
 }

--- a/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
@@ -171,23 +171,6 @@ namespace OpenFeature.Tests
         }
 
         [Fact]
-        public void GetValueOnTargetingKeySetWithStructure_Equals_TargetingKey()
-        {
-            // Arrange
-            var value = "my_targeting_key";
-            var evaluationContext = EvaluationContext.Builder().Set(EvaluationContext.TargetingKeyIndex, new Value(value)).Build();
-
-            // Act
-            var result = evaluationContext.TryGetValue(EvaluationContext.TargetingKeyIndex, out var actualValue);
-            var targetingKeyvalue = evaluationContext.TargetingKey;
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(value, actualValue?.AsString);
-            Assert.Equal(value, targetingKeyvalue);
-        }
-
-        [Fact]
         public void GetValueOnTargetingKeySetWithTargetingKey_Equals_TargetingKey()
         {
             // Arrange
@@ -195,13 +178,46 @@ namespace OpenFeature.Tests
             var evaluationContext = EvaluationContext.Builder().SetTargetingKey(value).Build();
 
             // Act
-            var result = evaluationContext.TryGetValue(EvaluationContext.TargetingKeyIndex, out var actualValue);
-            var targetingKeyvalue = evaluationContext.TargetingKey;
+            var result = evaluationContext.TryGetValue(EvaluationContext.TargetingKeyIndex, out var actualFromStructure);
+            var actualFromTargetingKey = evaluationContext.TargetingKey;
 
             // Assert
             Assert.True(result);
-            Assert.Equal(value, actualValue?.AsString);
-            Assert.Equal(value, targetingKeyvalue);
+            Assert.Equal(value, actualFromStructure?.AsString);
+            Assert.Equal(value, actualFromTargetingKey);
+        }
+
+        [Fact]
+        public void GetValueOnTargetingKeySetWithStructure_Equals_TargetingKey()
+        {
+            // Arrange
+            var value = "my_targeting_key";
+            var evaluationContext = EvaluationContext.Builder().Set(EvaluationContext.TargetingKeyIndex, new Value(value)).Build();
+
+            // Act
+            var result = evaluationContext.TryGetValue(EvaluationContext.TargetingKeyIndex, out var actualFromStructure);
+            var actualFromTargetingKey = evaluationContext.TargetingKey;
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(value, actualFromStructure?.AsString);
+            Assert.Equal(value, actualFromTargetingKey);
+        }
+
+        [Fact]
+        public void GetValueOnTargetingKeySetWithNonStringValue_Equals_Null()
+        {
+            // Arrange
+            var evaluationContext = EvaluationContext.Builder().Set(EvaluationContext.TargetingKeyIndex, new Value(1)).Build();
+
+            // Act
+            var result = evaluationContext.TryGetValue(EvaluationContext.TargetingKeyIndex, out var actualFromStructure);
+            var actualFromTargetingKey = evaluationContext.TargetingKey;
+
+            // Assert
+            Assert.True(result);
+            Assert.Null(actualFromStructure?.AsString);
+            Assert.Null(actualFromTargetingKey);
         }
     }
 }


### PR DESCRIPTION
Use the internal dictionary for the `targetingKey`.

This is non-breaking from a compiler perspective. It could result in some behavioral changes, but IMO they are largely desirable.

Fixes: https://github.com/open-feature/dotnet-sdk/issues/235