### PR TITLE
build: Tidy build tests

### DIFF
--- a/build/Common.tests.props
+++ b/build/Common.tests.props
@@ -18,4 +18,9 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
   </ItemGroup>
+
+  <!-- Stops warning to use the .ConfigureAwait method. Tests should configure the await context as opposed to library code -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
+++ b/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
@@ -9,7 +9,7 @@ using OpenFeature.Model;
 namespace OpenFeature.Benchmark;
 
 [MemoryDiagnoser]
-[SimpleJob(RuntimeMoniker.Net60, baseline: true)]
+[SimpleJob(RuntimeMoniker.Net80, baseline: true)]
 [JsonExporterAttribute.Full]
 [JsonExporterAttribute.FullCompressed]
 public class OpenFeatureClientBenchmarks

--- a/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
+++ b/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
@@ -1,6 +1,5 @@
 
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using AutoFixture;
 using BenchmarkDotNet.Attributes;
@@ -13,7 +12,6 @@ namespace OpenFeature.Benchmark;
 [SimpleJob(RuntimeMoniker.Net60, baseline: true)]
 [JsonExporterAttribute.Full]
 [JsonExporterAttribute.FullCompressed]
-[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 public class OpenFeatureClientBenchmarks
 {
     private readonly string _domain;

--- a/test/OpenFeature.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using AutoFixture;
 using NSubstitute;
@@ -9,7 +8,6 @@ using Xunit;
 
 namespace OpenFeature.Tests;
 
-[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 public class FeatureProviderTests : ClearOpenFeatureInstanceFixture
 {
     [Fact]

--- a/test/OpenFeature.Tests/Hooks/LoggingHookTests.cs
+++ b/test/OpenFeature.Tests/Hooks/LoggingHookTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
@@ -9,8 +8,6 @@ using OpenFeature.Model;
 using Xunit;
 
 namespace OpenFeature.Tests.Hooks;
-
-[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 
 public class LoggingHookTests
 {

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +17,6 @@ using Xunit;
 
 namespace OpenFeature.Tests;
 
-[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
 {
     [Fact]

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture;
@@ -12,7 +11,6 @@ using Xunit;
 
 namespace OpenFeature.Tests;
 
-[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
 {
     [Fact]

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,7 +15,6 @@ using Xunit;
 
 namespace OpenFeature.Tests;
 
-[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
 {
     [Fact]

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
@@ -10,7 +9,6 @@ using Xunit;
 
 namespace OpenFeature.Tests;
 
-[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
 {
     [Fact]

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using NSubstitute;
 using OpenFeature.Constant;
@@ -11,7 +10,6 @@ using Xunit;
 
 namespace OpenFeature.Tests;
 
-[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 public class ProviderRepositoryTests
 {
     [Fact]

--- a/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
+++ b/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Error;
@@ -9,7 +8,6 @@ using Xunit;
 
 namespace OpenFeature.Tests.Providers.Memory;
 
-[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 public class InMemoryProviderTests
 {
     private FeatureProvider commonProvider;

--- a/test/OpenFeature.Tests/TestUtilsTest.cs
+++ b/test/OpenFeature.Tests/TestUtilsTest.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace OpenFeature.Tests;
 
-[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 public class TestUtilsTest
 {
     [Fact]


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request primarily addresses warnings related to the use of `ConfigureAwait` in test code. It suppresses these warnings globally for test projects and removes redundant `[SuppressMessage]` attributes from individual test classes.

### Suppression of `ConfigureAwait` warnings:
* [`build/Common.tests.props`](diffhunk://#diff-5472aa271be4e6ac0c793a3c1b9226e4f9a7907a6baa99ea16542fb89107ae86R21-R25): Added a global suppression for the `CA2007` warning, which advises the use of `.ConfigureAwait`. This is appropriate for test code where configuring the await context is unnecessary.

### Cleanup of redundant `[SuppressMessage]` attributes:
* Removed `[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]` attributes from the following test classes:
  - `OpenFeatureClientBenchmarks` in `test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs`
  - `FeatureProviderTests` in `test/OpenFeature.Tests/FeatureProviderTests.cs`
  - `LoggingHookTests` in `test/OpenFeature.Tests/Hooks/LoggingHookTests.cs`
  - `OpenFeatureClientTests` in `test/OpenFeature.Tests/OpenFeatureClientTests.cs`
  - `OpenFeatureEventTest` in `test/OpenFeature.Tests/OpenFeatureEventTests.cs`
  - `OpenFeatureHookTests` in `test/OpenFeature.Tests/OpenFeatureHookTests.cs`
  - `OpenFeatureTests` in `test/OpenFeature.Tests/OpenFeatureTests.cs`
  - `ProviderRepositoryTests` in `test/OpenFeature.Tests/ProviderRepositoryTests.cs`
  - `InMemoryProviderTests` in `test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs`
  - `TestUtilsTest` in `test/OpenFeature.Tests/TestUtilsTest.cs`

### Removal of unused imports:
* Removed `System.Diagnostics.CodeAnalysis` using directives from files where `[SuppressMessage]` attributes were deleted. Examples include:
  - `test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs`
  - `test/OpenFeature.Tests/FeatureProviderTests.cs`
  - `test/OpenFeature.Tests/Hooks/LoggingHookTests.cs`

These changes simplify the codebase by centralizing the suppression of `ConfigureAwait` warnings and removing unnecessary annotations and imports.