### PR TITLE
feat: Add evaluation details to finally hook stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ public class MyHook : Hook
     // code to run if there's an error during before hooks or during flag evaluation
   }
 
-  public ValueTask FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null)
+  public ValueTask FinallyAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> evaluationDetails, IReadOnlyDictionary<string, object> hints = null)
   {
     // code to run after all other stages, regardless of success/failure
   }

--- a/src/OpenFeature/Hook.cs
+++ b/src/OpenFeature/Hook.cs
@@ -31,7 +31,8 @@ namespace OpenFeature
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
         /// <returns>Modified EvaluationContext that is used for the flag evaluation</returns>
         public virtual ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
-            IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
+            IReadOnlyDictionary<string, object>? hints = null,
+            CancellationToken cancellationToken = default)
         {
             return new ValueTask<EvaluationContext>(EvaluationContext.Empty);
         }
@@ -44,8 +45,10 @@ namespace OpenFeature
         /// <param name="hints">Caller provided data</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
-            IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
+        public virtual ValueTask AfterAsync<T>(HookContext<T> context,
+            FlagEvaluationDetails<T> details,
+            IReadOnlyDictionary<string, object>? hints = null,
+            CancellationToken cancellationToken = default)
         {
             return new ValueTask();
         }
@@ -58,8 +61,10 @@ namespace OpenFeature
         /// <param name="hints">Caller provided data</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual ValueTask ErrorAsync<T>(HookContext<T> context, Exception error,
-            IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
+        public virtual ValueTask ErrorAsync<T>(HookContext<T> context,
+            Exception error,
+            IReadOnlyDictionary<string, object>? hints = null,
+            CancellationToken cancellationToken = default)
         {
             return new ValueTask();
         }
@@ -68,10 +73,14 @@ namespace OpenFeature
         /// Called unconditionally after flag evaluation.
         /// </summary>
         /// <param name="context">Provides context of innovation</param>
+        /// <param name="evaluationDetails">Flag evaluation information</param>
         /// <param name="hints">Caller provided data</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <typeparam name="T">Flag value type (bool|number|string|object)</typeparam>
-        public virtual ValueTask FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
+        public virtual ValueTask FinallyAsync<T>(HookContext<T> context,
+            FlagEvaluationDetails<T> evaluationDetails,
+            IReadOnlyDictionary<string, object>? hints = null,
+            CancellationToken cancellationToken = default)
         {
             return new ValueTask();
         }

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -252,12 +252,10 @@ namespace OpenFeature
                 // short circuit evaluation entirely if provider is in a bad state
                 if (provider.Status == ProviderStatus.NotReady)
                 {
-                    evaluation = new FlagEvaluationDetails<T>(flagKey, defaultValue, ErrorType.ProviderNotReady, Reason.Error, string.Empty, "Provider has not yet completed initialization.");
                     throw new ProviderNotReadyException("Provider has not yet completed initialization.");
                 }
                 else if (provider.Status == ProviderStatus.Fatal)
                 {
-                    evaluation = new FlagEvaluationDetails<T>(flagKey, defaultValue, ErrorType.ProviderFatal, Reason.Error, string.Empty, string.Empty);
                     throw new ProviderFatalException("Provider is in an irrecoverable error state.");
                 }
 

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -656,5 +656,25 @@ namespace OpenFeature.Tests
 
             Assert.Equal(expectedResult, actualEvaluationContext.GetValue(key).AsString);
         }
+
+        [Fact]
+        [Specification("4.3.8", "'evaluation details' passed to the 'finally' stage matches the evaluation details returned to the application author")]
+        public async Task FinallyHook_IncludesEvaluationDetails()
+        {
+            // Arrange
+            var provider = new TestProvider();
+            var providerHook = Substitute.For<Hook>();
+            provider.AddHook(providerHook);
+            await Api.Instance.SetProviderAsync(provider);
+            var client = Api.Instance.GetClient();
+
+            const string flagName = "flagName";
+
+            // Act
+            var evaluationDetails = await client.GetBooleanDetailsAsync(flagName, true);
+
+            // Assert
+            await providerHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), evaluationDetails);
+        }
     }
 }

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -45,10 +45,10 @@ namespace OpenFeature.Tests
             invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
             clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
             apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
