### PR TITLE
fix: Remove virtual GetEventChannel from FeatureProvider

### DIFF
--- a/src/OpenFeature/EventExecutor.cs
+++ b/src/OpenFeature/EventExecutor.cs
@@ -147,7 +147,7 @@ namespace OpenFeature
             if (oldProvider != null && !this.IsProviderBound(oldProvider))
             {
                 this._activeSubscriptions.Remove(oldProvider);
-                oldProvider.GetEventChannel()?.Writer.Complete();
+                oldProvider.GetEventChannel().Writer.Complete();
             }
         }
 

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -140,7 +140,7 @@ namespace OpenFeature
         /// Returns the event channel of the provider.
         /// </summary>
         /// <returns>The event channel of the provider</returns>
-        public virtual Channel<object> GetEventChannel() => this.EventChannel;
+        public Channel<object> GetEventChannel() => this.EventChannel;
 
         /// <summary>
         /// Track a user action or application state, usually representing a business objective or outcome. The implementation of this method is optional.

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using NSubstitute;
 using OpenFeature.Constant;
@@ -47,12 +48,14 @@ namespace OpenFeature.Tests
         {
             var providerA = Substitute.For<FeatureProvider>();
             providerA.Status.Returns(ProviderStatus.NotReady);
+            providerA.GetEventChannel().Returns(Channel.CreateBounded<object>(1));
 
             await Api.Instance.SetProviderAsync(providerA);
             await providerA.Received(1).InitializeAsync(Api.Instance.GetContext());
 
             var providerB = Substitute.For<FeatureProvider>();
             providerB.Status.Returns(ProviderStatus.NotReady);
+            providerB.GetEventChannel().Returns(Channel.CreateBounded<object>(1));
 
             await Api.Instance.SetProviderAsync(providerB);
             await providerB.Received(1).InitializeAsync(Api.Instance.GetContext());
@@ -60,12 +63,14 @@ namespace OpenFeature.Tests
 
             var providerC = Substitute.For<FeatureProvider>();
             providerC.Status.Returns(ProviderStatus.NotReady);
+            providerC.GetEventChannel().Returns(Channel.CreateBounded<object>(1));
 
             await Api.Instance.SetProviderAsync("named", providerC);
             await providerC.Received(1).InitializeAsync(Api.Instance.GetContext());
 
             var providerD = Substitute.For<FeatureProvider>();
             providerD.Status.Returns(ProviderStatus.NotReady);
+            providerD.GetEventChannel().Returns(Channel.CreateBounded<object>(1));
 
             await Api.Instance.SetProviderAsync("named", providerD);
             await providerD.Received(1).InitializeAsync(Api.Instance.GetContext());

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using NSubstitute;
 using OpenFeature.Constant;
@@ -48,14 +47,12 @@ namespace OpenFeature.Tests
         {
             var providerA = Substitute.For<FeatureProvider>();
             providerA.Status.Returns(ProviderStatus.NotReady);
-            providerA.GetEventChannel().Returns(Channel.CreateBounded<object>(1));
 
             await Api.Instance.SetProviderAsync(providerA);
             await providerA.Received(1).InitializeAsync(Api.Instance.GetContext());
 
             var providerB = Substitute.For<FeatureProvider>();
             providerB.Status.Returns(ProviderStatus.NotReady);
-            providerB.GetEventChannel().Returns(Channel.CreateBounded<object>(1));
 
             await Api.Instance.SetProviderAsync(providerB);
             await providerB.Received(1).InitializeAsync(Api.Instance.GetContext());
@@ -63,14 +60,12 @@ namespace OpenFeature.Tests
 
             var providerC = Substitute.For<FeatureProvider>();
             providerC.Status.Returns(ProviderStatus.NotReady);
-            providerC.GetEventChannel().Returns(Channel.CreateBounded<object>(1));
 
             await Api.Instance.SetProviderAsync("named", providerC);
             await providerC.Received(1).InitializeAsync(Api.Instance.GetContext());
 
             var providerD = Substitute.For<FeatureProvider>();
             providerD.Status.Returns(ProviderStatus.NotReady);
-            providerD.GetEventChannel().Returns(Channel.CreateBounded<object>(1));
 
             await Api.Instance.SetProviderAsync("named", providerD);
             await providerD.Received(1).InitializeAsync(Api.Instance.GetContext());


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request includes changes to the `EventChannel` handling in the `OpenFeature` library to improve code consistency and reliability.

Improvements to `EventChannel` handling:

* [`src/OpenFeature/EventExecutor.cs`](diffhunk://#diff-f563baadcf750bb66efaea76d7ec4783320e6efdc45c468effb531c948a2292cL150-R150): Removed unnecessary null-conditional operator when completing the `Writer` of the event channel.
* [`src/OpenFeature/FeatureProvider.cs`](diffhunk://#diff-96ebc8fc507d0a19d55b9a5cb57b72a0e8058e09f31ee7d0b39e99b00c5029d8L143-R143): Made the `GetEventChannel` method non-virtual to ensure consistent behavior across different implementations.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Related to #358 
