### PR TITLE
chore: in-memory UpdateFlags to UpdateFlagsAsync

### DIFF
--- a/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
+++ b/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
@@ -43,10 +43,10 @@ namespace OpenFeature.Providers.Memory
         }
 
         /// <summary>
-        /// Updating provider flags configuration, replacing all flags.
+        /// Update provider flag configuration, replacing all flags.
         /// </summary>
         /// <param name="flags">the flags to use instead of the previous flags.</param>
-        public async Task UpdateFlags(IDictionary<string, Flag>? flags = null)
+        public async Task UpdateFlagsAsync(IDictionary<string, Flag>? flags = null)
         {
             var changed = this._flags.Keys.ToList();
             if (flags == null)

--- a/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
+++ b/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
@@ -170,7 +170,7 @@ namespace OpenFeature.Tests.Providers.Memory
         public async Task EmptyFlags_ShouldWork()
         {
             var provider = new InMemoryProvider();
-            await provider.UpdateFlags();
+            await provider.UpdateFlagsAsync();
             Assert.Equal("InMemory", provider.GetMetadata().Name);
         }
 
@@ -216,7 +216,7 @@ namespace OpenFeature.Tests.Providers.Memory
             Assert.True(details.Value);
 
             // update flags
-            await provider.UpdateFlags(new Dictionary<string, Flag>(){
+            await provider.UpdateFlagsAsync(new Dictionary<string, Flag>(){
             {
                 "new-flag", new Flag<string>(
                     variants: new Dictionary<string, string>(){


### PR DESCRIPTION
I was doing an audit before the release and found this one method could use a suffix update.