### PR TITLE
feat: Add Extension Method for adding global Hook via DependencyInjection

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ builder.Services.AddOpenFeature(featureBuilder => {
     featureBuilder
         .AddHostedFeatureLifecycle() // From Hosting package
         .AddContext((contextBuilder, serviceProvider) => { /* Custom context configuration */ })
+        .AddHook<LoggingHook>()
         .AddInMemoryProvider();
 });
 ```
@@ -446,6 +447,7 @@ builder.Services.AddOpenFeature(featureBuilder => {
     featureBuilder
         .AddHostedFeatureLifecycle()
         .AddContext((contextBuilder, serviceProvider) => { /* Custom context configuration */ })
+        .AddHook((serviceProvider) => new LoggingHook( /* Custom configuration */ ))
         .AddInMemoryProvider("name1")
         .AddInMemoryProvider("name2")
         .AddPolicyName(options => {

--- a/src/OpenFeature.DependencyInjection/Internal/FeatureLifecycleManager.cs
+++ b/src/OpenFeature.DependencyInjection/Internal/FeatureLifecycleManager.cs
@@ -34,6 +34,15 @@ internal sealed partial class FeatureLifecycleManager : IFeatureLifecycleManager
             var featureProvider = _serviceProvider.GetRequiredKeyedService<FeatureProvider>(name);
             await _featureApi.SetProviderAsync(name, featureProvider).ConfigureAwait(false);
         }
+
+        var hooks = new List<Hook>();
+        foreach (var hookName in options.HookNames)
+        {
+            var hook = _serviceProvider.GetRequiredKeyedService<Hook>(hookName);
+            hooks.Add(hook);
+        }
+
+        _featureApi.AddHooks(hooks);
     }
 
     /// <inheritdoc />

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -262,4 +262,26 @@ public static partial class OpenFeatureBuilderExtensions
     /// <returns>The configured <see cref="OpenFeatureBuilder"/> instance.</returns>
     public static OpenFeatureBuilder AddPolicyName(this OpenFeatureBuilder builder, Action<PolicyNameOptions> configureOptions)
         => AddPolicyName<PolicyNameOptions>(builder, configureOptions);
+
+    /// <summary>
+    /// Adds a feature hook to the service collection using a factory method. Hooks added here are not domain-bound.
+    /// </summary>
+    /// <typeparam name="THook">The type of<see cref="Hook"/> to be added.</typeparam>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance.</param>
+    /// <param name="implementationFactory"></param>
+    /// <returns></returns>
+    public static OpenFeatureBuilder AddHook<THook>(this OpenFeatureBuilder builder, Func<IServiceProvider, THook> implementationFactory)
+        where THook : Hook
+    {
+        var hookName = typeof(THook).Name;
+
+        builder.Services.PostConfigure<OpenFeatureOptions>(options => options.AddHookName(hookName));
+
+        builder.Services.AddKeyedSingleton<Hook>(hookName, (serviceProvider, key) =>
+        {
+            return implementationFactory(serviceProvider);
+        });
+
+        return builder;
+    }
 }

--- a/src/OpenFeature.DependencyInjection/OpenFeatureOptions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureOptions.cs
@@ -46,4 +46,16 @@ public class OpenFeatureOptions
             }
         }
     }
+
+    private readonly HashSet<string> _hookNames = [];
+
+    internal IReadOnlyCollection<string> HookNames => _hookNames;
+
+    internal void AddHookName(string name)
+    {
+        lock (_hookNames)
+        {
+            _hookNames.Add(name);
+        }
+    }
 }

--- a/test/OpenFeature.DependencyInjection.Tests/NoOpHook.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/NoOpHook.cs
@@ -1,0 +1,26 @@
+using OpenFeature.Model;
+
+namespace OpenFeature.DependencyInjection.Tests;
+
+internal class NoOpHook : Hook
+{
+    public override ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
+    {
+        return base.BeforeAsync(context, hints, cancellationToken);
+    }
+
+    public override ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details, IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
+    {
+        return base.AfterAsync(context, details, hints, cancellationToken);
+    }
+
+    public override ValueTask FinallyAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> evaluationDetails, IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
+    {
+        return base.FinallyAsync(context, evaluationDetails, hints, cancellationToken);
+    }
+
+    public override ValueTask ErrorAsync<T>(HookContext<T> context, Exception error, IReadOnlyDictionary<string, object>? hints = null, CancellationToken cancellationToken = default)
+    {
+        return base.ErrorAsync(context, error, hints, cancellationToken);
+    }
+}

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -241,4 +241,34 @@ public partial class OpenFeatureBuilderExtensionsTests
         Assert.NotNull(provider);
         Assert.IsType<NoOpFeatureProvider>(provider);
     }
+
+    [Fact]
+    public void AddHook_AddsHookAsKeyedService()
+    {
+        // Arrange
+        _systemUnderTest.AddHook(sp => new NoOpHook());
+
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Act
+        var hook = serviceProvider.GetKeyedService<Hook>("NoOpHook");
+
+        // Assert
+        Assert.NotNull(hook);
+    }
+
+    [Fact]
+    public void AddHook_AddsNameNameToOpenFeatureOptions()
+    {
+        // Arrange
+        _systemUnderTest.AddHook(sp => new NoOpHook());
+
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Act
+        var options = serviceProvider.GetRequiredService<IOptions<OpenFeatureOptions>>();
+
+        // Assert
+        Assert.Contains(options.Value.HookNames, t => t == "NoOpHook");
+    }
 }

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -258,7 +258,7 @@ public partial class OpenFeatureBuilderExtensionsTests
     }
 
     [Fact]
-    public void AddHook_AddsNameNameToOpenFeatureOptions()
+    public void AddHook_AddsHookNameToOpenFeatureOptions()
     {
         // Arrange
         _systemUnderTest.AddHook(sp => new NoOpHook());
@@ -270,5 +270,35 @@ public partial class OpenFeatureBuilderExtensionsTests
 
         // Assert
         Assert.Contains(options.Value.HookNames, t => t == "NoOpHook");
+    }
+
+    [Fact]
+    public void AddHook_WithSpecifiedNameToOpenFeatureOptions()
+    {
+        // Arrange
+        _systemUnderTest.AddHook<NoOpHook>("my-custom-name");
+
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Act
+        var hook = serviceProvider.GetKeyedService<Hook>("my-custom-name");
+
+        // Assert
+        Assert.NotNull(hook);
+    }
+
+    [Fact]
+    public void AddHook_WithSpecifiedNameAndImplementationFactory_AsKeyedService()
+    {
+        // Arrange
+        _systemUnderTest.AddHook("my-custom-name", (serviceProvider) => new NoOpHook());
+
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Act
+        var hook = serviceProvider.GetKeyedService<Hook>("my-custom-name");
+
+        // Assert
+        Assert.NotNull(hook);
     }
 }

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -246,7 +246,7 @@ public partial class OpenFeatureBuilderExtensionsTests
     public void AddHook_AddsHookAsKeyedService()
     {
         // Arrange
-        _systemUnderTest.AddHook(sp => new NoOpHook());
+        _systemUnderTest.AddHook<NoOpHook>();
 
         var serviceProvider = _services.BuildServiceProvider();
 

--- a/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
+++ b/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- This adds a new OpenFeatureBuilder extension method to add global or not domain-bound hooks to the OpenFeature Api.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #456

### Notes
<!-- any additional notes for this PR -->

We inject any provided Hooks as Singletons in the DI container. We use keyed singletons and use the class name as the key. Maybe we'd want to use a different name to avoid conflicts?

I've done some manual testing with a sample weatherforecast ASP.NET Core web application

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

