### PR TITLE
ci: update renovate configuration to fix immortal PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>open-feature/community-tooling"
-  ]
+  ],
+  "dependencyDashboardApproval": true,
+  "recreateWhen": "never"
 }


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the Renovate configuration to enhance dependency management workflows. The most notable changes include enabling dependency dashboard approval and specifying that dependencies should not be recreated automatically.

Changes to Renovate configuration:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L5-R7): Enabled the `dependencyDashboardApproval` setting to require manual approval for dependency updates.
* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L5-R7): Added the `recreateWhen` setting with a value of `"never"` to prevent automatic recreation of dependency updates.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #448

### Notes
<!-- any additional notes for this PR -->
I followed Renovate's general recommendation. I also changed to require dashboard manual approval because we don't want the PRs to pop up for dotnet extensions (they should be closed since we need to publish the lowest version compatible; see #426). So we should look into the dashboard issue #92 to create the PRs for dependencies.