-            providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
-            invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
-            clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
-            apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+            apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
 
             var testProvider = new TestProvider();
             testProvider.AddHook(providerHook);
@@ -70,10 +70,10 @@ namespace OpenFeature.Tests
                 invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
                 clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
                 apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-                apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+                apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
             });
 
             _ = apiHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
@@ -84,10 +84,10 @@ namespace OpenFeature.Tests
             _ = invocationHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
             _ = clientHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
             _ = apiHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = providerHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = invocationHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = clientHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            _ = apiHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = providerHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = invocationHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = clientHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            _ = apiHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
         }
 
         [Fact]
@@ -239,10 +239,12 @@ namespace OpenFeature.Tests
             };
             var hookContext = new HookContext<bool>("test", false, FlagValueType.Boolean,
                 new ClientMetadata(null, null), new Metadata(null), EvaluationContext.Empty);
+            var evaluationDetails =
+                new FlagEvaluationDetails<bool>("test", false, ErrorType.None, "testing", "testing");
 
             await hook.BeforeAsync(hookContext, hookHints);
-            await hook.AfterAsync(hookContext, new FlagEvaluationDetails<bool>("test", false, ErrorType.None, "testing", "testing"), hookHints);
-            await hook.FinallyAsync(hookContext, hookHints);
+            await hook.AfterAsync(hookContext, evaluationDetails, hookHints);
+            await hook.FinallyAsync(hookContext, evaluationDetails, hookHints);
             await hook.ErrorAsync(hookContext, new Exception(), hookHints);
 
             hookContext.ClientMetadata.Name.Should().BeNull();
@@ -269,7 +271,7 @@ namespace OpenFeature.Tests
             hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Returns(EvaluationContext.Empty);
             featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
             _ = hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
 
             await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
@@ -282,12 +284,12 @@ namespace OpenFeature.Tests
                 hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
                 featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
                 hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-                hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+                hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
             });
 
             _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
             _ = hook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
+            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
             _ = featureProvider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
         }
 
@@ -331,8 +333,8 @@ namespace OpenFeature.Tests
             featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
             hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
             hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
-            hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Returns(new ValueTask());
-            hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Throws(new Exception());
+            hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
+            hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Throws(new Exception());
 
             await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
@@ -348,8 +350,8 @@ namespace OpenFeature.Tests
                 featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
                 hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
                 hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-                hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), null);
-                hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), null);
+                hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+                hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
             });
 
             _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
@@ -357,8 +359,8 @@ namespace OpenFeature.Tests
             _ = featureProvider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
             _ = hook2.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
             _ = hook1.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-            _ = hook2.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), null);
-            _ = hook1.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook2.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+            _ = hook1.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
         }
 
         [Fact]
@@ -458,7 +460,7 @@ namespace OpenFeature.Tests
             hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(new ValueTask());
 
-            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(new ValueTask());
 
             await Api.Instance.SetProviderAsync(featureProvider);
@@ -471,7 +473,7 @@ namespace OpenFeature.Tests
                 hook.Received().BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
                 featureProvider.Received().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>());
                 hook.Received().AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-                hook.Received().FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received().FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
             });
         }
 
@@ -489,7 +491,7 @@ namespace OpenFeature.Tests
             // Sequence
             hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Throws(exceptionToThrow);
             hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(new ValueTask());
-            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), null).Returns(new ValueTask());
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
 
             var client = Api.Instance.GetClient();
             client.AddHooks(hook);
@@ -500,13 +502,13 @@ namespace OpenFeature.Tests
             {
                 hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
                 hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-                hook.FinallyAsync(Arg.Any<HookContext<bool>>(), null);
+                hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
             });
 
             resolvedFlag.Should().BeTrue();
             _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
             _ = hook.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), exceptionToThrow, null);
-            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), null);
+            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
         }
 
         [Fact]
@@ -536,7 +538,7 @@ namespace OpenFeature.Tests
             hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(new ValueTask());
 
