### PR TITLE
docs: disable space in link text lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD033 -->
+<!-- markdownlint-disable MD033 MD039 -->
 <!-- x-hide-in-docs-start -->
 <!-- NuGet doesn't support most HTML tags. Disabling dark mode support until https://github.com/NuGet/NuGetGallery/issues/8644 is resolved. -->
 ![OpenFeature Dark Logo](https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/black/openfeature-horizontal-black.svg)


### PR DESCRIPTION
A recent change in the markdown link rules made multi-line links a violation of MD039.

https://github.com/DavidAnson/markdownlint/commit/a6cf08dfc654e5b7610cbb153d423d6a0f3b7907

This is impacting the doc updater.

https://github.com/open-feature/openfeature.dev/actions/runs/12348450303/job/34457301528?pr=872