### PR TITLE
ci: Remove artifact attestation step from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,3 @@ jobs:
         with:
           name: nupkgs
           path: src/**/*.nupkg
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
-        with:
-          subject-path: "src/**/*.nupkg"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request includes a small change to the `.github/workflows/ci.yml` file. The change removes the step that generates artifact attestation using the `actions/attest-build-provenance` action.

* Removed the `Generate artifact attestation` step from the CI workflow in `.github/workflows/ci.yml`.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #423 

### Notes
<!-- any additional notes for this PR -->

This only removes execution from the PRs and forks. It will not be removed from the main publishing action.