### PR TITLE
chore: Replace SpecFlow with Reqnroll for testing framework

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,9 +26,7 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.1.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="SpecFlow" Version="3.9.74" />
-    <PackageVersion Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
-    <PackageVersion Include="SpecFlow.xUnit" Version="3.9.74" />
+    <PackageVersion Include="Reqnroll.xUnit" Version="2.2.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.1" />

--- a/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
+++ b/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
@@ -16,9 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SpecFlow" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" />
-    <PackageReference Include="SpecFlow.xUnit" />
+    <PackageReference Include="Reqnroll.xUnit" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -4,7 +4,7 @@ using OpenFeature.Constant;
 using OpenFeature.Extension;
 using OpenFeature.Model;
 using OpenFeature.Providers.Memory;
-using TechTalk.SpecFlow;
+using Reqnroll;
 using Xunit;
 
 namespace OpenFeature.E2ETests


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
This pull request includes updates to the testing framework by replacing SpecFlow with Reqnroll across multiple files. 

Testing framework updates:

* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L29-R29): Replaced SpecFlow packages with Reqnroll.xUnit package.
* [`test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj`](diffhunk://#diff-ab2ad60395e1cc72b327459243ed8c5711efbd88531a3b3b813fb6c4c6019886L19-R19): Updated package references to use Reqnroll.xUnit instead of SpecFlow packages.
* [`test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs`](diffhunk://#diff-9ca6e89533e4b3f7a2deaf8de6d6f07a80b7eab2afa6f2e8bfc682b9ca60dc6bL7-R7): Replaced `TechTalk.SpecFlow` with `Reqnroll` in the using directives.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #354 