### PR TITLE
feat!: domain instead of client name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ public async Task Example()
 
 ## 🌟 Features
 
-| Status | Features                        | Description                                                                                                                        |
-| ------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| ✅     | [Providers](#providers)         | Integrate with a commercial, open source, or in-house feature management tool.                                                     |
-| ✅     | [Targeting](#targeting)         | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context). |
-| ✅     | [Hooks](#hooks)                 | Add functionality to various stages of the flag evaluation life-cycle.                                                             |
-| ✅     | [Logging](#logging)             | Integrate with popular logging packages.                                                                                           |
-| ✅     | [Named clients](#named-clients) | Utilize multiple providers in a single application.                                                                                |
-| ✅     | [Eventing](#eventing)           | React to state changes in the provider or flag management system.                                                                  |
-| ✅    | [Shutdown](#shutdown)           | Gracefully clean up a provider during application shutdown.                                                                        |
-| ✅     | [Extending](#extending)         | Extend OpenFeature with custom providers and hooks.                                                                                |
+| Status | Features                | Description                                                                                                                        |
+| ------ | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| ✅      | [Providers](#providers) | Integrate with a commercial, open source, or in-house feature management tool.                                                     |
+| ✅      | [Targeting](#targeting) | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context). |
+| ✅      | [Hooks](#hooks)         | Add functionality to various stages of the flag evaluation life-cycle.                                                             |
+| ✅      | [Logging](#logging)     | Integrate with popular logging packages.                                                                                           |
+| ✅      | [Domains](#domains)     | Logically bind clients with providers.                                                                                             |
+| ✅      | [Eventing](#eventing)   | React to state changes in the provider or flag management system.                                                                  |
+| ✅      | [Shutdown](#shutdown)   | Gracefully clean up a provider during application shutdown.                                                                        |
+| ✅      | [Extending](#extending) | Extend OpenFeature with custom providers and hooks.                                                                                |
 
 > Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌
 
@@ -96,7 +96,7 @@ await Api.Instance.SetProviderAsync(new MyProvider());
 ```
 
 In some situations, it may be beneficial to register multiple providers in the same application.
-This is possible using [named clients](#named-clients), which is covered in more detail below.
+This is possible using [domains](#domains), which is covered in more detail below.
 
 ### Targeting
 
@@ -151,26 +151,28 @@ var value = await client.GetBooleanValueAsync("boolFlag", false, context, new Fl
 
 The .NET SDK uses Microsoft.Extensions.Logging. See the [manual](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line) for complete documentation.
 
-### Named clients
+### Domains
 
-Clients can be given a name.
-A name is a logical identifier that can be used to associate clients with a particular provider.
-If a name has no associated provider, the global provider is used.
+Clients can be assigned to a domain.
+A domain is a logical identifier which can be used to associate clients with a particular provider.
+If a domain has no associated provider, the default provider is used.
 
 ```csharp
 // registering the default provider
 await Api.Instance.SetProviderAsync(new LocalProvider());
 
-// registering a named provider
+// registering a provider to a domain
 await Api.Instance.SetProviderAsync("clientForCache", new CachedProvider());
 
 // a client backed by default provider
 FeatureClient clientDefault = Api.Instance.GetClient();
 
 // a client backed by CachedProvider
-FeatureClient clientNamed = Api.Instance.GetClient("clientForCache");
-
+FeatureClient scopedClient = Api.Instance.GetClient("clientForCache");
 ```
+
+Domains can be defined on a provider during registration.
+For more details, please refer to the [providers](#providers) section.
 
 ### Eventing
 

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -50,19 +50,19 @@ namespace OpenFeature
         }
 
         /// <summary>
-        /// Sets the feature provider to given clientName. In order to wait for the provider to be set, and
+        /// Binds the feature provider to the given domain. In order to wait for the provider to be set, and
         /// initialization to complete, await the returned task.
         /// </summary>
-        /// <param name="clientName">Name of client</param>
+        /// <param name="domain">An identifier which logically binds clients with providers</param>
         /// <param name="featureProvider">Implementation of <see cref="FeatureProvider"/></param>
-        public async Task SetProviderAsync(string clientName, FeatureProvider featureProvider)
+        public async Task SetProviderAsync(string domain, FeatureProvider featureProvider)
         {
-            if (string.IsNullOrWhiteSpace(clientName))
+            if (string.IsNullOrWhiteSpace(domain))
             {
-                throw new ArgumentNullException(nameof(clientName));
+                throw new ArgumentNullException(nameof(domain));
             }
-            this._eventExecutor.RegisterClientFeatureProvider(clientName, featureProvider);
-            await this._repository.SetProviderAsync(clientName, featureProvider, this.GetContext(), this.AfterInitialization, this.AfterError).ConfigureAwait(false);
+            this._eventExecutor.RegisterClientFeatureProvider(domain, featureProvider);
+            await this._repository.SetProviderAsync(domain, featureProvider, this.GetContext(), this.AfterInitialization, this.AfterError).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -82,14 +82,14 @@ namespace OpenFeature
         }
 
         /// <summary>
-        /// Gets the feature provider with given clientName
+        /// Gets the feature provider with given domain
         /// </summary>
-        /// <param name="clientName">Name of client</param>
-        /// <returns>A provider associated with the given clientName, if clientName is empty or doesn't
+        /// <param name="domain">Name of client</param>
+        /// <returns>A provider associated with the given domain, if domain is empty or doesn't
         /// have a corresponding provider the default provider will be returned</returns>
-        public FeatureProvider GetProvider(string clientName)
+        public FeatureProvider GetProvider(string domain)
         {
-            return this._repository.GetProvider(clientName);
+            return this._repository.GetProvider(domain);
         }
 
         /// <summary>
@@ -104,12 +104,12 @@ namespace OpenFeature
         public Metadata? GetProviderMetadata() => this.GetProvider().GetMetadata();
 
         /// <summary>
-        /// Gets providers metadata assigned to the given clientName. If the clientName has no provider
+        /// Gets providers metadata assigned to the given domain. If the domain has no provider
         /// assigned to it the default provider will be returned
         /// </summary>
-        /// <param name="clientName">Name of client</param>
+        /// <param name="domain">Name of client</param>
         /// <returns>Metadata assigned to provider</returns>
-        public Metadata? GetProviderMetadata(string clientName) => this.GetProvider(clientName).GetMetadata();
+        public Metadata? GetProviderMetadata(string domain) => this.GetProvider(domain).GetMetadata();
 
         /// <summary>
         /// Create a new instance of <see cref="FeatureClient"/> using the current provider

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -84,7 +84,8 @@ namespace OpenFeature
         /// <summary>
         /// Gets the feature provider with given domain
         /// </summary>
-        /// <param name="domain">Name of client</param>
+        /// <param name="domain">An identifier which logically binds clients with providers</param>
+
         /// <returns>A provider associated with the given domain, if domain is empty or doesn't
         /// have a corresponding provider the default provider will be returned</returns>
         public FeatureProvider GetProvider(string domain)

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -108,7 +108,8 @@ namespace OpenFeature
         /// Gets providers metadata assigned to the given domain. If the domain has no provider
         /// assigned to it the default provider will be returned
         /// </summary>
-        /// <param name="domain">Name of client</param>
+        /// <param name="domain">An identifier which logically binds clients with providers</param>
+
         /// <returns>Metadata assigned to provider</returns>
         public Metadata? GetProviderMetadata(string domain) => this.GetProvider(domain).GetMetadata();
 

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -127,7 +127,7 @@ namespace OpenFeature
         /// <summary>
         /// Set a named provider
         /// </summary>
-        /// <param name="clientName">the name to associate with the provider</param>
+        /// <param name="domain">an identifier which logically binds clients with providers</param>
         /// <param name="featureProvider">the provider to set as the default, passing null has no effect</param>
         /// <param name="context">the context to initialize the provider with</param>
         /// <param name="afterInitSuccess">
@@ -138,15 +138,15 @@ namespace OpenFeature
         /// initialization
         /// </param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel any async side effects.</param>
-        public async Task SetProviderAsync(string? clientName,
+        public async Task SetProviderAsync(string? domain,
             FeatureProvider? featureProvider,
             EvaluationContext context,
             Func<FeatureProvider, Task>? afterInitSuccess = null,
             Func<FeatureProvider, Exception, Task>? afterInitError = null,
             CancellationToken cancellationToken = default)
         {
-            // Cannot set a provider for a null clientName.
-            if (clientName == null)
+            // Cannot set a provider for a null domain.
+            if (domain == null)
             {
                 return;
             }
@@ -155,17 +155,17 @@ namespace OpenFeature
 
             try
             {
-                this._featureProviders.TryGetValue(clientName, out var oldProvider);
+                this._featureProviders.TryGetValue(domain, out var oldProvider);
                 if (featureProvider != null)
                 {
-                    this._featureProviders.AddOrUpdate(clientName, featureProvider,
+                    this._featureProviders.AddOrUpdate(domain, featureProvider,
                         (key, current) => featureProvider);
                 }
                 else
                 {
                     // If names of clients are programmatic, then setting the provider to null could result
                     // in unbounded growth of the collection.
-                    this._featureProviders.TryRemove(clientName, out _);
+                    this._featureProviders.TryRemove(domain, out _);
                 }
 
                 // We want to allow shutdown to happen concurrently with initialization, and the caller to not
@@ -238,22 +238,22 @@ namespace OpenFeature
             }
         }
 
-        public FeatureProvider GetProvider(string? clientName)
+        public FeatureProvider GetProvider(string? domain)
         {
 #if NET6_0_OR_GREATER
-            if (string.IsNullOrEmpty(clientName))
+            if (string.IsNullOrEmpty(domain))
             {
                 return this.GetProvider();
             }
 #else
             // This is a workaround for the issue in .NET Framework where string.IsNullOrEmpty is not nullable compatible.
-            if (clientName == null || string.IsNullOrEmpty(clientName))
+            if (domain == null || string.IsNullOrEmpty(domain))
             {
                 return this.GetProvider();
             }
 #endif
 
-            return this._featureProviders.TryGetValue(clientName, out var featureProvider)
+            return this._featureProviders.TryGetValue(domain, out var featureProvider)
                 ? featureProvider
                 : this.GetProvider();
         }

--- a/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
+++ b/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
@@ -16,7 +16,7 @@ namespace OpenFeature.Benchmark
     [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
     public class OpenFeatureClientBenchmarks
     {
-        private readonly string _clientName;
+        private readonly string _domain;
         private readonly string _clientVersion;
         private readonly string _flagName;
         private readonly bool _defaultBoolValue;
@@ -30,7 +30,7 @@ namespace OpenFeature.Benchmark
         public OpenFeatureClientBenchmarks()
         {
             var fixture = new Fixture();
-            this._clientName = fixture.Create<string>();
+            this._domain = fixture.Create<string>();
             this._clientVersion = fixture.Create<string>();
             this._flagName = fixture.Create<string>();
             this._defaultBoolValue = fixture.Create<bool>();
@@ -40,7 +40,7 @@ namespace OpenFeature.Benchmark
             this._defaultStructureValue = fixture.Create<Value>();
             this._emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
-            this._client = Api.Instance.GetClient(this._clientName, this._clientVersion);
+            this._client = Api.Instance.GetClient(this._domain, this._clientVersion);
         }
 
         [Benchmark]

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -27,13 +27,13 @@ namespace OpenFeature.Tests
         public void OpenFeatureClient_Should_Allow_Hooks()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var hook1 = Substitute.For<Hook>();
             var hook2 = Substitute.For<Hook>();
             var hook3 = Substitute.For<Hook>();
 
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
 
             client.AddHooks(new[] { hook1, hook2 });
 
@@ -53,11 +53,11 @@ namespace OpenFeature.Tests
         public void OpenFeatureClient_Metadata_Should_Have_Name()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
 
-            client.GetMetadata().Name.Should().Be(clientName);
+            client.GetMetadata().Name.Should().Be(domain);
             client.GetMetadata().Version.Should().Be(clientVersion);
         }
 
@@ -68,7 +68,7 @@ namespace OpenFeature.Tests
         public async Task OpenFeatureClient_Should_Allow_Flag_Evaluation()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultBoolValue = fixture.Create<bool>();
@@ -79,7 +79,7 @@ namespace OpenFeature.Tests
             var emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
             await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
 
             (await client.GetBooleanValueAsync(flagName, defaultBoolValue)).Should().Be(defaultBoolValue);
             (await client.GetBooleanValueAsync(flagName, defaultBoolValue, EvaluationContext.Empty)).Should().Be(defaultBoolValue);
@@ -114,7 +114,7 @@ namespace OpenFeature.Tests
         public async Task OpenFeatureClient_Should_Allow_Details_Flag_Evaluation()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultBoolValue = fixture.Create<bool>();
@@ -125,7 +125,7 @@ namespace OpenFeature.Tests
             var emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
             await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
 
             var boolFlagEvaluationDetails = new FlagEvaluationDetails<bool>(flagName, defaultBoolValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
             (await client.GetBooleanDetailsAsync(flagName, defaultBoolValue)).Should().BeEquivalentTo(boolFlagEvaluationDetails);
@@ -163,7 +163,7 @@ namespace OpenFeature.Tests
         public async Task OpenFeatureClient_Should_Return_DefaultValue_When_Type_Mismatch()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<Value>();
@@ -176,7 +176,7 @@ namespace OpenFeature.Tests
             mockedFeatureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(mockedFeatureProvider);
-            var client = Api.Instance.GetClient(clientName, clientVersion, mockedLogger);
+            var client = Api.Instance.GetClient(domain, clientVersion, mockedLogger);
 
             var evaluationDetails = await client.GetObjectDetailsAsync(flagName, defaultValue);
             evaluationDetails.ErrorType.Should().Be(ErrorType.TypeMismatch);
@@ -277,7 +277,7 @@ namespace OpenFeature.Tests
         public async Task Should_Resolve_BooleanValue()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<bool>();
@@ -288,7 +288,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
 
             (await client.GetBooleanValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
@@ -299,7 +299,7 @@ namespace OpenFeature.Tests
         public async Task Should_Resolve_StringValue()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<string>();
@@ -310,7 +310,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
 
             (await client.GetStringValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
@@ -321,7 +321,7 @@ namespace OpenFeature.Tests
         public async Task Should_Resolve_IntegerValue()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<int>();
@@ -332,7 +332,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
 
             (await client.GetIntegerValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
@@ -343,7 +343,7 @@ namespace OpenFeature.Tests
         public async Task Should_Resolve_DoubleValue()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<double>();
@@ -354,7 +354,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
 
             (await client.GetDoubleValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
@@ -365,7 +365,7 @@ namespace OpenFeature.Tests
         public async Task Should_Resolve_StructureValue()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<Value>();
@@ -376,7 +376,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
 
             (await client.GetObjectValueAsync(flagName, defaultValue)).Should().Be(defaultValue);
 
@@ -387,7 +387,7 @@ namespace OpenFeature.Tests
         public async Task When_Error_Is_Returned_From_Provider_Should_Return_Error()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<Value>();
@@ -399,7 +399,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
             var response = await client.GetObjectDetailsAsync(flagName, defaultValue);
 
             response.ErrorType.Should().Be(ErrorType.ParseError);
@@ -412,7 +412,7 @@ namespace OpenFeature.Tests
         public async Task When_Exception_Occurs_During_Evaluation_Should_Return_Error()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<Value>();
@@ -424,7 +424,7 @@ namespace OpenFeature.Tests
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
             await Api.Instance.SetProviderAsync(featureProviderMock);
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
             var response = await client.GetObjectDetailsAsync(flagName, defaultValue);
 
             response.ErrorType.Should().Be(ErrorType.ParseError);
@@ -437,7 +437,7 @@ namespace OpenFeature.Tests
         public async Task Cancellation_Token_Added_Is_Passed_To_Provider()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultString = fixture.Create<string>();
@@ -459,8 +459,8 @@ namespace OpenFeature.Tests
             featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
             featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-            await Api.Instance.SetProviderAsync(clientName, featureProviderMock);
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            await Api.Instance.SetProviderAsync(domain, featureProviderMock);
+            var client = Api.Instance.GetClient(domain, clientVersion);
             var task = client.GetStringDetailsAsync(flagName, defaultString, EvaluationContext.Empty, null, cts.Token);
             cts.Cancel(); // cancel before awaiting
 
@@ -474,11 +474,11 @@ namespace OpenFeature.Tests
         public void Should_Get_And_Set_Context()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var KEY = "key";
             var VAL = 1;
-            FeatureClient client = Api.Instance.GetClient(clientName, clientVersion);
+            FeatureClient client = Api.Instance.GetClient(domain, clientVersion);
             client.SetContext(new EvaluationContextBuilder().Set(KEY, VAL).Build());
             Assert.Equal(VAL, client.GetContext().GetValue(KEY).AsInteger);
         }

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -304,9 +304,9 @@ namespace OpenFeature.Tests
             var fixture = new Fixture();
             var eventHandler = Substitute.For<EventHandlerDelegate>();
 
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
-            var myClient = Api.Instance.GetClient(clientName, clientVersion);
+            var myClient = Api.Instance.GetClient(domain, clientVersion);
 
             var testProvider = new TestProvider();
             await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name!, testProvider);
@@ -332,9 +332,9 @@ namespace OpenFeature.Tests
             failingEventHandler.When(x => x.Invoke(Arg.Any<ProviderEventPayload>()))
                 .Do(x => throw new Exception());
 
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
-            var myClient = Api.Instance.GetClient(clientName, clientVersion);
+            var myClient = Api.Instance.GetClient(domain, clientVersion);
 
             myClient.AddHandler(ProviderEventTypes.ProviderReady, failingEventHandler);
             myClient.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -27,7 +27,7 @@ namespace OpenFeature.Tests
         public async Task Hooks_Should_Be_Called_In_Order()
         {
             var fixture = new Fixture();
-            var clientName = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var clientVersion = fixture.Create<string>();
             var flagName = fixture.Create<string>();
             var defaultValue = fixture.Create<bool>();
@@ -54,7 +54,7 @@ namespace OpenFeature.Tests
             testProvider.AddHook(providerHook);
             Api.Instance.AddHooks(apiHook);
             await Api.Instance.SetProviderAsync(testProvider);
-            var client = Api.Instance.GetClient(clientName, clientVersion);
+            var client = Api.Instance.GetClient(domain, clientVersion);
             client.AddHooks(clientHook);
 
             await client.GetBooleanValueAsync(flagName, defaultValue, EvaluationContext.Empty,

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -101,10 +101,10 @@ namespace OpenFeature.Tests
             await openFeature.SetProviderAsync(TestProvider.DefaultName, new TestProvider());
 
             var defaultClient = openFeature.GetProviderMetadata();
-            var namedClient = openFeature.GetProviderMetadata(TestProvider.DefaultName);
+            var domainScopedClient = openFeature.GetProviderMetadata(TestProvider.DefaultName);
 
             defaultClient?.Name.Should().Be(NoOpProvider.NoOpProviderName);
-            namedClient?.Name.Should().Be(TestProvider.DefaultName);
+            domainScopedClient?.Name.Should().Be(TestProvider.DefaultName);
         }
 
         [Fact]


### PR DESCRIPTION
Uses "domain" terminology instead of "client name / named client".

Fixes: https://github.com/open-feature/dotnet-sdk/issues/249

I believe with this, we are able to release a 2.0