-            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(new ValueTask());
 
             await Api.Instance.SetProviderAsync(featureProvider);
@@ -550,7 +552,7 @@ namespace OpenFeature.Tests
             {
                 hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
                 hook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-                hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+                hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
             });
 
             await featureProvider.DidNotReceive().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>());
@@ -569,7 +571,7 @@ namespace OpenFeature.Tests
             hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), cts.Token).Returns(EvaluationContext.Empty);
             featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), cts.Token).Returns(new ResolutionDetails<bool>("test", false));
             _ = hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), cts.Token);
-            _ = hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), cts.Token);
+            _ = hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), cts.Token);
 
             await Api.Instance.SetProviderAsync(featureProvider);
             var client = Api.Instance.GetClient();
@@ -579,7 +581,7 @@ namespace OpenFeature.Tests
 
             _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), cts.Token);
             _ = hook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), cts.Token);
-            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), cts.Token);
+            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), cts.Token);
         }
 
         [Fact]
@@ -606,7 +608,7 @@ namespace OpenFeature.Tests
             hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(new ValueTask());
 
-            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
                 .Returns(new ValueTask());
 
             await Api.Instance.SetProviderAsync(featureProvider);
@@ -616,7 +618,7 @@ namespace OpenFeature.Tests
 
             _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), cts.Token);
             _ = hook.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>(), cts.Token);
-            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), cts.Token);
+            _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), cts.Token);
 
             await featureProvider.DidNotReceive().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>());
         }

--- a/test/OpenFeature.Tests/TestImplementations.cs
+++ b/test/OpenFeature.Tests/TestImplementations.cs
@@ -48,6 +48,7 @@ namespace OpenFeature.Tests
         }
 
         public override ValueTask FinallyAsync<T>(HookContext<T> context,
+            FlagEvaluationDetails<T> evaluationDetails,
             IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
         {
             Interlocked.Increment(ref this._finallyCallCount);


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## Add evaluation details to the finally hook stage
<!-- add the description of the PR here -->

This pull request includes several changes to improve the handling of flag evaluation details and error handling in the OpenFeature library. The most important changes include modifying hook methods to accept `FlagEvaluationDetails` as a parameter, updating the `EvaluateFlagAsync` method to handle provider errors more gracefully, and adjusting the corresponding unit tests to reflect these changes.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #328 

### Notes
<!-- any additional notes for this PR -->

#### Improvements to Hook Methods:
* [`src/OpenFeature/Hook.cs`](diffhunk://#diff-d69e6a4b3c0fb22dcb05a1104cd353a597bc8f54bb29c458ed41d394d8f1c12aL34-R35): Modified the `FinallyAsync` methods to accept `FlagEvaluationDetails` as a parameter. [[1]](diffhunk://#diff-d69e6a4b3c0fb22dcb05a1104cd353a597bc8f54bb29c458ed41d394d8f1c12aR76-R83)
* [`src/OpenFeature/Hook.cs`](diffhunk://#diff-d69e6a4b3c0fb22dcb05a1104cd353a597bc8f54bb29c458ed41d394d8f1c12aL34-R35): Modified the hooks methods to split the parameters per line.[[1]](diffhunk://#diff-d69e6a4b3c0fb22dcb05a1104cd353a597bc8f54bb29c458ed41d394d8f1c12aL34-R35) [[2]](diffhunk://#diff-d69e6a4b3c0fb22dcb05a1104cd353a597bc8f54bb29c458ed41d394d8f1c12aL47-R51) [[3]](diffhunk://#diff-d69e6a4b3c0fb22dcb05a1104cd353a597bc8f54bb29c458ed41d394d8f1c12aL61-R67) 

#### Enhancements to Flag Evaluation:
* [`src/OpenFeature/OpenFeatureClient.cs`](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907L247-R260): Updated the `EvaluateFlagAsync` method to initialize `FlagEvaluationDetails` in case of provider errors and ensure the `FinallyAsync` hook is always called with the correct evaluation details. [[1]](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907L247-R260) [[2]](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907L300-R304) [[3]](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907L354-R365)