### PR TITLE
ci: Add provenance attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,19 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-    - '**.md'
+      - "**.md"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-    - '**.md'
+      - "**.md"
 
 jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -50,6 +50,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
 
     runs-on: ubuntu-latest
 
@@ -91,3 +93,8 @@ jobs:
         with:
           name: nupkgs
           path: src/**/*.nupkg
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          subject-path: "src/**/*.nupkg"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,13 @@ jobs:
         run: dotnet pack -c Release --no-restore
 
       - name: Publish to Nuget
-        run: dotnet nuget push "src/**/*.nupkg" --api-key "${{ secrets.NUGET_TOKEN }}" --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push artifacts/packages/*.nupkg --api-key "${{ secrets.NUGET_TOKEN }}" --source https://api.nuget.org/v3/index.json
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: packages
+          path: artifacts/packages
 
   sbom:
     runs-on: ubuntu-latest
@@ -87,5 +93,20 @@ jobs:
       - name: Attach SBOM to artifact
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run:
-          gh release upload ${{ needs.release-please.outputs.release_tag_name }} bom.json
+        run: gh release upload ${{ needs.release-please.outputs.release_tag_name }} bom.json
+
+  attestation:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+    needs: release-please
+    continue-on-error: true
+    if: ${{ needs.release-please.outputs.release_created }}
+
+    steps:
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          subject-path: "artifacts/packages/*.nupkg"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: release-please
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
     if: ${{ needs.release-please.outputs.release_created }}
 
     steps:
@@ -56,11 +60,10 @@ jobs:
       - name: Publish to Nuget
         run: dotnet nuget push "src/**/*.nupkg" --api-key "${{ secrets.NUGET_TOKEN }}" --source https://api.nuget.org/v3/index.json
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
-          name: packages
-          path: artifacts/packages
+          subject-path: "src/**/*.nupkg"
 
   sbom:
     runs-on: ubuntu-latest
@@ -94,19 +97,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: gh release upload ${{ needs.release-please.outputs.release_tag_name }} bom.json
-
-  attestation:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      attestations: write
-    needs: release-please
-    continue-on-error: true
-    if: ${{ needs.release-please.outputs.release_created }}
-
-    steps:
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
-        with:
-          subject-path: "artifacts/packages/*.nupkg"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         run: dotnet pack -c Release --no-restore
 
       - name: Publish to Nuget
-        run: dotnet nuget push artifacts/packages/*.nupkg --api-key "${{ secrets.NUGET_TOKEN }}" --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "src/**/*.nupkg" --api-key "${{ secrets.NUGET_TOKEN }}" --source https://api.nuget.org/v3/index.json
 
       - name: Upload artifacts
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request includes several updates to the GitHub Actions workflows to enhance CI/CD capabilities and improve artifact security. The key changes involve adding new permissions and steps to the workflows for both continuous integration and release processes.

Enhancements to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL7-R11): Adjusted the indentation for `paths-ignore` in both `push` and `pull_request` triggers.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR53-R54): Added `id-token` and `attestations` permissions under `jobs`.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR96-R100): Introduced a step to generate artifact attestation using `actions/attest-build-provenance`.

Enhancements to release workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R33-R36): Added `id-token`, `contents`, and `attestations` permissions under `jobs`.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R63-R67): Added a step to generate artifact attestation using `actions/attest-build-provenance`.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L90-R99): Simplified the `run` command for attaching SBOM to the artifact.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #409

### Notes
The attestation for the PR can be checked here: https://github.com/open-feature/dotnet-sdk/attestations/6175280