### PR TITLE
fix: Fix unit test clean context 

### DIFF
--- a/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -5,7 +5,7 @@ namespace OpenFeature.Tests;
 public class ClearOpenFeatureInstanceFixture : IDisposable
 {
     // Make sure the singleton is cleared between tests
-    public ClearOpenFeatureInstanceFixture()
+    public void Dispose()
     {
         Api.Instance.SetContext(null);
         Api.Instance.ClearHooks();

--- a/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -1,13 +1,14 @@
-namespace OpenFeature.Tests
+using System;
+
+namespace OpenFeature.Tests;
+
+public class ClearOpenFeatureInstanceFixture : IDisposable
 {
-    public class ClearOpenFeatureInstanceFixture
+    // Make sure the singleton is cleared between tests
+    public ClearOpenFeatureInstanceFixture()
     {
-        // Make sure the singleton is cleared between tests
-        public ClearOpenFeatureInstanceFixture()
-        {
-            Api.Instance.SetContext(null);
-            Api.Instance.ClearHooks();
-            Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).Wait();
-        }
+        Api.Instance.SetContext(null);
+        Api.Instance.ClearHooks();
+        Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).Wait();
     }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- It fixes an issue where the context sometimes needs to be cleared correctly.
- It should eliminate any further race conditions in the unit tests.

### Notes
<!-- any additional notes for this PR -->
Following an investigation on xUnit shared contexts, I found we should use `IDisposable` to clear data between tests. See https://xunit.net/docs/shared-context for reference.