### PR TITLE
fix: Adding Async Lifetime method to fix flaky unit tests

### DIFF
--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -29,7 +29,7 @@ namespace OpenFeature
         /// <summary>
         /// Singleton instance of Api
         /// </summary>
-        public static Api Instance { get; } = new Api();
+        public static Api Instance { get; private set; } = new Api();
 
         // Explicit static constructor to tell C# compiler
         // not to mark type as beforeFieldInit
@@ -299,6 +299,14 @@ namespace OpenFeature
             };
 
             await this._eventExecutor.EventChannel.Writer.WriteAsync(new Event { Provider = provider, EventPayload = eventPayload }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// This method should only be using for testing purposes. It will reset the singleton instance of the API.
+        /// </summary>
+        internal static void ResetApi()
+        {
+            Instance = new Api();
         }
     }
 }

--- a/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -14,8 +14,5 @@ public class ClearOpenFeatureInstanceFixture : IAsyncLifetime
     public async Task DisposeAsync()
     {
         await Api.Instance.ShutdownAsync().ConfigureAwait(false);
-        // Api.Instance.SetContext(null);
-        // Api.Instance.ClearHooks();
-        // Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).Wait();
     }
 }

--- a/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -1,14 +1,21 @@
-using System;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace OpenFeature.Tests;
 
-public class ClearOpenFeatureInstanceFixture : IDisposable
+public class ClearOpenFeatureInstanceFixture : IAsyncLifetime
 {
-    // Make sure the singleton is cleared between tests
-    public void Dispose()
+    public Task InitializeAsync()
     {
-        Api.Instance.SetContext(null);
-        Api.Instance.ClearHooks();
-        Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).Wait();
+        return Task.CompletedTask;
+    }
+
+    // Make sure the singleton is cleared between tests
+    public async Task DisposeAsync()
+    {
+        await Api.Instance.ShutdownAsync().ConfigureAwait(false);
+        // Api.Instance.SetContext(null);
+        // Api.Instance.ClearHooks();
+        // Api.Instance.SetProviderAsync(new NoOpFeatureProvider()).Wait();
     }
 }

--- a/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -7,6 +7,8 @@ public class ClearOpenFeatureInstanceFixture : IAsyncLifetime
 {
     public Task InitializeAsync()
     {
+        Api.ResetApi();
+
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Changes the way we currently reset the Api between unit tests. This approach should be safer since it calls the official `Shutdown`, and when we call the API again, all the resources are reset.

### Notes
<!-- any additional notes for this PR -->
Check for more details: https://xunit.net/docs/shared-context#:~:text=For%20context%20cleanup%2C%20add%20the%20IDisposable%20interface%20to,call%20IAsyncDisposable%20%28it%20is%20planned%20for%20xUnit%20v3%29.