### PR TITLE
fix: Address issue with newline characters when running Logging Hook Unit Tests on linux

### DIFF
--- a/test/OpenFeature.Tests/Hooks/LoggingHookTests.cs
+++ b/test/OpenFeature.Tests/Hooks/LoggingHookTests.cs
@@ -44,7 +44,9 @@ namespace OpenFeature.Tests.Hooks
                 DefaultValue:False
 
                 """,
-                record.Message);
+                record.Message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         [Fact]
@@ -74,7 +76,9 @@ namespace OpenFeature.Tests.Hooks
                 DefaultValue:False
 
                 """,
-                record.Message);
+                record.Message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         [Fact]
@@ -107,15 +111,6 @@ namespace OpenFeature.Tests.Hooks
             var record = logger.LatestRecord;
             Assert.Equal(LogLevel.Debug, record.Level);
 
-            Assert.Contains(
-                """
-                Before Flag Evaluation Domain:client
-                ProviderName:provider
-                FlagKey:test
-                DefaultValue:False
-                Context:
-                """,
-                record.Message);
             Assert.Multiple(
                 () => Assert.Contains("key_1:value", record.Message),
                 () => Assert.Contains("key_2:False", record.Message),
@@ -157,7 +152,9 @@ namespace OpenFeature.Tests.Hooks
                 Context:
 
                 """,
-                record.Message);
+                record.Message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         [Fact]
@@ -215,7 +212,9 @@ namespace OpenFeature.Tests.Hooks
                 DefaultValue:False
 
                 """,
-                record.Message);
+                record.Message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         [Fact]
@@ -250,15 +249,6 @@ namespace OpenFeature.Tests.Hooks
             var record = logger.LatestRecord;
             Assert.Equal(LogLevel.Error, record.Level);
 
-            Assert.Contains(
-                """
-                Error during Flag Evaluation Domain:client
-                ProviderName:provider
-                FlagKey:test
-                DefaultValue:False
-                Context:
-                """,
-                record.Message);
             Assert.Multiple(
                 () => Assert.Contains("key_1: ", record.Message),
                 () => Assert.Contains("key_2:True", record.Message),
@@ -301,7 +291,9 @@ namespace OpenFeature.Tests.Hooks
                 Context:
 
                 """,
-                record.Message);
+                record.Message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         [Fact]
@@ -358,7 +350,9 @@ namespace OpenFeature.Tests.Hooks
                 DefaultValue:False
 
                 """,
-                record.Message);
+                record.Message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         [Fact]
@@ -392,16 +386,6 @@ namespace OpenFeature.Tests.Hooks
 
             var record = logger.LatestRecord;
             Assert.Equal(LogLevel.Debug, record.Level);
-
-            Assert.Contains(
-                """
-                After Flag Evaluation Domain:client
-                ProviderName:provider
-                FlagKey:test
-                DefaultValue:False
-                Context:
-                """,
-                record.Message);
 
             // .NET Framework uses G15 formatter on double.ToString
             // .NET uses G17 formatter on double.ToString
@@ -452,7 +436,9 @@ namespace OpenFeature.Tests.Hooks
                 Context:
 
                 """,
-                record.Message);
+                record.Message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         [Fact]
@@ -499,8 +485,9 @@ namespace OpenFeature.Tests.Hooks
                     key_1:OpenFeature.Model.Value
 
                 """,
-                    message
-                );
+                message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         [Fact]
@@ -539,8 +526,9 @@ namespace OpenFeature.Tests.Hooks
                     key_1:True
 
                 """,
-                    message
-                );
+                message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         [Fact]
@@ -579,8 +567,9 @@ namespace OpenFeature.Tests.Hooks
                     key_1:True
 
                 """,
-                    message
-                );
+                message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         [Fact]
@@ -619,8 +608,9 @@ namespace OpenFeature.Tests.Hooks
                     key_1:True
 
                 """,
-                    message
-                );
+                message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         [Fact]
@@ -659,8 +649,9 @@ namespace OpenFeature.Tests.Hooks
                     key_1:
 
                 """,
-                    message
-                );
+                message,
+                ignoreLineEndingDifferences: true
+            );
         }
 
         private static string NormalizeLogRecord(FakeLogRecord record)


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

I noticed when I ran the LoggingHook unit tests on a WSL Ubuntu instance the some tests fails due to new line characters. It appears I never normalized or excluded newline characters when asserting equal

![image](https://github.com/user-attachments/assets/91bceb1b-41be-4f5c-b330-874ef614c163)

I also removed the `Assert.Contains` snippets as the content and layout of the log message is asserted in the other tests. This Assert method does not have an overload for ignoring new line characters

I assume the GitHub CI runner may be ignore the line endings by default?

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

