### PR TITLE
refactor: InMemoryProvider throwing when types mismatched

### DIFF
--- a/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
+++ b/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
-using OpenFeature.Error;
 using OpenFeature.Model;
 
 namespace OpenFeature.Providers.Memory
@@ -112,7 +111,7 @@ namespace OpenFeature.Providers.Memory
                 return value.Evaluate(flagKey, defaultValue, context);
             }
 
-            throw new TypeMismatchException($"flag {flagKey} is not of type {typeof(T)}");
+            return new ResolutionDetails<T>(flagKey, defaultValue, ErrorType.TypeMismatch, Reason.Error);
         }
     }
 }

--- a/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
+++ b/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
@@ -186,9 +186,14 @@ namespace OpenFeature.Tests.Providers.Memory
         }
 
         [Fact]
-        public async Task MismatchedFlag_ShouldThrow()
+        public async Task MismatchedFlag_ShouldReturnTypeMismatchError()
         {
-            await Assert.ThrowsAsync<TypeMismatchException>(() => this.commonProvider.ResolveStringValueAsync("boolean-flag", "nope", EvaluationContext.Empty));
+            // Act
+            var result = await this.commonProvider.ResolveStringValueAsync("boolean-flag", "nope", EvaluationContext.Empty);
+
+            // Assert
+            Assert.Equal(Reason.Error, result.Reason);
+            Assert.Equal(ErrorType.TypeMismatch, result.ErrorType);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Update InMemoryProvider to return an ErrorType with a default value instead of throwing exceptions
- Add unit test to cover the new behavior

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #441

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

