### PR TITLE
chore: restrict publish to environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       release_tag_name: ${{ steps.release.outputs.tag_name }}
 
   release:
+    environment: publish
     runs-on: ubuntu-latest
     needs: release-please
     permissions:


### PR DESCRIPTION
Restricts usage of the `NUGET_TOKEN` to only the `publish` environment.