### PR TITLE
fix: Fix SBOM release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          dotnet-version: |
+            9.0.x
+          source-url: https://nuget.pkg.github.com/open-feature/index.json
+
       - name: Install CycloneDX.NET
         run: dotnet tool install CycloneDX
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- This pull request includes an update to the `.github/workflows/release.yml` file to set up the .NET SDK for the release workflow.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #362 

### Notes
* Added a step to set up the .NET SDK using the `actions/setup-dotnet` action, specifying the .NET version `9.0.x` and the source URL for the NuGet package.

### How to test
<!-- if applicable, add testing instructions under this section -->
Check green build here: https://github.com/open-feature/dotnet-sdk/actions/runs/13141307066/job/36668893117