### PR TITLE
feat: update FeatureLifecycleStateOptions.StopState default to Stopped

### DIFF
--- a/src/OpenFeature.Hosting/FeatureLifecycleStateOptions.cs
+++ b/src/OpenFeature.Hosting/FeatureLifecycleStateOptions.cs
@@ -14,5 +14,5 @@ public class FeatureLifecycleStateOptions
     /// <summary>
     /// Gets or sets the state during the feature shutdown lifecycle.
     /// </summary>
-    public FeatureStopState StopState { get; set; } = FeatureStopState.Stopping;
+    public FeatureStopState StopState { get; set; } = FeatureStopState.Stopped;
 }

--- a/src/OpenFeature.Hosting/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.Hosting/OpenFeatureBuilderExtensions.cs
@@ -19,15 +19,7 @@ public static partial class OpenFeatureBuilderExtensions
     /// <returns>The <see cref="OpenFeatureBuilder"/> instance.</returns>
     public static OpenFeatureBuilder AddHostedFeatureLifecycle(this OpenFeatureBuilder builder, Action<FeatureLifecycleStateOptions>? configureOptions = null)
     {
-        if (configureOptions == null)
-        {
-            builder.Services.Configure<FeatureLifecycleStateOptions>(cfg =>
-            {
-                cfg.StartState = FeatureStartState.Starting;
-                cfg.StopState = FeatureStopState.Stopping;
-            });
-        }
-        else
+        if (configureOptions is not null)
         {
             builder.Services.Configure(configureOptions);
         }


### PR DESCRIPTION
## This PR

- feat: update FeatureLifecycleStateOptions.StopState default to Stopped
- refactor: remove the default options setup since it's same as default value, no need to configure

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #410 

