### PR TITLE
feat: add AddHandler extension method to Dependency Injection package

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,9 +433,18 @@ For a basic configuration, you can use the InMemoryProvider. This provider is si
 builder.Services.AddOpenFeature(featureBuilder => {
     featureBuilder
         .AddHostedFeatureLifecycle() // From Hosting package
+        .AddInMemoryProvider();
+});
+```
+
+You can add EvaluationContext, hooks, and handlers at a global/API level as needed.
+
+```csharp
+builder.Services.AddOpenFeature(featureBuilder => {
+    featureBuilder
         .AddContext((contextBuilder, serviceProvider) => { /* Custom context configuration */ })
         .AddHook<LoggingHook>()
-        .AddInMemoryProvider();
+        .AddHandler(ProviderEventTypes.ProviderReady, (eventDetails) => { /* Handle event */ });
 });
 ```
 

--- a/src/OpenFeature.DependencyInjection/Internal/EventHandlerDelegateWrapper.cs
+++ b/src/OpenFeature.DependencyInjection/Internal/EventHandlerDelegateWrapper.cs
@@ -1,0 +1,17 @@
+using OpenFeature.Constant;
+using OpenFeature.Model;
+
+namespace OpenFeature.DependencyInjection.Internal;
+
+internal record EventHandlerDelegateWrapper
+{
+    public ProviderEventTypes ProviderEventType { get; }
+
+    public EventHandlerDelegate EventHandlerDelegate { get; }
+
+    public EventHandlerDelegateWrapper(ProviderEventTypes providerEventTypes, EventHandlerDelegate eventHandlerDelegate)
+    {
+        ProviderEventType = providerEventTypes;
+        EventHandlerDelegate = eventHandlerDelegate;
+    }
+}

--- a/src/OpenFeature.DependencyInjection/Internal/EventHandlerDelegateWrapper.cs
+++ b/src/OpenFeature.DependencyInjection/Internal/EventHandlerDelegateWrapper.cs
@@ -3,15 +3,6 @@ using OpenFeature.Model;
 
 namespace OpenFeature.DependencyInjection.Internal;
 
-internal record EventHandlerDelegateWrapper
-{
-    public ProviderEventTypes ProviderEventType { get; }
-
-    public EventHandlerDelegate EventHandlerDelegate { get; }
-
-    public EventHandlerDelegateWrapper(ProviderEventTypes providerEventTypes, EventHandlerDelegate eventHandlerDelegate)
-    {
-        ProviderEventType = providerEventTypes;
-        EventHandlerDelegate = eventHandlerDelegate;
-    }
-}
+internal record EventHandlerDelegateWrapper(
+    ProviderEventTypes ProviderEventType,
+    EventHandlerDelegate EventHandlerDelegate);

--- a/src/OpenFeature.DependencyInjection/Internal/FeatureLifecycleManager.cs
+++ b/src/OpenFeature.DependencyInjection/Internal/FeatureLifecycleManager.cs
@@ -43,6 +43,12 @@ internal sealed partial class FeatureLifecycleManager : IFeatureLifecycleManager
         }
 
         _featureApi.AddHooks(hooks);
+
+        foreach (var handlerName in options.HandlerNames)
+        {
+            var handler = _serviceProvider.GetRequiredKeyedService<EventHandlerDelegateWrapper>(handlerName);
+            _featureApi.AddHandler(handler.ProviderEventType, handler.EventHandlerDelegate);
+        }
     }
 
     /// <inheritdoc />

--- a/src/OpenFeature.DependencyInjection/Internal/FeatureLifecycleManager.cs
+++ b/src/OpenFeature.DependencyInjection/Internal/FeatureLifecycleManager.cs
@@ -44,13 +44,10 @@ internal sealed partial class FeatureLifecycleManager : IFeatureLifecycleManager
 
         _featureApi.AddHooks(hooks);
 
-        foreach (var handlerName in options.HandlerNames)
+        var handlers = _serviceProvider.GetServices<EventHandlerDelegateWrapper>();
+        foreach (var handler in handlers)
         {
-            var handlers = _serviceProvider.GetKeyedServices<EventHandlerDelegateWrapper>(handlerName);
-            foreach (var handler in handlers)
-            {
-                _featureApi.AddHandler(handler.ProviderEventType, handler.EventHandlerDelegate);
-            }
+            _featureApi.AddHandler(handler.ProviderEventType, handler.EventHandlerDelegate);
         }
     }
 

--- a/src/OpenFeature.DependencyInjection/Internal/FeatureLifecycleManager.cs
+++ b/src/OpenFeature.DependencyInjection/Internal/FeatureLifecycleManager.cs
@@ -46,8 +46,11 @@ internal sealed partial class FeatureLifecycleManager : IFeatureLifecycleManager
 
         foreach (var handlerName in options.HandlerNames)
         {
-            var handler = _serviceProvider.GetRequiredKeyedService<EventHandlerDelegateWrapper>(handlerName);
-            _featureApi.AddHandler(handler.ProviderEventType, handler.EventHandlerDelegate);
+            var handlers = _serviceProvider.GetKeyedServices<EventHandlerDelegateWrapper>(handlerName);
+            foreach (var handler in handlers)
+            {
+                _featureApi.AddHandler(handler.ProviderEventType, handler.EventHandlerDelegate);
+            }
         }
     }
 

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -315,7 +315,7 @@ public static partial class OpenFeatureBuilderExtensions
     /// <returns></returns>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, ProviderEventTypes type, EventHandlerDelegate eventHandlerDelegate)
     {
-        return AddHandler(builder, string.Empty, type, sp => eventHandlerDelegate);
+        return AddHandler(builder, typeof(EventHandlerDelegate).Name, type, sp => eventHandlerDelegate);
     }
 
     /// <summary>
@@ -340,7 +340,7 @@ public static partial class OpenFeatureBuilderExtensions
     /// <returns></returns>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, ProviderEventTypes type, Func<IServiceProvider, EventHandlerDelegate> implementationFactory)
     {
-        return AddHandler(builder, string.Empty, type, implementationFactory);
+        return AddHandler(builder, typeof(EventHandlerDelegate).Name, type, implementationFactory);
     }
 
     /// <summary>
@@ -353,14 +353,14 @@ public static partial class OpenFeatureBuilderExtensions
     /// <returns></returns>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, string handlerName, ProviderEventTypes type, Func<IServiceProvider, EventHandlerDelegate> implementationFactory)
     {
-        if (string.IsNullOrEmpty(handlerName))
-            handlerName = Guid.NewGuid().ToString();
+        if (string.IsNullOrWhiteSpace(handlerName))
+            handlerName = string.Empty;
 
         var key = string.Join(":", handlerName, type.ToString());
 
         builder.Services.PostConfigure<OpenFeatureOptions>(options => options.AddHandlerName(key));
 
-        builder.Services.TryAddKeyedSingleton(key, (serviceProvider, _) =>
+        builder.Services.AddKeyedSingleton(key, (serviceProvider, _) =>
         {
             var handler = implementationFactory(serviceProvider);
             return new EventHandlerDelegateWrapper(type, handler);

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using OpenFeature.Constant;
 using OpenFeature.DependencyInjection;
+using OpenFeature.DependencyInjection.Internal;
 using OpenFeature.Model;
 
 namespace OpenFeature;
@@ -302,5 +304,74 @@ public static partial class OpenFeatureBuilderExtensions
         }
 
         return builder;
+    }
+
+    /// <summary>
+    /// Add a <see cref="EventHandlerDelegate"/> to allow you to react to state changes in the provider or underlying flag management system, such as flag definition changes, provider readiness, or error conditions
+    /// </summary>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance.</param>
+    /// <param name="type">The type <see cref="ProviderEventTypes"/> to handle.</param>
+    /// <param name="eventHandlerDelegate">The handler which reacts to <see cref="ProviderEventTypes"/>.</param>
+    /// <returns></returns>
+    public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, ProviderEventTypes type, EventHandlerDelegate eventHandlerDelegate)
+    {
+        return AddHandler(builder, GenerateRandomName(), type, sp => eventHandlerDelegate);
+    }
+
+    /// <summary>
+    /// Add a <see cref="EventHandlerDelegate"/> to allow you to react to state changes in the provider or underlying flag management system, such as flag definition changes, provider readiness, or error conditions
+    /// </summary>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance.</param>
+    /// <param name="handlerName">The name of the <see cref="EventHandlerDelegate"/>.</param>
+    /// <param name="type">The type <see cref="ProviderEventTypes"/> to handle.</param>
+    /// <param name="eventHandlerDelegate">The handler which reacts to <see cref="ProviderEventTypes"/>.</param>
+    /// <returns></returns>
+    public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, string handlerName, ProviderEventTypes type, EventHandlerDelegate eventHandlerDelegate)
+    {
+        return AddHandler(builder, handlerName, type, sp => eventHandlerDelegate);
+    }
+
+    /// <summary>
+    /// Add a <see cref="EventHandlerDelegate"/> to allow you to react to state changes in the provider or underlying flag management system, such as flag definition changes, provider readiness, or error conditions
+    /// </summary>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance.</param>
+    /// <param name="type">The type <see cref="ProviderEventTypes"/> to handle.</param>
+    /// <param name="implementationFactory">The handler factory for creating a handler which reacts to <see cref="ProviderEventTypes"/>.</param>
+    /// <returns></returns>
+    public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, ProviderEventTypes type, Func<IServiceProvider, EventHandlerDelegate> implementationFactory)
+    {
+        return AddHandler(builder, GenerateRandomName(), type, implementationFactory);
+    }
+
+    /// <summary>
+    /// Add a <see cref="EventHandlerDelegate"/> to allow you to react to state changes in the provider or underlying flag management system, such as flag definition changes, provider readiness, or error conditions
+    /// </summary>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance.</param>
+    /// <param name="handlerName">The name of the <see cref="EventHandlerDelegate"/>.</param>
+    /// <param name="type">The type <see cref="ProviderEventTypes"/> to handle.</param>
+    /// <param name="implementationFactory">The handler factory for creating a handler which reacts to <see cref="ProviderEventTypes"/>.</param>
+    /// <returns></returns>
+    public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, string handlerName, ProviderEventTypes type, Func<IServiceProvider, EventHandlerDelegate> implementationFactory)
+    {
+        var key = string.Join(":", handlerName, type.ToString());
+
+        builder.Services.PostConfigure<OpenFeatureOptions>(options => options.AddHandlerName(key));
+
+        builder.Services.TryAddKeyedSingleton(key, (serviceProvider, _) =>
+        {
+            var handler = implementationFactory(serviceProvider);
+            return new EventHandlerDelegateWrapper(type, handler);
+        });
+
+        return builder;
+    }
+
+    static readonly Random _random = new();
+    private static string GenerateRandomName()
+    {
+        const string characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        const int length = 4;
+
+        return new string([.. Enumerable.Range(0, length).Select(_ => characters[_random.Next(characters.Length)])]);
     }
 }

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -315,21 +315,7 @@ public static partial class OpenFeatureBuilderExtensions
     /// <returns>The <see cref="OpenFeatureBuilder"/> instance.</returns>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, ProviderEventTypes type, EventHandlerDelegate eventHandlerDelegate)
     {
-        return AddHandler(builder, typeof(EventHandlerDelegate).Name, type, sp => eventHandlerDelegate);
-    }
-
-    /// <summary>
-    /// Add a <see cref="EventHandlerDelegate"/> to allow you to react to state changes in the provider or underlying flag management system, such as flag definition changes, provider readiness, or error conditions
-    /// </summary>
-    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance.</param>
-    /// <param name="handlerName">The name of the <see cref="EventHandlerDelegate"/>.</param>
-    /// <param name="type">The type <see cref="ProviderEventTypes"/> to handle.</param>
-    /// <param name="eventHandlerDelegate">The handler which reacts to <see cref="ProviderEventTypes"/>.</param>
-    /// <returns>The <see cref="OpenFeatureBuilder"/> instance.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="handlerName"/> is null or empty</exception>
-    public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, string handlerName, ProviderEventTypes type, EventHandlerDelegate eventHandlerDelegate)
-    {
-        return AddHandler(builder, handlerName, type, sp => eventHandlerDelegate);
+        return AddHandler(builder, type, _ => eventHandlerDelegate);
     }
 
     /// <summary>
@@ -341,27 +327,7 @@ public static partial class OpenFeatureBuilderExtensions
     /// <returns>The <see cref="OpenFeatureBuilder"/> instance.</returns>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, ProviderEventTypes type, Func<IServiceProvider, EventHandlerDelegate> implementationFactory)
     {
-        return AddHandler(builder, typeof(EventHandlerDelegate).Name, type, implementationFactory);
-    }
-
-    /// <summary>
-    /// Add a <see cref="EventHandlerDelegate"/> to allow you to react to state changes in the provider or underlying flag management system, such as flag definition changes, provider readiness, or error conditions
-    /// </summary>
-    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance.</param>
-    /// <param name="handlerName">The name of the <see cref="EventHandlerDelegate"/>.</param>
-    /// <param name="type">The type <see cref="ProviderEventTypes"/> to handle.</param>
-    /// <param name="implementationFactory">The handler factory for creating a handler which reacts to <see cref="ProviderEventTypes"/>.</param>
-    /// <returns>The <see cref="OpenFeatureBuilder"/> instance.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="handlerName"/> is null or empty</exception>
-    public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, string handlerName, ProviderEventTypes type, Func<IServiceProvider, EventHandlerDelegate> implementationFactory)
-    {
-        Guard.ThrowIfNullOrWhiteSpace(handlerName);
-
-        var key = string.Join(":", handlerName, type.ToString());
-
-        builder.Services.PostConfigure<OpenFeatureOptions>(options => options.AddHandlerName(key));
-
-        builder.Services.AddKeyedSingleton(key, (serviceProvider, _) =>
+        builder.Services.AddSingleton((serviceProvider) =>
         {
             var handler = implementationFactory(serviceProvider);
             return new EventHandlerDelegateWrapper(type, handler);

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -315,7 +315,7 @@ public static partial class OpenFeatureBuilderExtensions
     /// <returns></returns>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, ProviderEventTypes type, EventHandlerDelegate eventHandlerDelegate)
     {
-        return AddHandler(builder, GenerateRandomName(), type, sp => eventHandlerDelegate);
+        return AddHandler(builder, string.Empty, type, sp => eventHandlerDelegate);
     }
 
     /// <summary>
@@ -340,7 +340,7 @@ public static partial class OpenFeatureBuilderExtensions
     /// <returns></returns>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, ProviderEventTypes type, Func<IServiceProvider, EventHandlerDelegate> implementationFactory)
     {
-        return AddHandler(builder, GenerateRandomName(), type, implementationFactory);
+        return AddHandler(builder, string.Empty, type, implementationFactory);
     }
 
     /// <summary>
@@ -353,6 +353,9 @@ public static partial class OpenFeatureBuilderExtensions
     /// <returns></returns>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, string handlerName, ProviderEventTypes type, Func<IServiceProvider, EventHandlerDelegate> implementationFactory)
     {
+        if (string.IsNullOrEmpty(handlerName))
+            handlerName = Guid.NewGuid().ToString();
+
         var key = string.Join(":", handlerName, type.ToString());
 
         builder.Services.PostConfigure<OpenFeatureOptions>(options => options.AddHandlerName(key));
@@ -364,14 +367,5 @@ public static partial class OpenFeatureBuilderExtensions
         });
 
         return builder;
-    }
-
-    static readonly Random _random = new();
-    private static string GenerateRandomName()
-    {
-        const string characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-        const int length = 4;
-
-        return new string([.. Enumerable.Range(0, length).Select(_ => characters[_random.Next(characters.Length)])]);
     }
 }

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -355,8 +355,7 @@ public static partial class OpenFeatureBuilderExtensions
     /// <exception cref="ArgumentException">Thrown when <paramref name="handlerName"/> is null or empty</exception>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, string handlerName, ProviderEventTypes type, Func<IServiceProvider, EventHandlerDelegate> implementationFactory)
     {
-        if (string.IsNullOrWhiteSpace(handlerName))
-            throw new ArgumentException("Null or empty Handler name", nameof(handlerName));
+        Guard.ThrowIfNullOrWhiteSpace(handlerName);
 
         var key = string.Join(":", handlerName, type.ToString());
 

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -312,7 +312,7 @@ public static partial class OpenFeatureBuilderExtensions
     /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance.</param>
     /// <param name="type">The type <see cref="ProviderEventTypes"/> to handle.</param>
     /// <param name="eventHandlerDelegate">The handler which reacts to <see cref="ProviderEventTypes"/>.</param>
-    /// <returns></returns>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance.</returns>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, ProviderEventTypes type, EventHandlerDelegate eventHandlerDelegate)
     {
         return AddHandler(builder, typeof(EventHandlerDelegate).Name, type, sp => eventHandlerDelegate);
@@ -325,7 +325,8 @@ public static partial class OpenFeatureBuilderExtensions
     /// <param name="handlerName">The name of the <see cref="EventHandlerDelegate"/>.</param>
     /// <param name="type">The type <see cref="ProviderEventTypes"/> to handle.</param>
     /// <param name="eventHandlerDelegate">The handler which reacts to <see cref="ProviderEventTypes"/>.</param>
-    /// <returns></returns>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="handlerName"/> is null or empty</exception>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, string handlerName, ProviderEventTypes type, EventHandlerDelegate eventHandlerDelegate)
     {
         return AddHandler(builder, handlerName, type, sp => eventHandlerDelegate);
@@ -337,7 +338,7 @@ public static partial class OpenFeatureBuilderExtensions
     /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance.</param>
     /// <param name="type">The type <see cref="ProviderEventTypes"/> to handle.</param>
     /// <param name="implementationFactory">The handler factory for creating a handler which reacts to <see cref="ProviderEventTypes"/>.</param>
-    /// <returns></returns>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance.</returns>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, ProviderEventTypes type, Func<IServiceProvider, EventHandlerDelegate> implementationFactory)
     {
         return AddHandler(builder, typeof(EventHandlerDelegate).Name, type, implementationFactory);
@@ -350,11 +351,12 @@ public static partial class OpenFeatureBuilderExtensions
     /// <param name="handlerName">The name of the <see cref="EventHandlerDelegate"/>.</param>
     /// <param name="type">The type <see cref="ProviderEventTypes"/> to handle.</param>
     /// <param name="implementationFactory">The handler factory for creating a handler which reacts to <see cref="ProviderEventTypes"/>.</param>
-    /// <returns></returns>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="handlerName"/> is null or empty</exception>
     public static OpenFeatureBuilder AddHandler(this OpenFeatureBuilder builder, string handlerName, ProviderEventTypes type, Func<IServiceProvider, EventHandlerDelegate> implementationFactory)
     {
         if (string.IsNullOrWhiteSpace(handlerName))
-            handlerName = string.Empty;
+            throw new ArgumentException("Null or empty Handler name", nameof(handlerName));
 
         var key = string.Join(":", handlerName, type.ToString());
 

--- a/src/OpenFeature.DependencyInjection/OpenFeatureOptions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureOptions.cs
@@ -58,4 +58,16 @@ public class OpenFeatureOptions
             _hookNames.Add(name);
         }
     }
+
+    private readonly HashSet<string> _handlerNames = [];
+
+    internal IReadOnlyCollection<string> HandlerNames => _handlerNames;
+
+    internal void AddHandlerName(string name)
+    {
+        lock (_handlerNames)
+        {
+            _handlerNames.Add(name);
+        }
+    }
 }

--- a/src/OpenFeature.DependencyInjection/OpenFeatureOptions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureOptions.cs
@@ -58,16 +58,4 @@ public class OpenFeatureOptions
             _hookNames.Add(name);
         }
     }
-
-    private readonly HashSet<string> _handlerNames = [];
-
-    internal IReadOnlyCollection<string> HandlerNames => _handlerNames;
-
-    internal void AddHandlerName(string name)
-    {
-        lock (_handlerNames)
-        {
-            _handlerNames.Add(name);
-        }
-    }
 }

--- a/test/OpenFeature.DependencyInjection.Tests/FeatureLifecycleManagerTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/FeatureLifecycleManagerTests.cs
@@ -93,11 +93,7 @@ public class FeatureLifecycleManagerTests
         var handler = new EventHandlerDelegateWrapper(ProviderEventTypes.ProviderReady, eventHandlerDelegate);
 
         _serviceCollection.AddSingleton<FeatureProvider>(featureProvider)
-            .AddKeyedSingleton("test:ProviderReady", (_, key) => handler)
-            .Configure<OpenFeatureOptions>(options =>
-            {
-                options.AddHandlerName("test:ProviderReady");
-            });
+            .AddSingleton(_ => handler);
 
         var serviceProvider = _serviceCollection.BuildServiceProvider();
         var sut = new FeatureLifecycleManager(Api.Instance, serviceProvider, NullLogger<FeatureLifecycleManager>.Instance);
@@ -117,12 +113,8 @@ public class FeatureLifecycleManagerTests
         var handler2 = new EventHandlerDelegateWrapper(ProviderEventTypes.ProviderReady, eventHandlerDelegate2);
 
         _serviceCollection.AddSingleton<FeatureProvider>(featureProvider)
-            .AddKeyedSingleton("test:ProviderReady", (_, key) => handler1)
-            .AddKeyedSingleton("test:ProviderReady", (_, key) => handler2)
-            .Configure<OpenFeatureOptions>(options =>
-            {
-                options.AddHandlerName("test:ProviderReady");
-            });
+            .AddSingleton(_ => handler1)
+            .AddSingleton(_ => handler2);
 
         var serviceProvider = _serviceCollection.BuildServiceProvider();
         var sut = new FeatureLifecycleManager(Api.Instance, serviceProvider, NullLogger<FeatureLifecycleManager>.Instance);

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -353,6 +353,24 @@ public partial class OpenFeatureBuilderExtensionsTests
         Assert.Equal(ServiceLifetime.Singleton, handler.Lifetime);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void AddHandler_WithEmptyName_AddsEventHandlerDelegateWrapperAsKeyedService(string? handlerName)
+    {
+        // Arrange
+        EventHandlerDelegate eventHandler = (eventDetails) => { };
+        _systemUnderTest.AddHandler(handlerName!, Constant.ProviderEventTypes.ProviderReady, eventHandler);
+
+        // Act
+        var handlers = _services.Where(s => s.ServiceType == typeof(EventHandlerDelegateWrapper)).ToList();
+        var handler = handlers.First();
+
+        // Assert
+        Assert.True(handler.IsKeyedService);
+        Assert.Equal(ServiceLifetime.Singleton, handler.Lifetime);
+    }
+
     [Fact]
     public void AddHandler_WithImplementationFactory_AddsEventHandlerDelegateWrapperAsKeyedService()
     {

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -381,15 +381,14 @@ public partial class OpenFeatureBuilderExtensionsTests
     {
         // Arrange
         EventHandlerDelegate eventHandler = (eventDetails) => { };
-        _systemUnderTest.AddHandler(handlerName!, Constant.ProviderEventTypes.ProviderReady, eventHandler);
 
         // Act
-        var handlers = _services.Where(s => s.ServiceType == typeof(EventHandlerDelegateWrapper)).ToList();
-        var handler = handlers.First();
+        Action act = () => _systemUnderTest.AddHandler(handlerName!, Constant.ProviderEventTypes.ProviderReady, eventHandler);
 
         // Assert
-        Assert.True(handler.IsKeyedService);
-        Assert.Equal(ServiceLifetime.Singleton, handler.Lifetime);
+        var ex = Assert.Throws<ArgumentException>(act);
+        Assert.Equal("handlerName", ex.ParamName);
+        Assert.StartsWith("Null or empty Handler name", ex.Message);
     }
 
     [Fact]

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -308,12 +308,12 @@ public partial class OpenFeatureBuilderExtensionsTests
     {
         // Arrange
         EventHandlerDelegate eventHandler = (eventDetails) => { };
-        _systemUnderTest.AddHandler("test", Constant.ProviderEventTypes.ProviderReady, eventHandler);
+        _systemUnderTest.AddHandler(Constant.ProviderEventTypes.ProviderReady, eventHandler);
 
         var serviceProvider = _services.BuildServiceProvider();
 
         // Act
-        var handler = serviceProvider.GetKeyedService<EventHandlerDelegateWrapper>("test:ProviderReady");
+        var handler = serviceProvider.GetService<EventHandlerDelegateWrapper>();
 
         // Assert
         Assert.NotNull(handler);
@@ -332,7 +332,7 @@ public partial class OpenFeatureBuilderExtensionsTests
         var serviceProvider = _services.BuildServiceProvider();
 
         // Act
-        var handler = serviceProvider.GetKeyedServices<EventHandlerDelegateWrapper>("EventHandlerDelegate:ProviderReady");
+        var handler = serviceProvider.GetServices<EventHandlerDelegateWrapper>();
 
         // Assert
         Assert.NotEmpty(handler);
@@ -341,86 +341,19 @@ public partial class OpenFeatureBuilderExtensionsTests
     }
 
     [Fact]
-    public void AddHandler_SetsHandlerNameInOpenFeatureOptions()
-    {
-        // Arrange
-        EventHandlerDelegate eventHandler = (eventDetails) => { };
-        _systemUnderTest.AddHandler("test", Constant.ProviderEventTypes.ProviderReady, eventHandler);
-
-        var serviceProvider = _services.BuildServiceProvider();
-
-        // Act
-        var options = serviceProvider.GetService<IOptions<OpenFeatureOptions>>();
-        var openFeatureOptions = options!.Value;
-
-        // Assert
-        Assert.Contains("test:ProviderReady", openFeatureOptions.HandlerNames);
-    }
-
-    [Fact]
-    public void AddHandler_WithoutName_AddsEventHandlerDelegateWrapperAsKeyedService()
-    {
-        // Arrange
-        EventHandlerDelegate eventHandler = (eventDetails) => { };
-        _systemUnderTest.AddHandler(Constant.ProviderEventTypes.ProviderReady, eventHandler);
-
-        // Act
-        var handlers = _services.Where(s => s.ServiceType == typeof(EventHandlerDelegateWrapper)).ToList();
-        var handler = handlers.First();
-
-        // Assert
-        Assert.True(handler.IsKeyedService);
-        Assert.Equal(ServiceLifetime.Singleton, handler.Lifetime);
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData("  ")]
-    [InlineData(null)]
-    public void AddHandler_WithEmptyName_AddsEventHandlerDelegateWrapperAsKeyedService(string? handlerName)
-    {
-        // Arrange
-        EventHandlerDelegate eventHandler = (eventDetails) => { };
-
-        // Act
-        Action act = () => _systemUnderTest.AddHandler(handlerName!, Constant.ProviderEventTypes.ProviderReady, eventHandler);
-
-        // Assert
-        var ex = Assert.Throws<ArgumentNullException>(act);
-        Assert.Equal("handlerName", ex.ParamName);
-        Assert.StartsWith("Value cannot be null.", ex.Message);
-    }
-
-    [Fact]
     public void AddHandler_WithImplementationFactory_AddsEventHandlerDelegateWrapperAsKeyedService()
     {
         // Arrange
         EventHandlerDelegate eventHandler = (eventDetails) => { };
-        _systemUnderTest.AddHandler("test", Constant.ProviderEventTypes.ProviderReady, sp => eventHandler);
+        _systemUnderTest.AddHandler(Constant.ProviderEventTypes.ProviderReady, _ => eventHandler);
 
         var serviceProvider = _services.BuildServiceProvider();
 
         // Act
-        var handler = serviceProvider.GetKeyedService<EventHandlerDelegateWrapper>("test:ProviderReady");
+        var handler = serviceProvider.GetService<EventHandlerDelegateWrapper>();
 
         // Assert
         Assert.NotNull(handler);
         Assert.Equal(eventHandler, handler.EventHandlerDelegate);
-    }
-
-    [Fact]
-    public void AddHandlerWithImplementationFactory_WithoutName_AddsEventHandlerDelegateWrapperAsKeyedService()
-    {
-        // Arrange
-        EventHandlerDelegate eventHandler = (eventDetails) => { };
-        _systemUnderTest.AddHandler(Constant.ProviderEventTypes.ProviderReady, sp => eventHandler);
-
-        // Act
-        var handlers = _services.Where(s => s.ServiceType == typeof(EventHandlerDelegateWrapper)).ToList();
-        var handler = handlers.First();
-
-        // Assert
-        Assert.True(handler.IsKeyedService);
-        Assert.Equal(ServiceLifetime.Singleton, handler.Lifetime);
     }
 }

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -321,6 +321,26 @@ public partial class OpenFeatureBuilderExtensionsTests
     }
 
     [Fact]
+    public void AddHandlerTwice_MultipleEventHandlerDelegateWrappersAsKeyedServices()
+    {
+        // Arrange
+        EventHandlerDelegate eventHandler1 = (eventDetails) => { };
+        EventHandlerDelegate eventHandler2 = (eventDetails) => { };
+        _systemUnderTest.AddHandler(Constant.ProviderEventTypes.ProviderReady, eventHandler1);
+        _systemUnderTest.AddHandler(Constant.ProviderEventTypes.ProviderReady, eventHandler2);
+
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Act
+        var handler = serviceProvider.GetKeyedServices<EventHandlerDelegateWrapper>("EventHandlerDelegate:ProviderReady");
+
+        // Assert
+        Assert.NotEmpty(handler);
+        Assert.Equal(eventHandler1, handler.ElementAt(0).EventHandlerDelegate);
+        Assert.Equal(eventHandler2, handler.ElementAt(1).EventHandlerDelegate);
+    }
+
+    [Fact]
     public void AddHandler_SetsHandlerNameInOpenFeatureOptions()
     {
         // Arrange
@@ -355,6 +375,7 @@ public partial class OpenFeatureBuilderExtensionsTests
 
     [Theory]
     [InlineData("")]
+    [InlineData("  ")]
     [InlineData(null)]
     public void AddHandler_WithEmptyName_AddsEventHandlerDelegateWrapperAsKeyedService(string? handlerName)
     {

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -386,9 +386,9 @@ public partial class OpenFeatureBuilderExtensionsTests
         Action act = () => _systemUnderTest.AddHandler(handlerName!, Constant.ProviderEventTypes.ProviderReady, eventHandler);
 
         // Assert
-        var ex = Assert.Throws<ArgumentException>(act);
+        var ex = Assert.Throws<ArgumentNullException>(act);
         Assert.Equal("handlerName", ex.ParamName);
-        Assert.StartsWith("Null or empty Handler name", ex.Message);
+        Assert.StartsWith("Value cannot be null.", ex.Message);
     }
 
     [Fact]

--- a/test/OpenFeature.IntegrationTests/FeatureFlagIntegrationTest.cs
+++ b/test/OpenFeature.IntegrationTests/FeatureFlagIntegrationTest.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.Metrics;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
@@ -12,7 +11,6 @@ using OpenFeature.DependencyInjection;
 using OpenFeature.DependencyInjection.Providers.Memory;
 using OpenFeature.Hooks;
 using OpenFeature.IntegrationTests.Services;
-using OpenFeature.Model;
 using OpenFeature.Providers.Memory;
 
 namespace OpenFeature.IntegrationTests;


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Introduces a new extension method in the OpenFeature.DependencyInjection package which allows consumers to add, at a global/api level, a handler. 

Example usage:

```csharp
builder.Services.AddOpenFeature(feature =>
{
    feature.AddHostedFeatureLifecycle()
        .AddInMemoryProvider()
        .AddHandler(ProviderEventTypes.ProviderReady, (@event) => { Console.WriteLine("{0}", @event!.ProviderName); })
        .AddHandler(ProviderEventTypes.ProviderReady, sp => (@event) =>
        {
            var logger = sp.GetRequiredService<ILogger<Program>>();
            logger.LogInformation("Provider Ready");
        });
});
```

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #457

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

