### PR TITLE
test: Add missing gherkin tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Initialize Tests
         run: |
           git submodule update --init --recursive
-          cp spec/specification/assets/gherkin/*.feature test/OpenFeature.E2ETests/Features/
 
       - name: Run Tests
         run: dotnet test test/OpenFeature.E2ETests/ --configuration Release --logger GitHubActions

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Initialize Tests
         run: |
           git submodule update --init --recursive
-          cp spec/specification/assets/gherkin/evaluation.feature test/OpenFeature.E2ETests/Features/
+          cp spec/specification/assets/gherkin/*.feature test/OpenFeature.E2ETests/Features/
 
       - name: Run Tests
         run: dotnet test test/OpenFeature.E2ETests/ --configuration Release --logger GitHubActions

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Initialize Tests
         run: |
           git submodule update --init --recursive
+          cp spec/specification/assets/gherkin/*.feature test/OpenFeature.E2ETests/Features/
 
       - name: Run Tests
         run: dotnet test test/OpenFeature.E2ETests/ --configuration Release --logger GitHubActions

--- a/.gitignore
+++ b/.gitignore
@@ -350,7 +350,7 @@ ASALocalRun/
 !.vscode/extensions.json
 
 # integration tests
-test/OpenFeature.E2ETests/Features/evaluation.feature
-test/OpenFeature.E2ETests/Features/evaluation.feature.cs
+test/OpenFeature.E2ETests/Features/*.feature
+test/OpenFeature.E2ETests/Features/*.feature.cs
 cs-report.json
 specification.json

--- a/build/Common.tests.props
+++ b/build/Common.tests.props
@@ -5,11 +5,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
     <Content Include="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenFeature.sln'))\build\xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/build/xunit.runner.json
+++ b/build/xunit.runner.json
@@ -1,4 +1,5 @@
 {
   "maxParallelThreads": 1,
-  "parallelizeTestCollections": false
+  "parallelizeTestCollections": false,
+  "parallelizeAssembly": false
 }

--- a/src/OpenFeature/Model/ImmutableMetadata.cs
+++ b/src/OpenFeature/Model/ImmutableMetadata.cs
@@ -85,4 +85,6 @@ public sealed class ImmutableMetadata
 
         return value is T tValue ? tValue : null;
     }
+
+    internal int Count => this._metadata.Count;
 }

--- a/src/OpenFeature/Providers/Memory/Flag.cs
+++ b/src/OpenFeature/Providers/Memory/Flag.cs
@@ -19,6 +19,7 @@ namespace OpenFeature.Providers.Memory
         private readonly Dictionary<string, T> _variants;
         private readonly string _defaultVariant;
         private readonly Func<EvaluationContext, string>? _contextEvaluator;
+        private readonly ImmutableMetadata? _flagMetadata;
 
         /// <summary>
         /// Flag representation for the in-memory provider.
@@ -26,11 +27,13 @@ namespace OpenFeature.Providers.Memory
         /// <param name="variants">dictionary of variants and their corresponding values</param>
         /// <param name="defaultVariant">default variant (should match 1 key in variants dictionary)</param>
         /// <param name="contextEvaluator">optional context-sensitive evaluation function</param>
-        public Flag(Dictionary<string, T> variants, string defaultVariant, Func<EvaluationContext, string>? contextEvaluator = null)
+        /// <param name="flagMetadata">optional metadata for the flag</param>
+        public Flag(Dictionary<string, T> variants, string defaultVariant, Func<EvaluationContext, string>? contextEvaluator = null, ImmutableMetadata? flagMetadata = null)
         {
             this._variants = variants;
             this._defaultVariant = defaultVariant;
             this._contextEvaluator = contextEvaluator;
+            this._flagMetadata = flagMetadata;
         }
 
         internal ResolutionDetails<T> Evaluate(string flagKey, T _, EvaluationContext? evaluationContext)
@@ -44,7 +47,8 @@ namespace OpenFeature.Providers.Memory
                         flagKey,
                         value,
                         variant: this._defaultVariant,
-                        reason: Reason.Static
+                        reason: Reason.Static,
+                        flagMetadata: this._flagMetadata
                     );
                 }
                 else
@@ -65,7 +69,8 @@ namespace OpenFeature.Providers.Memory
                         flagKey,
                         value,
                         variant: variant,
-                        reason: Reason.TargetingMatch
+                        reason: Reason.TargetingMatch,
+                        flagMetadata: this._flagMetadata
                     );
                 }
             }

--- a/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
+++ b/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
@@ -29,4 +29,10 @@
     <ProjectReference Include="..\..\src\OpenFeature\OpenFeature.csproj" />
   </ItemGroup>
 
+  <Target Name="GherkinRestore" BeforeTargets="CoreBuild">
+    <ItemGroup>
+      <GherkinFiles Include="..\..\spec\specification\assets\gherkin\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(GherkinFiles)" DestinationFolder="Features/"/>
+  </Target>
 </Project>

--- a/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
+++ b/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
@@ -36,9 +36,4 @@
     <Copy SourceFiles="@(GherkinFiles)" DestinationFolder="Features/"/>
   </Target>
 
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 </Project>

--- a/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
+++ b/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
@@ -35,4 +35,10 @@
     </ItemGroup>
     <Copy SourceFiles="@(GherkinFiles)" DestinationFolder="Features/"/>
   </Target>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/test/OpenFeature.E2ETests/Steps/BaseStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/BaseStepDefinitions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using OpenFeature.E2ETests.Utils;
 using OpenFeature.Model;
 using OpenFeature.Providers.Memory;
 using Reqnroll;
@@ -120,12 +121,4 @@ public class BaseStepDefinitions
             )
         }
     };
-
-    internal enum FlagType
-    {
-        Integer,
-        Float,
-        String,
-        Boolean
-    }
 }

--- a/test/OpenFeature.E2ETests/Steps/BaseStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/BaseStepDefinitions.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OpenFeature.Model;
+using OpenFeature.Providers.Memory;
+using Reqnroll;
+
+namespace OpenFeature.E2ETests.Steps;
+
+[Binding]
+public class BaseStepDefinitions
+{
+    internal FeatureClient? Client;
+    private string _flagKey = null!;
+    private string _defaultValue = null!;
+    internal FlagType? FlagTypeEnum;
+    internal object Result = null!;
+
+    [Given(@"a stable provider")]
+    public void GivenAStableProvider()
+    {
+        var memProvider = new InMemoryProvider(E2EFlagConfig);
+        Api.Instance.SetProviderAsync(memProvider).Wait();
+        this.Client = Api.Instance.GetClient("TestClient", "1.0.0");
+    }
+
+    [Given(@"a Boolean-flag with key ""(.*)"" and a default value ""(.*)""")]
+    [Given(@"a boolean-flag with key ""(.*)"" and a default value ""(.*)""")]
+    public void GivenABoolean_FlagWithKeyAndADefaultValue(string key, string defaultType)
+    {
+        this._flagKey = key;
+        this._defaultValue = defaultType;
+        this.FlagTypeEnum = FlagType.Boolean;
+    }
+
+    [Given(@"a Float-flag with key ""(.*)"" and a default value ""(.*)""")]
+    [Given(@"a float-flag with key ""(.*)"" and a default value ""(.*)""")]
+    public void GivenAFloat_FlagWithKeyAndADefaultValue(string key, string defaultType)
+    {
+        this._flagKey = key;
+        this._defaultValue = defaultType;
+        this.FlagTypeEnum = FlagType.Float;
+    }
+
+    [Given(@"a Integer-flag with key ""(.*)"" and a default value ""(.*)""")]
+    [Given(@"a integer-flag with key ""(.*)"" and a default value ""(.*)""")]
+    public void GivenAnInteger_FlagWithKeyAndADefaultValue(string key, string defaultType)
+    {
+        this._flagKey = key;
+        this._defaultValue = defaultType;
+        this.FlagTypeEnum = FlagType.Integer;
+    }
+
+    [Given(@"a String-flag with key ""(.*)"" and a default value ""(.*)""")]
+    [Given(@"a string-flag with key ""(.*)"" and a default value ""(.*)""")]
+    public void GivenAString_FlagWithKeyAndADefaultValue(string key, string defaultType)
+    {
+        this._flagKey = key;
+        this._defaultValue = defaultType;
+        this.FlagTypeEnum = FlagType.String;
+    }
+
+    [When(@"the flag was evaluated with details")]
+    public async Task WhenTheFlagWasEvaluatedWithDetails()
+    {
+        switch (this.FlagTypeEnum)
+        {
+            case FlagType.Boolean:
+                this.Result = await this.Client!
+                    .GetBooleanDetailsAsync(this._flagKey, bool.Parse(this._defaultValue)).ConfigureAwait(false);
+                break;
+            case FlagType.Float:
+                this.Result = await this.Client!
+                    .GetDoubleDetailsAsync(this._flagKey, double.Parse(this._defaultValue)).ConfigureAwait(false);
+                break;
+            case FlagType.Integer:
+                this.Result = await this.Client!
+                    .GetIntegerDetailsAsync(this._flagKey, int.Parse(this._defaultValue)).ConfigureAwait(false);
+                break;
+            case FlagType.String:
+                this.Result = await this.Client!.GetStringDetailsAsync(this._flagKey, this._defaultValue)
+                    .ConfigureAwait(false);
+                break;
+        }
+    }
+
+    private static readonly IDictionary<string, Flag> E2EFlagConfig = new Dictionary<string, Flag>
+    {
+        {
+            "metadata-flag", new Flag<bool>(
+                variants: new Dictionary<string, bool> { { "on", true }, { "off", false } },
+                defaultVariant: "on",
+                flagMetadata: new ImmutableMetadata(new Dictionary<string, object>
+                {
+                    { "string", "1.0.2" }, { "integer", 2 }, { "float", 0.1 }, { "boolean", true }
+                })
+            )
+        },
+        {
+            "boolean-flag", new Flag<bool>(
+                variants: new Dictionary<string, bool> { { "on", true }, { "off", false } },
+                defaultVariant: "on"
+            )
+        },
+        {
+            "integer-flag", new Flag<int>(
+                variants: new Dictionary<string, int> { { "23", 23 }, { "42", 42 } },
+                defaultVariant: "23"
+            )
+        },
+        {
+            "float-flag", new Flag<double>(
+                variants: new Dictionary<string, double> { { "2.3", 2.3 }, { "4.2", 4.2 } },
+                defaultVariant: "2.3"
+            )
+        },
+        {
+            "string-flag", new Flag<string>(
+                variants: new Dictionary<string, string> { { "value", "value" }, { "value2", "value2" } },
+                defaultVariant: "value"
+            )
+        }
+    };
+
+    internal enum FlagType
+    {
+        Integer,
+        Float,
+        String,
+        Boolean
+    }
+}

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -7,7 +7,7 @@ using OpenFeature.Providers.Memory;
 using Reqnroll;
 using Xunit;
 
-namespace OpenFeature.E2ETests
+namespace OpenFeature.E2ETests.Steps
 {
     [Binding]
     public class EvaluationStepDefinitions

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -12,98 +12,94 @@ namespace OpenFeature.E2ETests
     [Binding]
     public class EvaluationStepDefinitions
     {
-        private static FeatureClient? client;
-        private Task<bool>? booleanFlagValue;
-        private Task<string>? stringFlagValue;
-        private Task<int>? intFlagValue;
-        private Task<double>? doubleFlagValue;
-        private Task<Value>? objectFlagValue;
-        private Task<FlagEvaluationDetails<bool>>? booleanFlagDetails;
-        private Task<FlagEvaluationDetails<string>>? stringFlagDetails;
-        private Task<FlagEvaluationDetails<int>>? intFlagDetails;
-        private Task<FlagEvaluationDetails<double>>? doubleFlagDetails;
-        private Task<FlagEvaluationDetails<Value>>? objectFlagDetails;
-        private string? contextAwareFlagKey;
-        private string? contextAwareDefaultValue;
-        private string? contextAwareValue;
-        private EvaluationContext? context;
-        private string? notFoundFlagKey;
-        private string? notFoundDefaultValue;
-        private FlagEvaluationDetails<string>? notFoundDetails;
-        private string? typeErrorFlagKey;
-        private int typeErrorDefaultValue;
-        private FlagEvaluationDetails<int>? typeErrorDetails;
-
-        public EvaluationStepDefinitions(ScenarioContext scenarioContext)
-        {
-        }
+        private static FeatureClient? _client;
+        private Task<bool>? _booleanFlagValue;
+        private Task<string>? _stringFlagValue;
+        private Task<int>? _intFlagValue;
+        private Task<double>? _doubleFlagValue;
+        private Task<Value>? _objectFlagValue;
+        private Task<FlagEvaluationDetails<bool>>? _booleanFlagDetails;
+        private Task<FlagEvaluationDetails<string>>? _stringFlagDetails;
+        private Task<FlagEvaluationDetails<int>>? _intFlagDetails;
+        private Task<FlagEvaluationDetails<double>>? _doubleFlagDetails;
+        private Task<FlagEvaluationDetails<Value>>? _objectFlagDetails;
+        private string? _contextAwareFlagKey;
+        private string? _contextAwareDefaultValue;
+        private string? _contextAwareValue;
+        private EvaluationContext? _context;
+        private string? _notFoundFlagKey;
+        private string? _notFoundDefaultValue;
+        private FlagEvaluationDetails<string>? _notFoundDetails;
+        private string? _typeErrorFlagKey;
+        private int _typeErrorDefaultValue;
+        private FlagEvaluationDetails<int>? _typeErrorDetails;
 
         [Given("a stable provider")]
         public void GivenAStableProvider()
         {
-            var memProvider = new InMemoryProvider(this.e2eFlagConfig);
+            var memProvider = new InMemoryProvider(this._e2EFlagConfig);
             Api.Instance.SetProviderAsync(memProvider).Wait();
-            client = Api.Instance.GetClient("TestClient", "1.0.0");
+            _client = Api.Instance.GetClient("TestClient", "1.0.0");
         }
 
         [When(@"a boolean flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Whenabooleanflagwithkeyisevaluatedwithdefaultvalue(string flagKey, bool defaultValue)
         {
-            this.booleanFlagValue = client?.GetBooleanValueAsync(flagKey, defaultValue);
+            this._booleanFlagValue = _client?.GetBooleanValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved boolean value should be ""(.*)""")]
         public void Thentheresolvedbooleanvalueshouldbe(bool expectedValue)
         {
-            Assert.Equal(expectedValue, this.booleanFlagValue?.Result);
+            Assert.Equal(expectedValue, this._booleanFlagValue?.Result);
         }
 
         [When(@"a string flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Whenastringflagwithkeyisevaluatedwithdefaultvalue(string flagKey, string defaultValue)
         {
-            this.stringFlagValue = client?.GetStringValueAsync(flagKey, defaultValue);
+            this._stringFlagValue = _client?.GetStringValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved string value should be ""(.*)""")]
         public void Thentheresolvedstringvalueshouldbe(string expected)
         {
-            Assert.Equal(expected, this.stringFlagValue?.Result);
+            Assert.Equal(expected, this._stringFlagValue?.Result);
         }
 
         [When(@"an integer flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void Whenanintegerflagwithkeyisevaluatedwithdefaultvalue(string flagKey, int defaultValue)
         {
-            this.intFlagValue = client?.GetIntegerValueAsync(flagKey, defaultValue);
+            this._intFlagValue = _client?.GetIntegerValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved integer value should be (.*)")]
         public void Thentheresolvedintegervalueshouldbe(int expected)
         {
-            Assert.Equal(expected, this.intFlagValue?.Result);
+            Assert.Equal(expected, this._intFlagValue?.Result);
         }
 
         [When(@"a float flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void Whenafloatflagwithkeyisevaluatedwithdefaultvalue(string flagKey, double defaultValue)
         {
-            this.doubleFlagValue = client?.GetDoubleValueAsync(flagKey, defaultValue);
+            this._doubleFlagValue = _client?.GetDoubleValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved float value should be (.*)")]
         public void Thentheresolvedfloatvalueshouldbe(double expected)
         {
-            Assert.Equal(expected, this.doubleFlagValue?.Result);
+            Assert.Equal(expected, this._doubleFlagValue?.Result);
         }
 
         [When(@"an object flag with key ""(.*)"" is evaluated with a null default value")]
         public void Whenanobjectflagwithkeyisevaluatedwithanulldefaultvalue(string flagKey)
         {
-            this.objectFlagValue = client?.GetObjectValueAsync(flagKey, new Value());
+            this._objectFlagValue = _client?.GetObjectValueAsync(flagKey, new Value());
         }
 
         [Then(@"the resolved object value should be contain fields ""(.*)"", ""(.*)"", and ""(.*)"", with values ""(.*)"", ""(.*)"" and (.*), respectively")]
         public void Thentheresolvedobjectvalueshouldbecontainfieldsandwithvaluesandrespectively(string boolField, string stringField, string numberField, bool boolValue, string stringValue, int numberValue)
         {
-            Value? value = this.objectFlagValue?.Result;
+            Value? value = this._objectFlagValue?.Result;
             Assert.Equal(boolValue, value?.AsStructure?[boolField].AsBoolean);
             Assert.Equal(stringValue, value?.AsStructure?[stringField].AsString);
             Assert.Equal(numberValue, value?.AsStructure?[numberField].AsInteger);
@@ -112,13 +108,13 @@ namespace OpenFeature.E2ETests
         [When(@"a boolean flag with key ""(.*)"" is evaluated with details and default value ""(.*)""")]
         public void Whenabooleanflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, bool defaultValue)
         {
-            this.booleanFlagDetails = client?.GetBooleanDetailsAsync(flagKey, defaultValue);
+            this._booleanFlagDetails = _client?.GetBooleanDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved boolean details value should be ""(.*)"", the variant should be ""(.*)"", and the reason should be ""(.*)""")]
         public void Thentheresolvedbooleandetailsvalueshouldbethevariantshouldbeandthereasonshouldbe(bool expectedValue, string expectedVariant, string expectedReason)
         {
-            var result = this.booleanFlagDetails?.Result;
+            var result = this._booleanFlagDetails?.Result;
             Assert.Equal(expectedValue, result?.Value);
             Assert.Equal(expectedVariant, result?.Variant);
             Assert.Equal(expectedReason, result?.Reason);
@@ -127,13 +123,13 @@ namespace OpenFeature.E2ETests
         [When(@"a string flag with key ""(.*)"" is evaluated with details and default value ""(.*)""")]
         public void Whenastringflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, string defaultValue)
         {
-            this.stringFlagDetails = client?.GetStringDetailsAsync(flagKey, defaultValue);
+            this._stringFlagDetails = _client?.GetStringDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved string details value should be ""(.*)"", the variant should be ""(.*)"", and the reason should be ""(.*)""")]
         public void Thentheresolvedstringdetailsvalueshouldbethevariantshouldbeandthereasonshouldbe(string expectedValue, string expectedVariant, string expectedReason)
         {
-            var result = this.stringFlagDetails?.Result;
+            var result = this._stringFlagDetails?.Result;
             Assert.Equal(expectedValue, result?.Value);
             Assert.Equal(expectedVariant, result?.Variant);
             Assert.Equal(expectedReason, result?.Reason);
@@ -142,13 +138,13 @@ namespace OpenFeature.E2ETests
         [When(@"an integer flag with key ""(.*)"" is evaluated with details and default value (.*)")]
         public void Whenanintegerflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, int defaultValue)
         {
-            this.intFlagDetails = client?.GetIntegerDetailsAsync(flagKey, defaultValue);
+            this._intFlagDetails = _client?.GetIntegerDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved integer details value should be (.*), the variant should be ""(.*)"", and the reason should be ""(.*)""")]
         public void Thentheresolvedintegerdetailsvalueshouldbethevariantshouldbeandthereasonshouldbe(int expectedValue, string expectedVariant, string expectedReason)
         {
-            var result = this.intFlagDetails?.Result;
+            var result = this._intFlagDetails?.Result;
             Assert.Equal(expectedValue, result?.Value);
             Assert.Equal(expectedVariant, result?.Variant);
             Assert.Equal(expectedReason, result?.Reason);
@@ -157,13 +153,13 @@ namespace OpenFeature.E2ETests
         [When(@"a float flag with key ""(.*)"" is evaluated with details and default value (.*)")]
         public void Whenafloatflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, double defaultValue)
         {
-            this.doubleFlagDetails = client?.GetDoubleDetailsAsync(flagKey, defaultValue);
+            this._doubleFlagDetails = _client?.GetDoubleDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved float details value should be (.*), the variant should be ""(.*)"", and the reason should be ""(.*)""")]
         public void Thentheresolvedfloatdetailsvalueshouldbethevariantshouldbeandthereasonshouldbe(double expectedValue, string expectedVariant, string expectedReason)
         {
-            var result = this.doubleFlagDetails?.Result;
+            var result = this._doubleFlagDetails?.Result;
             Assert.Equal(expectedValue, result?.Value);
             Assert.Equal(expectedVariant, result?.Variant);
             Assert.Equal(expectedReason, result?.Reason);
@@ -172,13 +168,13 @@ namespace OpenFeature.E2ETests
         [When(@"an object flag with key ""(.*)"" is evaluated with details and a null default value")]
         public void Whenanobjectflagwithkeyisevaluatedwithdetailsandanulldefaultvalue(string flagKey)
         {
-            this.objectFlagDetails = client?.GetObjectDetailsAsync(flagKey, new Value());
+            this._objectFlagDetails = _client?.GetObjectDetailsAsync(flagKey, new Value());
         }
 
         [Then(@"the resolved object details value should be contain fields ""(.*)"", ""(.*)"", and ""(.*)"", with values ""(.*)"", ""(.*)"" and (.*), respectively")]
         public void Thentheresolvedobjectdetailsvalueshouldbecontainfieldsandwithvaluesandrespectively(string boolField, string stringField, string numberField, bool boolValue, string stringValue, int numberValue)
         {
-            var value = this.objectFlagDetails?.Result.Value;
+            var value = this._objectFlagDetails?.Result.Value;
             Assert.Equal(boolValue, value?.AsStructure?[boolField].AsBoolean);
             Assert.Equal(stringValue, value?.AsStructure?[stringField].AsString);
             Assert.Equal(numberValue, value?.AsStructure?[numberField].AsInteger);
@@ -187,14 +183,14 @@ namespace OpenFeature.E2ETests
         [Then(@"the variant should be ""(.*)"", and the reason should be ""(.*)""")]
         public void Giventhevariantshouldbeandthereasonshouldbe(string expectedVariant, string expectedReason)
         {
-            Assert.Equal(expectedVariant, this.objectFlagDetails?.Result.Variant);
-            Assert.Equal(expectedReason, this.objectFlagDetails?.Result.Reason);
+            Assert.Equal(expectedVariant, this._objectFlagDetails?.Result.Variant);
+            Assert.Equal(expectedReason, this._objectFlagDetails?.Result.Reason);
         }
 
         [When(@"context contains keys ""(.*)"", ""(.*)"", ""(.*)"", ""(.*)"" with values ""(.*)"", ""(.*)"", (.*), ""(.*)""")]
         public void Whencontextcontainskeyswithvalues(string field1, string field2, string field3, string field4, string value1, string value2, int value3, string value4)
         {
-            this.context = new EvaluationContextBuilder()
+            this._context = new EvaluationContextBuilder()
                 .Set(field1, value1)
                 .Set(field2, value2)
                 .Set(field3, value3)
@@ -204,67 +200,67 @@ namespace OpenFeature.E2ETests
         [When(@"a flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Givenaflagwithkeyisevaluatedwithdefaultvalue(string flagKey, string defaultValue)
         {
-            this.contextAwareFlagKey = flagKey;
-            this.contextAwareDefaultValue = defaultValue;
-            this.contextAwareValue = client?.GetStringValueAsync(flagKey, this.contextAwareDefaultValue, this.context)?.Result;
+            this._contextAwareFlagKey = flagKey;
+            this._contextAwareDefaultValue = defaultValue;
+            this._contextAwareValue = _client?.GetStringValueAsync(flagKey, this._contextAwareDefaultValue, this._context).Result;
         }
 
         [Then(@"the resolved string response should be ""(.*)""")]
         public void Thentheresolvedstringresponseshouldbe(string expected)
         {
-            Assert.Equal(expected, this.contextAwareValue);
+            Assert.Equal(expected, this._contextAwareValue);
         }
 
         [Then(@"the resolved flag value is ""(.*)"" when the context is empty")]
         public void Giventheresolvedflagvalueiswhenthecontextisempty(string expected)
         {
-            string? emptyContextValue = client?.GetStringValueAsync(this.contextAwareFlagKey!, this.contextAwareDefaultValue!, EvaluationContext.Empty).Result;
+            string? emptyContextValue = _client?.GetStringValueAsync(this._contextAwareFlagKey!, this._contextAwareDefaultValue!, EvaluationContext.Empty).Result;
             Assert.Equal(expected, emptyContextValue);
         }
 
         [When(@"a non-existent string flag with key ""(.*)"" is evaluated with details and a default value ""(.*)""")]
         public void Whenanonexistentstringflagwithkeyisevaluatedwithdetailsandadefaultvalue(string flagKey, string defaultValue)
         {
-            this.notFoundFlagKey = flagKey;
-            this.notFoundDefaultValue = defaultValue;
-            this.notFoundDetails = client?.GetStringDetailsAsync(this.notFoundFlagKey, this.notFoundDefaultValue).Result;
+            this._notFoundFlagKey = flagKey;
+            this._notFoundDefaultValue = defaultValue;
+            this._notFoundDetails = _client?.GetStringDetailsAsync(this._notFoundFlagKey, this._notFoundDefaultValue).Result;
         }
 
         [Then(@"the default string value should be returned")]
         public void Thenthedefaultstringvalueshouldbereturned()
         {
-            Assert.Equal(this.notFoundDefaultValue, this.notFoundDetails?.Value);
+            Assert.Equal(this._notFoundDefaultValue, this._notFoundDetails?.Value);
         }
 
         [Then(@"the reason should indicate an error and the error code should indicate a missing flag with ""(.*)""")]
         public void Giventhereasonshouldindicateanerrorandtheerrorcodeshouldindicateamissingflagwith(string errorCode)
         {
-            Assert.Equal(Reason.Error.ToString(), this.notFoundDetails?.Reason);
-            Assert.Equal(errorCode, this.notFoundDetails?.ErrorType.GetDescription());
+            Assert.Equal(Reason.Error, this._notFoundDetails?.Reason);
+            Assert.Equal(errorCode, this._notFoundDetails?.ErrorType.GetDescription());
         }
 
         [When(@"a string flag with key ""(.*)"" is evaluated as an integer, with details and a default value (.*)")]
         public void Whenastringflagwithkeyisevaluatedasanintegerwithdetailsandadefaultvalue(string flagKey, int defaultValue)
         {
-            this.typeErrorFlagKey = flagKey;
-            this.typeErrorDefaultValue = defaultValue;
-            this.typeErrorDetails = client?.GetIntegerDetailsAsync(this.typeErrorFlagKey, this.typeErrorDefaultValue).Result;
+            this._typeErrorFlagKey = flagKey;
+            this._typeErrorDefaultValue = defaultValue;
+            this._typeErrorDetails = _client?.GetIntegerDetailsAsync(this._typeErrorFlagKey, this._typeErrorDefaultValue).Result;
         }
 
         [Then(@"the default integer value should be returned")]
         public void Thenthedefaultintegervalueshouldbereturned()
         {
-            Assert.Equal(this.typeErrorDefaultValue, this.typeErrorDetails?.Value);
+            Assert.Equal(this._typeErrorDefaultValue, this._typeErrorDetails?.Value);
         }
 
         [Then(@"the reason should indicate an error and the error code should indicate a type mismatch with ""(.*)""")]
         public void Giventhereasonshouldindicateanerrorandtheerrorcodeshouldindicateatypemismatchwith(string errorCode)
         {
-            Assert.Equal(Reason.Error.ToString(), this.typeErrorDetails?.Reason);
-            Assert.Equal(errorCode, this.typeErrorDetails?.ErrorType.GetDescription());
+            Assert.Equal(Reason.Error, this._typeErrorDetails?.Reason);
+            Assert.Equal(errorCode, this._typeErrorDetails?.ErrorType.GetDescription());
         }
 
-        private IDictionary<string, Flag> e2eFlagConfig = new Dictionary<string, Flag>(){
+        private readonly IDictionary<string, Flag> _e2EFlagConfig = new Dictionary<string, Flag>(){
             {
                 "boolean-flag", new Flag<bool>(
                     variants: new Dictionary<string, bool>(){

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -13,7 +13,7 @@ namespace OpenFeature.E2ETests.Steps
     [Scope(Feature = "Flag evaluation")]
     public class EvaluationStepDefinitions
     {
-        private static FeatureClient? _client;
+        private FeatureClient? _client;
         private Task<bool>? _booleanFlagValue;
         private Task<string>? _stringFlagValue;
         private Task<int>? _intFlagValue;
@@ -40,13 +40,13 @@ namespace OpenFeature.E2ETests.Steps
         {
             var memProvider = new InMemoryProvider(this._e2EFlagConfig);
             Api.Instance.SetProviderAsync(memProvider).Wait();
-            _client = Api.Instance.GetClient("TestClient", "1.0.0");
+            this._client = Api.Instance.GetClient("TestClient", "1.0.0");
         }
 
         [When(@"a boolean flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Whenabooleanflagwithkeyisevaluatedwithdefaultvalue(string flagKey, bool defaultValue)
         {
-            this._booleanFlagValue = _client?.GetBooleanValueAsync(flagKey, defaultValue);
+            this._booleanFlagValue = this._client?.GetBooleanValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved boolean value should be ""(.*)""")]
@@ -58,7 +58,7 @@ namespace OpenFeature.E2ETests.Steps
         [When(@"a string flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Whenastringflagwithkeyisevaluatedwithdefaultvalue(string flagKey, string defaultValue)
         {
-            this._stringFlagValue = _client?.GetStringValueAsync(flagKey, defaultValue);
+            this._stringFlagValue = this._client?.GetStringValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved string value should be ""(.*)""")]
@@ -70,7 +70,7 @@ namespace OpenFeature.E2ETests.Steps
         [When(@"an integer flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void Whenanintegerflagwithkeyisevaluatedwithdefaultvalue(string flagKey, int defaultValue)
         {
-            this._intFlagValue = _client?.GetIntegerValueAsync(flagKey, defaultValue);
+            this._intFlagValue = this._client?.GetIntegerValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved integer value should be (.*)")]
@@ -82,7 +82,7 @@ namespace OpenFeature.E2ETests.Steps
         [When(@"a float flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void Whenafloatflagwithkeyisevaluatedwithdefaultvalue(string flagKey, double defaultValue)
         {
-            this._doubleFlagValue = _client?.GetDoubleValueAsync(flagKey, defaultValue);
+            this._doubleFlagValue = this._client?.GetDoubleValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved float value should be (.*)")]
@@ -94,7 +94,7 @@ namespace OpenFeature.E2ETests.Steps
         [When(@"an object flag with key ""(.*)"" is evaluated with a null default value")]
         public void Whenanobjectflagwithkeyisevaluatedwithanulldefaultvalue(string flagKey)
         {
-            this._objectFlagValue = _client?.GetObjectValueAsync(flagKey, new Value());
+            this._objectFlagValue = this._client?.GetObjectValueAsync(flagKey, new Value());
         }
 
         [Then(@"the resolved object value should be contain fields ""(.*)"", ""(.*)"", and ""(.*)"", with values ""(.*)"", ""(.*)"" and (.*), respectively")]
@@ -109,7 +109,7 @@ namespace OpenFeature.E2ETests.Steps
         [When(@"a boolean flag with key ""(.*)"" is evaluated with details and default value ""(.*)""")]
         public void Whenabooleanflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, bool defaultValue)
         {
-            this._booleanFlagDetails = _client?.GetBooleanDetailsAsync(flagKey, defaultValue);
+            this._booleanFlagDetails = this._client?.GetBooleanDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved boolean details value should be ""(.*)"", the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -124,7 +124,7 @@ namespace OpenFeature.E2ETests.Steps
         [When(@"a string flag with key ""(.*)"" is evaluated with details and default value ""(.*)""")]
         public void Whenastringflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, string defaultValue)
         {
-            this._stringFlagDetails = _client?.GetStringDetailsAsync(flagKey, defaultValue);
+            this._stringFlagDetails = this._client?.GetStringDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved string details value should be ""(.*)"", the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -139,7 +139,7 @@ namespace OpenFeature.E2ETests.Steps
         [When(@"an integer flag with key ""(.*)"" is evaluated with details and default value (.*)")]
         public void Whenanintegerflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, int defaultValue)
         {
-            this._intFlagDetails = _client?.GetIntegerDetailsAsync(flagKey, defaultValue);
+            this._intFlagDetails = this._client?.GetIntegerDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved integer details value should be (.*), the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -154,7 +154,7 @@ namespace OpenFeature.E2ETests.Steps
         [When(@"a float flag with key ""(.*)"" is evaluated with details and default value (.*)")]
         public void Whenafloatflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, double defaultValue)
         {
-            this._doubleFlagDetails = _client?.GetDoubleDetailsAsync(flagKey, defaultValue);
+            this._doubleFlagDetails = this._client?.GetDoubleDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved float details value should be (.*), the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -169,7 +169,7 @@ namespace OpenFeature.E2ETests.Steps
         [When(@"an object flag with key ""(.*)"" is evaluated with details and a null default value")]
         public void Whenanobjectflagwithkeyisevaluatedwithdetailsandanulldefaultvalue(string flagKey)
         {
-            this._objectFlagDetails = _client?.GetObjectDetailsAsync(flagKey, new Value());
+            this._objectFlagDetails = this._client?.GetObjectDetailsAsync(flagKey, new Value());
         }
 
         [Then(@"the resolved object details value should be contain fields ""(.*)"", ""(.*)"", and ""(.*)"", with values ""(.*)"", ""(.*)"" and (.*), respectively")]
@@ -203,7 +203,7 @@ namespace OpenFeature.E2ETests.Steps
         {
             this._contextAwareFlagKey = flagKey;
             this._contextAwareDefaultValue = defaultValue;
-            this._contextAwareValue = _client?.GetStringValueAsync(flagKey, this._contextAwareDefaultValue, this._context).Result;
+            this._contextAwareValue = this._client?.GetStringValueAsync(flagKey, this._contextAwareDefaultValue, this._context).Result;
         }
 
         [Then(@"the resolved string response should be ""(.*)""")]
@@ -215,7 +215,7 @@ namespace OpenFeature.E2ETests.Steps
         [Then(@"the resolved flag value is ""(.*)"" when the context is empty")]
         public void Giventheresolvedflagvalueiswhenthecontextisempty(string expected)
         {
-            string? emptyContextValue = _client?.GetStringValueAsync(this._contextAwareFlagKey!, this._contextAwareDefaultValue!, EvaluationContext.Empty).Result;
+            string? emptyContextValue = this._client?.GetStringValueAsync(this._contextAwareFlagKey!, this._contextAwareDefaultValue!, EvaluationContext.Empty).Result;
             Assert.Equal(expected, emptyContextValue);
         }
 
@@ -224,7 +224,7 @@ namespace OpenFeature.E2ETests.Steps
         {
             this._notFoundFlagKey = flagKey;
             this._notFoundDefaultValue = defaultValue;
-            this._notFoundDetails = _client?.GetStringDetailsAsync(this._notFoundFlagKey, this._notFoundDefaultValue).Result;
+            this._notFoundDetails = this._client?.GetStringDetailsAsync(this._notFoundFlagKey, this._notFoundDefaultValue).Result;
         }
 
         [Then(@"the default string value should be returned")]
@@ -245,7 +245,7 @@ namespace OpenFeature.E2ETests.Steps
         {
             this._typeErrorFlagKey = flagKey;
             this._typeErrorDefaultValue = defaultValue;
-            this._typeErrorDetails = _client?.GetIntegerDetailsAsync(this._typeErrorFlagKey, this._typeErrorDefaultValue).Result;
+            this._typeErrorDetails = this._client?.GetIntegerDetailsAsync(this._typeErrorFlagKey, this._typeErrorDefaultValue).Result;
         }
 
         [Then(@"the default integer value should be returned")]

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -10,6 +10,7 @@ using Xunit;
 namespace OpenFeature.E2ETests.Steps
 {
     [Binding]
+    [Scope(Feature = "Flag evaluation")]
     public class EvaluationStepDefinitions
     {
         private static FeatureClient? _client;

--- a/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
@@ -63,14 +63,94 @@ public class HooksStepDefinitions
     public void ThenTheHooksShouldBeCalledWithEvaluationDetails(string hook, Table table)
     {
         this.CheckHookExecution(hook);
-        // TODO: Check the evaluation details
-        ScenarioContext.StepIsPending();
+        var key = table.Rows[0]["value"];
+        switch (key)
+        {
+            case "boolean-flag":
+                CheckCorrectFlag(table);
+                break;
+            case "missing-flag":
+                CheckMissingFlag(table);
+                break;
+            case "wrong-flag":
+                this.CheckWrongFlag(table);
+                break;
+        }
     }
 
     [Given(@"a string-flag with key ""(.*)"" and a default value ""(.*)""")]
     public async Task GivenAString_FlagWithKeyAndADefaultValue(string key, string defaultValue)
     {
         _ = await this._client!.GetStringValueAsync(key, defaultValue).ConfigureAwait(false);
+    }
+
+    private static void CheckCorrectFlag(Table table)
+    {
+        Assert.Equal("string", table.Rows[0]["data_type"]);
+        Assert.Equal("flag_key", table.Rows[0]["key"]);
+        Assert.Equal("boolean-flag", table.Rows[0]["value"]);
+
+        Assert.Equal("boolean", table.Rows[1]["data_type"]);
+        Assert.Equal("value", table.Rows[1]["key"]);
+        Assert.Equal("true", table.Rows[1]["value"]);
+
+        Assert.Equal("string", table.Rows[2]["data_type"]);
+        Assert.Equal("variant", table.Rows[2]["key"]);
+        Assert.Equal("on", table.Rows[2]["value"]);
+
+        Assert.Equal("string", table.Rows[3]["data_type"]);
+        Assert.Equal("reason", table.Rows[3]["key"]);
+        Assert.Equal("STATIC", table.Rows[3]["value"]);
+
+        Assert.Equal("string", table.Rows[4]["data_type"]);
+        Assert.Equal("error_code", table.Rows[4]["key"]);
+        Assert.Equal("null", table.Rows[4]["value"]);
+    }
+
+    private static void CheckMissingFlag(Table table)
+    {
+        Assert.Equal("string", table.Rows[0]["data_type"]);
+        Assert.Equal("flag_key", table.Rows[0]["key"]);
+        Assert.Equal("missing-flag", table.Rows[0]["value"]);
+
+        Assert.Equal("string", table.Rows[1]["data_type"]);
+        Assert.Equal("value", table.Rows[1]["key"]);
+        Assert.Equal("uh-oh", table.Rows[1]["value"]);
+
+        Assert.Equal("string", table.Rows[2]["data_type"]);
+        Assert.Equal("variant", table.Rows[2]["key"]);
+        Assert.Equal("null", table.Rows[2]["value"]);
+
+        Assert.Equal("string", table.Rows[3]["data_type"]);
+        Assert.Equal("reason", table.Rows[3]["key"]);
+        Assert.Equal("ERROR", table.Rows[3]["value"]);
+
+        Assert.Equal("string", table.Rows[4]["data_type"]);
+        Assert.Equal("error_code", table.Rows[4]["key"]);
+        Assert.Equal("FLAG_NOT_FOUND", table.Rows[4]["value"]);
+    }
+
+    private void CheckWrongFlag(Table table)
+    {
+        Assert.Equal("string", table.Rows[0]["data_type"]);
+        Assert.Equal("flag_key", table.Rows[0]["key"]);
+        Assert.Equal("wrong-flag", table.Rows[0]["value"]);
+
+        Assert.Equal("boolean", table.Rows[1]["data_type"]);
+        Assert.Equal("value", table.Rows[1]["key"]);
+        Assert.Equal("false", table.Rows[1]["value"]);
+
+        Assert.Equal("string", table.Rows[2]["data_type"]);
+        Assert.Equal("variant", table.Rows[2]["key"]);
+        Assert.Equal("null", table.Rows[2]["value"]);
+
+        Assert.Equal("string", table.Rows[3]["data_type"]);
+        Assert.Equal("reason", table.Rows[3]["key"]);
+        Assert.Equal("ERROR", table.Rows[3]["value"]);
+
+        Assert.Equal("string", table.Rows[4]["data_type"]);
+        Assert.Equal("error_code", table.Rows[4]["key"]);
+        Assert.Equal("TYPE_MISMATCH", table.Rows[4]["value"]);
     }
 
     private void CheckHookExecution(string hook)

--- a/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
@@ -1,6 +1,11 @@
+using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenFeature.Model;
 using OpenFeature.Providers.Memory;
 using Reqnroll;
+using Xunit;
 
 namespace OpenFeature.E2ETests.Steps;
 
@@ -8,43 +13,53 @@ namespace OpenFeature.E2ETests.Steps;
 [Scope(Feature = "Evaluation details through hooks")]
 public class HooksStepDefinitions
 {
-    private static FeatureClient? _client;
-    private static readonly IDictionary<string, Flag> E2EFlagConfig = new Dictionary<string, Flag>();
+    private FeatureClient? _client;
+    private TestHook? _testHook;
+    private static readonly IDictionary<string, Flag> E2EFlagConfig = new Dictionary<string, Flag>
+    {
+        {
+            "boolean-flag", new Flag<bool>(
+                variants: new Dictionary<string, bool> { { "on", true }, { "off", false } },
+                defaultVariant: "on"
+            )
+        }
+    };
 
     [Given(@"a stable provider")]
     public void GivenAStableProvider()
     {
         var memProvider = new InMemoryProvider(E2EFlagConfig);
         Api.Instance.SetProviderAsync(memProvider).Wait();
-        _client = Api.Instance.GetClient("TestClient", "1.0.0");
+        this._client = Api.Instance.GetClient("TestClient", "1.0.0");
     }
 
     [Given(@"a client with added hook")]
     public void GivenAClientWithAddedHook()
     {
-        ScenarioContext.StepIsPending();
+        this._testHook = new TestHook();
+        this._client!.AddHooks(this._testHook);
     }
 
     [Given(@"a boolean-flag with key ""(.*)"" and a default value ""(.*)""")]
-    public void GivenABoolean_FlagWithKeyAndADefaultValue(string p0, string @false)
+    public async Task GivenABoolean_FlagWithKeyAndADefaultValue(string key, string defaultValue)
     {
-        ScenarioContext.StepIsPending();
+        _ = await this._client!.GetBooleanValueAsync(key, bool.Parse(defaultValue)).ConfigureAwait(false);
     }
 
     [When(@"the flag was evaluated with details")]
     public void WhenTheFlagWasEvaluatedWithDetails()
     {
-        ScenarioContext.StepIsPending();
+        // This is a no-op, the flag evaluation is done in the Then step
     }
 
     [Then(@"the ""(.*)"" hook should have been executed")]
     public void ThenTheHookShouldHaveBeenExecuted(string before)
     {
-        ScenarioContext.StepIsPending();
+        Assert.Equal(1, this._testHook!.BeforeCount);
     }
 
     [Then(@"the ""(.*)"" hooks should be called with evaluation details")]
-    public void ThenTheHooksShouldBeCalledWithEvaluationDetails(string p0, Table table)
+    public void ThenTheHooksShouldBeCalledWithEvaluationDetails(string hook, Table table)
     {
         ScenarioContext.StepIsPending();
     }
@@ -54,4 +69,45 @@ public class HooksStepDefinitions
     {
         ScenarioContext.StepIsPending();
     }
+}
+
+class TestHook : Hook
+{
+    private int _afterCount;
+    private int _beforeCount;
+    private int _errorCount;
+    private int _finallyCount;
+
+    public override ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details, IReadOnlyDictionary<string, object>? hints = null,
+        CancellationToken cancellationToken = default)
+    {
+        this._afterCount++;
+        return base.AfterAsync(context, details, hints, cancellationToken);
+    }
+
+    public override ValueTask ErrorAsync<T>(HookContext<T> context, Exception error, IReadOnlyDictionary<string, object>? hints = null,
+        CancellationToken cancellationToken = default)
+    {
+        this._errorCount++;
+        return base.ErrorAsync(context, error, hints, cancellationToken);
+    }
+
+    public override ValueTask FinallyAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> evaluationDetails, IReadOnlyDictionary<string, object>? hints = null,
+        CancellationToken cancellationToken = default)
+    {
+        this._finallyCount++;
+        return base.FinallyAsync(context, evaluationDetails, hints, cancellationToken);
+    }
+
+    public override ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object>? hints = null,
+        CancellationToken cancellationToken = default)
+    {
+        this._beforeCount++;
+        return base.BeforeAsync(context, hints, cancellationToken);
+    }
+
+    public int AfterCount => this._afterCount;
+    public int BeforeCount => this._beforeCount;
+    public int ErrorCount => this._errorCount;
+    public int FinallyCount => this._finallyCount;
 }

--- a/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
@@ -1,0 +1,50 @@
+using Reqnroll;
+
+namespace OpenFeature.E2ETests.Steps;
+
+[Binding]
+[Scope(Feature = "Evaluation details through hooks")]
+public class HooksStepDefinitions
+{
+    [Given(@"a stable provider")]
+    public void GivenAStableProvider()
+    {
+        ScenarioContext.StepIsPending();
+    }
+
+    [Given(@"a client with added hook")]
+    public void GivenAClientWithAddedHook()
+    {
+        ScenarioContext.StepIsPending();
+    }
+
+    [Given(@"a boolean-flag with key ""(.*)"" and a default value ""(.*)""")]
+    public void GivenABoolean_FlagWithKeyAndADefaultValue(string p0, string @false)
+    {
+        ScenarioContext.StepIsPending();
+    }
+
+    [When(@"the flag was evaluated with details")]
+    public void WhenTheFlagWasEvaluatedWithDetails()
+    {
+        ScenarioContext.StepIsPending();
+    }
+
+    [Then(@"the ""(.*)"" hook should have been executed")]
+    public void ThenTheHookShouldHaveBeenExecuted(string before)
+    {
+        ScenarioContext.StepIsPending();
+    }
+
+    [Then(@"the ""(.*)"" hooks should be called with evaluation details")]
+    public void ThenTheHooksShouldBeCalledWithEvaluationDetails(string p0, Table table)
+    {
+        ScenarioContext.StepIsPending();
+    }
+
+    [Given(@"a string-flag with key ""(.*)"" and a default value ""(.*)""")]
+    public void GivenAString_FlagWithKeyAndADefaultValue(string p0, string p1)
+    {
+        ScenarioContext.StepIsPending();
+    }
+}

--- a/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using OpenFeature.Providers.Memory;
 using Reqnroll;
 
 namespace OpenFeature.E2ETests.Steps;
@@ -6,10 +8,15 @@ namespace OpenFeature.E2ETests.Steps;
 [Scope(Feature = "Evaluation details through hooks")]
 public class HooksStepDefinitions
 {
+    private static FeatureClient? _client;
+    private static readonly IDictionary<string, Flag> E2EFlagConfig = new Dictionary<string, Flag>();
+
     [Given(@"a stable provider")]
     public void GivenAStableProvider()
     {
-        ScenarioContext.StepIsPending();
+        var memProvider = new InMemoryProvider(E2EFlagConfig);
+        Api.Instance.SetProviderAsync(memProvider).Wait();
+        _client = Api.Instance.GetClient("TestClient", "1.0.0");
     }
 
     [Given(@"a client with added hook")]

--- a/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using OpenFeature.Model;
+using OpenFeature.E2ETests.Utils;
 using Reqnroll;
 using Xunit;
 
@@ -133,49 +129,4 @@ public class HooksStepDefinitions : BaseStepDefinitions
                 break;
         }
     }
-}
-
-class TestHook : Hook
-{
-    private int _afterCount;
-    private int _beforeCount;
-    private int _errorCount;
-    private int _finallyCount;
-
-    public override ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
-        IReadOnlyDictionary<string, object>? hints = null,
-        CancellationToken cancellationToken = default)
-    {
-        this._afterCount++;
-        return base.AfterAsync(context, details, hints, cancellationToken);
-    }
-
-    public override ValueTask ErrorAsync<T>(HookContext<T> context, Exception error,
-        IReadOnlyDictionary<string, object>? hints = null,
-        CancellationToken cancellationToken = default)
-    {
-        this._errorCount++;
-        return base.ErrorAsync(context, error, hints, cancellationToken);
-    }
-
-    public override ValueTask FinallyAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> evaluationDetails,
-        IReadOnlyDictionary<string, object>? hints = null,
-        CancellationToken cancellationToken = default)
-    {
-        this._finallyCount++;
-        return base.FinallyAsync(context, evaluationDetails, hints, cancellationToken);
-    }
-
-    public override ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
-        IReadOnlyDictionary<string, object>? hints = null,
-        CancellationToken cancellationToken = default)
-    {
-        this._beforeCount++;
-        return base.BeforeAsync(context, hints, cancellationToken);
-    }
-
-    public int AfterCount => this._afterCount;
-    public int BeforeCount => this._beforeCount;
-    public int ErrorCount => this._errorCount;
-    public int FinallyCount => this._finallyCount;
 }

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -52,7 +52,7 @@ public class MetadataStepDefinitions
         var items = itemsTable.Rows.ToDictionary(row => row["key"], row => (row["value"], row["metadata_type"]));
         var metadata = this._boolResult.FlagMetadata;
 
-        #if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER
         foreach (var (key, (value, metadataType)) in items)
         {
             var actual = metadataType switch
@@ -66,7 +66,7 @@ public class MetadataStepDefinitions
 
             Assert.Equal(value.ToLowerInvariant(), actual?.ToLowerInvariant());
         }
-        #else
+#else
         foreach (var item in items)
         {
             var key = item.Key;

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using OpenFeature.E2ETests.Utils;
 using OpenFeature.Model;
 using Reqnroll;
 using Xunit;
@@ -26,16 +27,16 @@ public class MetadataStepDefinitions : BaseStepDefinitions
             string? actual = null!;
             switch (metadataType)
             {
-                case "Boolean":
+                case FlagType.Boolean:
                     actual = metadata!.GetBool(key).ToString();
                     break;
-                case "Integer":
+                case FlagType.Integer:
                     actual = metadata!.GetInt(key).ToString();
                     break;
-                case "Float":
+                case FlagType.Float:
                     actual = metadata!.GetDouble(key).ToString();
                     break;
-                case "String":
+                case FlagType.String:
                     actual = metadata!.GetString(key);
                     break;
             }
@@ -72,11 +73,12 @@ public class MetadataStepDefinitions : BaseStepDefinitions
         {
             this.Key = key;
             this.Value = value;
-            this.MetadataType = metadataType;
+
+            this.MetadataType = FlagTypesUtil.ToEnum(metadataType);;
         }
 
         public string Key { get; }
         public string Value { get; }
-        public string MetadataType { get; }
+        public FlagType MetadataType { get; }
     }
 }

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -15,7 +15,7 @@ public class MetadataStepDefinitions
     private FlagEvaluationDetails<bool> _boolResult = null!;
     private FlagEvaluationDetails<Value> _objResult = null!;
 
-    private static FeatureClient? _client;
+    private FeatureClient? _client;
     private static readonly IDictionary<string, Flag> E2EFlagConfig = new Dictionary<string, Flag>
     {
         {
@@ -35,14 +35,14 @@ public class MetadataStepDefinitions
     {
         var memProvider = new InMemoryProvider(E2EFlagConfig);
         Api.Instance.SetProviderAsync(memProvider).Wait();
-        _client = Api.Instance.GetClient("TestClient", "1.0.0");
+        this._client = Api.Instance.GetClient("TestClient", "1.0.0");
     }
 
     [When("the flag was evaluated with details")]
     [Scope(Scenario = "Returns metadata")]
     public async Task WhenTheFlagWasEvaluatedWithDetails()
     {
-        this._boolResult = await _client!.GetBooleanDetailsAsync("metadata-flag", true).ConfigureAwait(false);
+        this._boolResult = await this._client!.GetBooleanDetailsAsync("metadata-flag", true).ConfigureAwait(false);
     }
 
     [Then("the resolved metadata should contain")]
@@ -95,7 +95,7 @@ public class MetadataStepDefinitions
     public void WhenTheFlagWasEvaluatedWithDetails_NoMetadata(string key, string flag_Type, object default_Value)
     {
         var defaultValue = new Value(default_Value);
-        this._objResult = _client!.GetObjectDetailsAsync(key, defaultValue).Result;
+        this._objResult = this._client!.GetObjectDetailsAsync(key, defaultValue).Result;
     }
 
     [Then("the resolved metadata is empty")]

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OpenFeature.Model;
+using OpenFeature.Providers.Memory;
+using Reqnroll;
+
+namespace OpenFeature.E2ETests.Steps;
+
+[Binding]
+[Scope(Feature = "Metadata")]
+public class MetadataStepDefinitions
+{
+    private FlagEvaluationDetails<bool> _boolResult = null!;
+    private FlagEvaluationDetails<Value> _objResult = null!;
+
+    private static FeatureClient? _client;
+    private static IDictionary<string, Flag> E2EFlagConfig = new Dictionary<string, Flag>
+    {
+        {
+            "metadata-flag", new Flag<bool>(
+                variants: new Dictionary<string, bool> { { "on", true }, { "off", false } },
+                defaultVariant: "on"
+            )
+        }
+    };
+
+    [Given("a stable provider")]
+    public void GivenAStableProvider()
+    {
+        var memProvider = new InMemoryProvider(E2EFlagConfig);
+        Api.Instance.SetProviderAsync(memProvider).Wait();
+        _client = Api.Instance.GetClient("TestClient", "1.0.0");
+    }
+
+    [Given("a Boolean-flag with key \"metadata-flag\" and a default value \"true\"")]
+    public void GivenABooleanFlagWithKeyMetadataFlagAndADefaultValueTrue()
+    {
+        // This is a no-op, as the flag is already defined in the provider
+    }
+
+    [When("the flag was evaluated with details")]
+    public async Task WhenTheFlagWasEvaluatedWithDetails()
+    {
+        this._boolResult = await _client!.GetBooleanDetailsAsync("metadata-flag", true).ConfigureAwait(false);
+    }
+
+    [Then("the resolved metadata should contain")]
+    public void ThenTheResolvedMetadataShouldContain(DataTable itemsTable)
+    {
+        ScenarioContext.StepIsPending();
+    }
+
+    [Given(@"a ""(.*)"" with key ""(.*)"" and a default value ""(.*)""")]
+    public async Task GivenAFlagWithKeyAndADefaultValue(string key, string flag_Type, object default_Value)
+    {
+        var defaultValue = new Value(default_Value);
+        this._objResult = await _client!.GetObjectDetailsAsync(key, defaultValue).ConfigureAwait(false);
+    }
+
+    [Then("the resolved metadata is empty")]
+    public void ThenTheResolvedMetadataIsEmpty()
+    {
+        ScenarioContext.StepIsPending();
+    }
+}

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -39,6 +39,7 @@ public class MetadataStepDefinitions
     }
 
     [When("the flag was evaluated with details")]
+    [Scope(Scenario = "Returns metadata")]
     public async Task WhenTheFlagWasEvaluatedWithDetails()
     {
         this._boolResult = await _client!.GetBooleanDetailsAsync("metadata-flag", true).ConfigureAwait(false);
@@ -51,10 +52,16 @@ public class MetadataStepDefinitions
     }
 
     [Given(@"a ""(.*)"" with key ""(.*)"" and a default value ""(.*)""")]
-    public async Task GivenAFlagWithKeyAndADefaultValue(string key, string flag_Type, object default_Value)
+    public void GivenAFlagWithKeyAndADefaultValue(string key, string flag_Type, object default_Value)
+    {
+        // This is a no-op, as the flag is already defined in the provider
+    }
+
+    [When(@"the flag was evaluated with details")]
+    public void WhenTheFlagWasEvaluatedWithDetails_NoMetadata(string key, string flag_Type, object default_Value)
     {
         var defaultValue = new Value(default_Value);
-        this._objResult = await _client!.GetObjectDetailsAsync(key, defaultValue).ConfigureAwait(false);
+        this._objResult = _client!.GetObjectDetailsAsync(key, defaultValue).Result;
     }
 
     [Then("the resolved metadata is empty")]

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -74,7 +74,7 @@ public class MetadataStepDefinitions : BaseStepDefinitions
             this.Key = key;
             this.Value = value;
 
-            this.MetadataType = FlagTypesUtil.ToEnum(metadataType);;
+            this.MetadataType = FlagTypesUtil.ToEnum(metadataType);
         }
 
         public string Key { get; }

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -182,5 +182,17 @@ public class MetadataStepDefinitions
         Boolean
     }
 
-    private record DataTableRows(string Key, string Value, string MetadataType);
+    private class DataTableRows
+    {
+        public DataTableRows(string key, string value, string metadataType)
+        {
+            this.Key = key;
+            this.Value = value;
+            this.MetadataType = metadataType;
+        }
+
+        public string Key { get; }
+        public string Value { get; }
+        public string MetadataType { get; }
+    }
 }

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using OpenFeature.Model;
 using OpenFeature.Providers.Memory;
 using Reqnroll;
+using Xunit;
 
 namespace OpenFeature.E2ETests.Steps;
 
@@ -19,7 +21,11 @@ public class MetadataStepDefinitions
         {
             "metadata-flag", new Flag<bool>(
                 variants: new Dictionary<string, bool> { { "on", true }, { "off", false } },
-                defaultVariant: "on"
+                defaultVariant: "on",
+                flagMetadata: new ImmutableMetadata(new Dictionary<string, object>
+                {
+                    { "string", "1.0.2" }, { "integer", 2 }, { "float", 0.1 }, { "boolean", true }
+                })
             )
         }
     };
@@ -40,9 +46,25 @@ public class MetadataStepDefinitions
     }
 
     [Then("the resolved metadata should contain")]
+    [Scope(Scenario = "Returns metadata")]
     public void ThenTheResolvedMetadataShouldContain(DataTable itemsTable)
     {
-        ScenarioContext.StepIsPending();
+        var items = itemsTable.Rows.ToDictionary(row => row["key"], row => (row["value"], row["metadata_type"]));
+        var metadata = this._boolResult.FlagMetadata;
+
+        foreach (var (key, (value, metadataType)) in items)
+        {
+            var actual = metadataType switch
+            {
+                "Boolean" => metadata!.GetBool(key).ToString(),
+                "Integer" => metadata!.GetInt(key).ToString(),
+                "Float" => metadata!.GetDouble(key).ToString(),
+                "String" => metadata!.GetString(key),
+                _ => null
+            };
+
+            Assert.Equal(value.ToLowerInvariant(), actual?.ToLowerInvariant());
+        }
     }
 
     [Given(@"a Boolean-flag with key ""(.*)"" and a default value ""(.*)""")]
@@ -79,6 +101,6 @@ public class MetadataStepDefinitions
     [Then("the resolved metadata is empty")]
     public void ThenTheResolvedMetadataIsEmpty()
     {
-        ScenarioContext.StepIsPending();
+        // ScenarioContext.StepIsPending();
     }
 }

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -32,12 +32,6 @@ public class MetadataStepDefinitions
         _client = Api.Instance.GetClient("TestClient", "1.0.0");
     }
 
-    [Given("a Boolean-flag with key \"metadata-flag\" and a default value \"true\"")]
-    public void GivenABooleanFlagWithKeyMetadataFlagAndADefaultValueTrue()
-    {
-        // This is a no-op, as the flag is already defined in the provider
-    }
-
     [When("the flag was evaluated with details")]
     [Scope(Scenario = "Returns metadata")]
     public async Task WhenTheFlagWasEvaluatedWithDetails()
@@ -53,6 +47,24 @@ public class MetadataStepDefinitions
 
     [Given(@"a Boolean-flag with key ""(.*)"" and a default value ""(.*)""")]
     public void GivenABoolean_FlagWithKeyAndADefaultValue(string key, string defaultType)
+    {
+        // This is a no-op, as the flag is already defined in the provider
+    }
+
+    [Given(@"a Float-flag with key ""(.*)"" and a default value ""(.*)""")]
+    public void GivenAFloat_FlagWithKeyAndADefaultValue(string key, string defaultType)
+    {
+        // This is a no-op, as the flag is already defined in the provider
+    }
+
+    [Given(@"a Integer-flag with key ""(.*)"" and a default value ""(.*)""")]
+    public void GivenAnInteger_FlagWithKeyAndADefaultValue(string key, string defaultType)
+    {
+        // This is a no-op, as the flag is already defined in the provider
+    }
+
+    [Given(@"a String-flag with key ""(.*)"" and a default value ""(.*)""")]
+    public void GivenAString_FlagWithKeyAndADefaultValue(string key, string defaultType)
     {
         // This is a no-op, as the flag is already defined in the provider
     }

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -16,7 +16,7 @@ public class MetadataStepDefinitions
     private FlagEvaluationDetails<Value> _objResult = null!;
 
     private static FeatureClient? _client;
-    private static IDictionary<string, Flag> E2EFlagConfig = new Dictionary<string, Flag>
+    private static readonly IDictionary<string, Flag> E2EFlagConfig = new Dictionary<string, Flag>
     {
         {
             "metadata-flag", new Flag<bool>(

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -101,6 +101,6 @@ public class MetadataStepDefinitions
     [Then("the resolved metadata is empty")]
     public void ThenTheResolvedMetadataIsEmpty()
     {
-        // ScenarioContext.StepIsPending();
+        Assert.Null(this._objResult.FlagMetadata?.Count);
     }
 }

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using OpenFeature.Model;
-using OpenFeature.Providers.Memory;
 using Reqnroll;
 using Xunit;
 
@@ -11,67 +8,14 @@ namespace OpenFeature.E2ETests.Steps;
 
 [Binding]
 [Scope(Feature = "Metadata")]
-public class MetadataStepDefinitions
+public class MetadataStepDefinitions : BaseStepDefinitions
 {
-    private object _objResult = null!;
-
-    private string _flagKey = null!;
-    private string _defaultValue = null!;
-    private FlagType? _flagType;
-
-    private FeatureClient? _client;
-    private static readonly IDictionary<string, Flag> E2EFlagConfig = new Dictionary<string, Flag>
-    {
-        {
-            "metadata-flag", new Flag<bool>(
-                variants: new Dictionary<string, bool> { { "on", true }, { "off", false } },
-                defaultVariant: "on",
-                flagMetadata: new ImmutableMetadata(new Dictionary<string, object>
-                {
-                    { "string", "1.0.2" }, { "integer", 2 }, { "float", 0.1 }, { "boolean", true }
-                })
-            )
-        },
-        {
-            "boolean-flag", new Flag<bool>(
-                variants: new Dictionary<string, bool> { { "on", true }, { "off", false } },
-                defaultVariant: "on"
-            )
-        },
-        {
-            "integer-flag", new Flag<int>(
-                variants: new Dictionary<string, int> { { "23", 23 }, { "42", 42 } },
-                defaultVariant: "23"
-            )
-        },
-        {
-            "float-flag", new Flag<double>(
-                variants: new Dictionary<string, double> { { "2.3", 2.3 }, { "4.2", 4.2 } },
-                defaultVariant: "2.3"
-            )
-        },
-        {
-            "string-flag", new Flag<string>(
-                variants: new Dictionary<string, string> { { "value", "value" }, { "value2", "value2" } },
-                defaultVariant: "value"
-            )
-        }
-    };
-
-    [Given("a stable provider")]
-    public void GivenAStableProvider()
-    {
-        var memProvider = new InMemoryProvider(E2EFlagConfig);
-        Api.Instance.SetProviderAsync(memProvider).Wait();
-        this._client = Api.Instance.GetClient("TestClient", "1.0.0");
-    }
-
     [Then("the resolved metadata should contain")]
     [Scope(Scenario = "Returns metadata")]
     public void ThenTheResolvedMetadataShouldContain(DataTable itemsTable)
     {
         var items = itemsTable.Rows.Select(row => new DataTableRows(row["key"], row["value"], row["metadata_type"])).ToList();
-        var metadata = (this._objResult as FlagEvaluationDetails<bool>)?.FlagMetadata;
+        var metadata = (this.Result as FlagEvaluationDetails<bool>)?.FlagMetadata;
 
         foreach (var item in items)
         {
@@ -100,86 +44,26 @@ public class MetadataStepDefinitions
         }
     }
 
-    [Given(@"a Boolean-flag with key ""(.*)"" and a default value ""(.*)""")]
-    public void GivenABoolean_FlagWithKeyAndADefaultValue(string key, string defaultType)
-    {
-        this._flagKey = key;
-        this._defaultValue = defaultType;
-        this._flagType = FlagType.Boolean;
-    }
-
-    [Given(@"a Float-flag with key ""(.*)"" and a default value ""(.*)""")]
-    public void GivenAFloat_FlagWithKeyAndADefaultValue(string key, string defaultType)
-    {
-        this._flagKey = key;
-        this._defaultValue = defaultType;
-        this._flagType = FlagType.Float;
-    }
-
-    [Given(@"a Integer-flag with key ""(.*)"" and a default value ""(.*)""")]
-    public void GivenAnInteger_FlagWithKeyAndADefaultValue(string key, string defaultType)
-    {
-        this._flagKey = key;
-        this._defaultValue = defaultType;
-        this._flagType = FlagType.Integer;
-    }
-
-    [Given(@"a String-flag with key ""(.*)"" and a default value ""(.*)""")]
-    public void GivenAString_FlagWithKeyAndADefaultValue(string key, string defaultType)
-    {
-        this._flagKey = key;
-        this._defaultValue = defaultType;
-        this._flagType = FlagType.String;
-    }
-
-    [When(@"the flag was evaluated with details")]
-    public async Task WhenTheFlagWasEvaluatedWithDetails()
-    {
-        switch (this._flagType)
-        {
-            case FlagType.Boolean:
-                this._objResult = await this._client!.GetBooleanDetailsAsync(this._flagKey, bool.Parse(this._defaultValue)).ConfigureAwait(false);
-                break;
-            case FlagType.Float:
-                this._objResult = await this._client!.GetDoubleDetailsAsync(this._flagKey, double.Parse(this._defaultValue)).ConfigureAwait(false);
-                break;
-            case FlagType.Integer:
-                this._objResult = await this._client!.GetIntegerDetailsAsync(this._flagKey, int.Parse(this._defaultValue)).ConfigureAwait(false);
-                break;
-            case FlagType.String:
-                this._objResult = await this._client!.GetStringDetailsAsync(this._flagKey, this._defaultValue).ConfigureAwait(false);
-                break;
-        }
-    }
-
     [Then("the resolved metadata is empty")]
     public void ThenTheResolvedMetadataIsEmpty()
     {
-        switch (this._flagType)
+        switch (this.FlagTypeEnum)
         {
             case FlagType.Boolean:
-                Assert.Null((this._objResult as FlagEvaluationDetails<bool>)?.FlagMetadata?.Count);
+                Assert.Null((this.Result as FlagEvaluationDetails<bool>)?.FlagMetadata?.Count);
                 break;
             case FlagType.Float:
-                Assert.Null((this._objResult as FlagEvaluationDetails<double>)?.FlagMetadata?.Count);
+                Assert.Null((this.Result as FlagEvaluationDetails<double>)?.FlagMetadata?.Count);
                 break;
             case FlagType.Integer:
-                Assert.Null((this._objResult as FlagEvaluationDetails<int>)?.FlagMetadata?.Count);
+                Assert.Null((this.Result as FlagEvaluationDetails<int>)?.FlagMetadata?.Count);
                 break;
             case FlagType.String:
-                Assert.Null((this._objResult as FlagEvaluationDetails<string>)?.FlagMetadata?.Count);
+                Assert.Null((this.Result as FlagEvaluationDetails<string>)?.FlagMetadata?.Count);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
         }
-    }
-
-    private enum FlagType
-    {
-        Integer,
-        Float,
-        String,
-        Boolean
     }
 
     private class DataTableRows

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -51,8 +51,8 @@ public class MetadataStepDefinitions
         ScenarioContext.StepIsPending();
     }
 
-    [Given(@"a ""(.*)"" with key ""(.*)"" and a default value ""(.*)""")]
-    public void GivenAFlagWithKeyAndADefaultValue(string key, string flag_Type, object default_Value)
+    [Given(@"a Boolean-flag with key ""(.*)"" and a default value ""(.*)""")]
+    public void GivenABoolean_FlagWithKeyAndADefaultValue(string key, string defaultType)
     {
         // This is a no-op, as the flag is already defined in the provider
     }

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -52,6 +52,7 @@ public class MetadataStepDefinitions
         var items = itemsTable.Rows.ToDictionary(row => row["key"], row => (row["value"], row["metadata_type"]));
         var metadata = this._boolResult.FlagMetadata;
 
+        #if NET8_0_OR_GREATER
         foreach (var (key, (value, metadataType)) in items)
         {
             var actual = metadataType switch
@@ -65,6 +66,33 @@ public class MetadataStepDefinitions
 
             Assert.Equal(value.ToLowerInvariant(), actual?.ToLowerInvariant());
         }
+        #else
+        foreach (var item in items)
+        {
+            var key = item.Key;
+            var value = item.Value.value;
+            var metadataType = item.Value.metadata_type;
+
+            string actual = null;
+            switch (metadataType)
+            {
+                case "Boolean":
+                    actual = metadata!.GetBool(key).ToString();
+                    break;
+                case "Integer":
+                    actual = metadata!.GetInt(key).ToString();
+                    break;
+                case "Float":
+                    actual = metadata!.GetDouble(key).ToString();
+                    break;
+                case "String":
+                    actual = metadata!.GetString(key);
+                    break;
+            }
+
+            Assert.Equal(value.ToLowerInvariant(), actual?.ToLowerInvariant());
+        }
+#endif
     }
 
     [Given(@"a Boolean-flag with key ""(.*)"" and a default value ""(.*)""")]

--- a/test/OpenFeature.E2ETests/Utils/FlagTypesUtil.cs
+++ b/test/OpenFeature.E2ETests/Utils/FlagTypesUtil.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace OpenFeature.E2ETests.Utils;
+
+public class FlagTypesUtil
+{
+    internal static FlagType ToEnum(string flagType)
+    {
+        return flagType.ToLowerInvariant() switch
+        {
+            "boolean" => FlagType.Boolean,
+            "float" => FlagType.Float,
+            "integer" => FlagType.Integer,
+            "string" => FlagType.String,
+            _ => throw new ArgumentException("Invalid flag type")
+        };
+    }
+}
+
+internal enum FlagType
+{
+    Integer,
+    Float,
+    String,
+    Boolean
+}

--- a/test/OpenFeature.E2ETests/Utils/FlagTypesUtil.cs
+++ b/test/OpenFeature.E2ETests/Utils/FlagTypesUtil.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenFeature.E2ETests.Utils;
 
-public class FlagTypesUtil
+[ExcludeFromCodeCoverage]
+internal static class FlagTypesUtil
 {
     internal static FlagType ToEnum(string flagType)
     {

--- a/test/OpenFeature.E2ETests/Utils/TestHook.cs
+++ b/test/OpenFeature.E2ETests/Utils/TestHook.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenFeature.Model;
+
+namespace OpenFeature.E2ETests.Utils;
+
+internal class TestHook : Hook
+{
+    private int _afterCount;
+    private int _beforeCount;
+    private int _errorCount;
+    private int _finallyCount;
+
+    public override ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+        IReadOnlyDictionary<string, object>? hints = null,
+        CancellationToken cancellationToken = default)
+    {
+        this._afterCount++;
+        return base.AfterAsync(context, details, hints, cancellationToken);
+    }
+
+    public override ValueTask ErrorAsync<T>(HookContext<T> context, Exception error,
+        IReadOnlyDictionary<string, object>? hints = null,
+        CancellationToken cancellationToken = default)
+    {
+        this._errorCount++;
+        return base.ErrorAsync(context, error, hints, cancellationToken);
+    }
+
+    public override ValueTask FinallyAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> evaluationDetails,
+        IReadOnlyDictionary<string, object>? hints = null,
+        CancellationToken cancellationToken = default)
+    {
+        this._finallyCount++;
+        return base.FinallyAsync(context, evaluationDetails, hints, cancellationToken);
+    }
+
+    public override ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context,
+        IReadOnlyDictionary<string, object>? hints = null,
+        CancellationToken cancellationToken = default)
+    {
+        this._beforeCount++;
+        return base.BeforeAsync(context, hints, cancellationToken);
+    }
+
+    public int AfterCount => this._afterCount;
+    public int BeforeCount => this._beforeCount;
+    public int ErrorCount => this._errorCount;
+    public int FinallyCount => this._finallyCount;
+}

--- a/test/OpenFeature.E2ETests/Utils/TestHook.cs
+++ b/test/OpenFeature.E2ETests/Utils/TestHook.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenFeature.Model;
 
 namespace OpenFeature.E2ETests.Utils;
 
+[ExcludeFromCodeCoverage]
 internal class TestHook : Hook
 {
     private int _afterCount;

--- a/test/OpenFeature.E2ETests/xunit.runner.json
+++ b/test/OpenFeature.E2ETests/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "parallelizeAssembly": false,
-  "parallelizeTestCollections": false
-}

--- a/test/OpenFeature.E2ETests/xunit.runner.json
+++ b/test/OpenFeature.E2ETests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false
+}

--- a/test/OpenFeature.Tests/ImmutableMetadataTest.cs
+++ b/test/OpenFeature.Tests/ImmutableMetadataTest.cs
@@ -241,4 +241,35 @@ public class ImmutableMetadataTest
         // Assert
         Assert.Null(result);
     }
+
+    [Fact]
+    public void Count_ShouldReturnCountOfMetadata()
+    {
+        // Arrange
+        var metadata = new Dictionary<string, object>
+        {
+            {
+                "wrongKey", new object()
+            },
+            {
+                "stringKey", "11"
+            },
+            {
+                "doubleKey", 1.2
+            },
+            {
+                "intKey", 1
+            },
+            {
+                "boolKey", true
+            }
+        };
+        var flagMetadata = new ImmutableMetadata(metadata);
+
+        // Act
+        var result = flagMetadata.Count;
+
+        // Assert
+        Assert.Equal(metadata.Count, result);
+    }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request includes several changes aimed at improving the test setup, enhancing the metadata handling, and refactoring the code for better readability and maintainability.

### Test Setup Improvements:
* [`.github/workflows/e2e.yml`](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL34-R34): Updated the `Initialize Tests` step to copy all Gherkin feature files instead of just `evaluation.feature`.
* [`test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj`](diffhunk://#diff-ab2ad60395e1cc72b327459243ed8c5711efbd88531a3b3b813fb6c4c6019886R32-R38): Added a new `GherkinRestore` target to copy Gherkin files before the build.

### Metadata Handling Enhancements:
* [`src/OpenFeature/Model/ImmutableMetadata.cs`](diffhunk://#diff-bf57504fda39c85dbda91d3829514b8b014f1293e5b5e53e490f4f4b74f0905bR88-R89): Added an internal `Count` property to the `ImmutableMetadata` class.
* [`src/OpenFeature/Providers/Memory/Flag.cs`](diffhunk://#diff-ba67e6465022bead062d71042b8f5d67b47ec11e06c4eefe2b9f473ac34fc8d1R22-R36): Introduced an optional `flagMetadata` parameter to the `Flag` class and updated the `Evaluate` method to include `flagMetadata` in the `ResolutionDetails`. [[1]](diffhunk://#diff-ba67e6465022bead062d71042b8f5d67b47ec11e06c4eefe2b9f473ac34fc8d1R22-R36) [[2]](diffhunk://#diff-ba67e6465022bead062d71042b8f5d67b47ec11e06c4eefe2b9f473ac34fc8d1L47-R51) [[3]](diffhunk://#diff-ba67e6465022bead062d71042b8f5d67b47ec11e06c4eefe2b9f473ac34fc8d1L68-R73)

### Code Refactoring:
* [`build/Common.tests.props`](diffhunk://#diff-5472aa271be4e6ac0c793a3c1b9226e4f9a7907a6baa99ea16542fb89107ae86L8-R12): Simplified the condition for identifying test projects by removing the dot before 'Tests'.
* [`test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs`](diffhunk://#diff-9ca6e89533e4b3f7a2deaf8de6d6f07a80b7eab2afa6f2e8bfc682b9ca60dc6bL10-R103): Refactored the class to use private fields with underscore prefixes for better readability and consistency. [[1]](diffhunk://#diff-9ca6e89533e4b3f7a2deaf8de6d6f07a80b7eab2afa6f2e8bfc682b9ca60dc6bL10-R103) [[2]](diffhunk://#diff-9ca6e89533e4b3f7a2deaf8de6d6f07a80b7eab2afa6f2e8bfc682b9ca60dc6bL115-R118) [[3]](diffhunk://#diff-9ca6e89533e4b3f7a2deaf8de6d6f07a80b7eab2afa6f2e8bfc682b9ca60dc6bL130-R133) [[4]](diffhunk://#diff-9ca6e89533e4b3f7a2deaf8de6d6f07a80b7eab2afa6f2e8bfc682b9ca60dc6bL145-R148) [[5]](diffhunk://#diff-9ca6e89533e4b3f7a2deaf8de6d6f07a80b7eab2afa6f2e8bfc682b9ca60dc6bL160-R163) [[6]](diffhunk://#diff-9ca6e89533e4b3f7a2deaf8de6d6f07a80b7eab2afa6f2e8bfc682b9ca60dc6bL175-R178) [[7]](diffhunk://#diff-9ca6e89533e4b3f7a2deaf8de6d6f07a80b7eab2afa6f2e8bfc682b9ca60dc6bL190-R194)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #376 

### Follow-up Tasks
- Cleanup `test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs` file. It should apply the same patterns as discussed in the PR. See #391 