### PR TITLE
build: Change dependency assets

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
+    <MicrosoftExtensionsVersion>9.0.0</MicrosoftExtensionsVersion>
   </PropertyGroup>
 
   <ItemGroup Label="src">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup Label="src">
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.3" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.3" />
-    <PackageVersion Include="System.Threading.Channels" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="System.Collections.Immutable" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="System.Threading.Channels" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request includes updates to the `Directory.Packages.props` file to centralize and manage package versions more effectively, particularly for Microsoft Extensions packages.

Key changes include:

* Added a new property `MicrosoftExtensionsVersion` with a default value of `8.0.0` and a conditional value of `9.0.0` for `net9.0` target framework.
* Updated `PackageVersion` elements to use the new `MicrosoftExtensionsVersion` property instead of hardcoded version numbers.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #424 

### Notes
<!-- any additional notes for this PR -->

I tried to follow the https://github.com/App-vNext/Polly approach to determining the dependencies we should bring in. It seems that all the major libraries depend on the lowest version of the target framework.
For example, if the target is net 8.0, the package will be 8.0.0. If the target is net 9.0, the package will be 9.0.0.
Thanks, @kylejuliandev, for the discussion and the examples in Slack.
