### PR TITLE
chore(workflows): Add permissions for contents and pull-requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   build-test-report:
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/dco-merge-group.yml
+++ b/.github/workflows/dco-merge-group.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   DCO:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     if: ${{ github.actor != 'renovate[bot]' }}
     steps:
       - run: echo "dummy DCO workflow (it won't run any check actually) to trigger by merge_group in order to enable merge queue"

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   check-format:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Check out code

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,4 +1,4 @@
-name: 'Lint PR'
+name: "Lint PR"
 
 on:
   pull_request_target:
@@ -11,6 +11,9 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
         env:


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request includes updates to several GitHub Actions workflows to add permissions for reading contents and writing pull requests. Additionally, there is a minor change to the `lint-pr.yml` workflow file to standardize the quotation marks used in the `name` field.

Workflow permissions updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR15-R17): Added permissions for reading contents and writing pull requests to the `build` job.
* [`.github/workflows/code-coverage.yml`](diffhunk://#diff-49708f979e226a1e7bd7a68d71b2e91aae8114dd3e9254d9830cd3b4d62d4303R15-R17): Added permissions for reading contents and writing pull requests to the `build-test-report` job.
* [`.github/workflows/dco-merge-group.yml`](diffhunk://#diff-cbf8f01aa06b4aa3d0729c5bce44e4f919c801b55f19a781b15f62aa10e68e90R10-R12): Added permissions for reading contents and writing pull requests to the `DCO` job.
* [`.github/workflows/dotnet-format.yml`](diffhunk://#diff-ca8c2611c79b991c0fbe04fec3c97c14dc83419f5efb1e8a7a96dd51e7df3e2aR12-R14): Added permissions for reading contents and writing pull requests to the `check-format` job.
* [`.github/workflows/e2e.yml`](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eR16-R18): Added permissions for reading contents and writing pull requests to the `e2e-tests` job.
* [`.github/workflows/lint-pr.yml`](diffhunk://#diff-70c3a017bfdb629fd50281fe5f7ad22e29c0ddac36e7065e9dc6d4f0924104f4R14-R16): Added permissions for reading contents and writing pull requests to the `main` job.

Standardization:

* [`.github/workflows/lint-pr.yml`](diffhunk://#diff-70c3a017bfdb629fd50281fe5f7ad22e29c0ddac36e7065e9dc6d4f0924104f4L1-R1): Changed single quotes to double quotes in the `name` field.