### PR TITLE
chore: Cleanup .props file

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -7,6 +7,7 @@
     <!-- Workaround for IDE0005 (Remove unnecessary usings/imports); see https://github.com/dotnet/roslyn/issues/41640 -->
     <NoWarn>EnableGenerateDocumentationFile</NoWarn>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NuGetAudit>true</NuGetAudit>
     <NuGetAuditMode>all</NuGetAuditMode>

--- a/build/Common.props
+++ b/build/Common.props
@@ -19,10 +19,6 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Threading.Channels" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />

--- a/build/Common.tests.props
+++ b/build/Common.tests.props
@@ -16,6 +16,10 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup Condition="$(MSBuildProjectName.Contains('E2E'))">
+    <Using Include="Reqnroll" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
   </ItemGroup>

--- a/build/Common.tests.props
+++ b/build/Common.tests.props
@@ -13,6 +13,7 @@
     <Content Include="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenFeature.slnx'))\build\xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenFeature.DependencyInjection/OpenFeature.DependencyInjection.csproj
+++ b/src/OpenFeature.DependencyInjection/OpenFeature.DependencyInjection.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0;net9.0;net462</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>OpenFeature.DependencyInjection</RootNamespace>
   </PropertyGroup>
 

--- a/src/OpenFeature.DependencyInjection/OpenFeature.DependencyInjection.csproj
+++ b/src/OpenFeature.DependencyInjection/OpenFeature.DependencyInjection.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0;net9.0;net462</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>OpenFeature.DependencyInjection</RootNamespace>
   </PropertyGroup>
 

--- a/src/OpenFeature.Hosting/OpenFeature.Hosting.csproj
+++ b/src/OpenFeature.Hosting/OpenFeature.Hosting.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>OpenFeature</RootNamespace>
   </PropertyGroup>
 

--- a/src/OpenFeature.Hosting/OpenFeature.Hosting.csproj
+++ b/src/OpenFeature.Hosting/OpenFeature.Hosting.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>OpenFeature</RootNamespace>
   </PropertyGroup>
 

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -1,9 +1,4 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OpenFeature.Constant;
 using OpenFeature.Error;

--- a/src/OpenFeature/AsyncLocalTransactionContextPropagator.cs
+++ b/src/OpenFeature/AsyncLocalTransactionContextPropagator.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using OpenFeature.Model;
 
 namespace OpenFeature;

--- a/src/OpenFeature/Error/FeatureProviderException.cs
+++ b/src/OpenFeature/Error/FeatureProviderException.cs
@@ -1,4 +1,3 @@
-using System;
 using OpenFeature.Constant;
 
 namespace OpenFeature.Error;

--- a/src/OpenFeature/Error/FlagNotFoundException.cs
+++ b/src/OpenFeature/Error/FlagNotFoundException.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 

--- a/src/OpenFeature/Error/GeneralException.cs
+++ b/src/OpenFeature/Error/GeneralException.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 

--- a/src/OpenFeature/Error/InvalidContextException.cs
+++ b/src/OpenFeature/Error/InvalidContextException.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 

--- a/src/OpenFeature/Error/ParseErrorException.cs
+++ b/src/OpenFeature/Error/ParseErrorException.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 

--- a/src/OpenFeature/Error/ProviderFatalException.cs
+++ b/src/OpenFeature/Error/ProviderFatalException.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 

--- a/src/OpenFeature/Error/ProviderNotReadyException.cs
+++ b/src/OpenFeature/Error/ProviderNotReadyException.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 

--- a/src/OpenFeature/Error/TargetingKeyMissingException.cs
+++ b/src/OpenFeature/Error/TargetingKeyMissingException.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 

--- a/src/OpenFeature/Error/TypeMismatchException.cs
+++ b/src/OpenFeature/Error/TypeMismatchException.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using OpenFeature.Constant;
 

--- a/src/OpenFeature/EventExecutor.cs
+++ b/src/OpenFeature/EventExecutor.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Threading.Channels;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenFeature.Constant;

--- a/src/OpenFeature/Extension/EnumExtensions.cs
+++ b/src/OpenFeature/Extension/EnumExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using System.ComponentModel;
-using System.Linq;
 
 namespace OpenFeature.Extension;
 

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -1,7 +1,5 @@
 using System.Collections.Immutable;
-using System.Threading;
 using System.Threading.Channels;
-using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 

--- a/src/OpenFeature/Hook.cs
+++ b/src/OpenFeature/Hook.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenFeature.Model;
 
 namespace OpenFeature;

--- a/src/OpenFeature/HookData.cs
+++ b/src/OpenFeature/HookData.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using OpenFeature.Model;
 

--- a/src/OpenFeature/HookRunner.cs
+++ b/src/OpenFeature/HookRunner.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OpenFeature.Model;
 

--- a/src/OpenFeature/Hooks/LoggingHook.cs
+++ b/src/OpenFeature/Hooks/LoggingHook.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OpenFeature.Model;
 

--- a/src/OpenFeature/IFeatureClient.cs
+++ b/src/OpenFeature/IFeatureClient.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 

--- a/src/OpenFeature/Model/EvaluationContext.cs
+++ b/src/OpenFeature/Model/EvaluationContext.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace OpenFeature.Model;

--- a/src/OpenFeature/Model/EvaluationContextBuilder.cs
+++ b/src/OpenFeature/Model/EvaluationContextBuilder.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OpenFeature.Model;
 
 /// <summary>

--- a/src/OpenFeature/Model/HookContext.cs
+++ b/src/OpenFeature/Model/HookContext.cs
@@ -1,4 +1,3 @@
-using System;
 using OpenFeature.Constant;
 
 namespace OpenFeature.Model;

--- a/src/OpenFeature/Model/ImmutableMetadata.cs
+++ b/src/OpenFeature/Model/ImmutableMetadata.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace OpenFeature.Model;

--- a/src/OpenFeature/Model/ProviderEvents.cs
+++ b/src/OpenFeature/Model/ProviderEvents.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using OpenFeature.Constant;
 
 namespace OpenFeature.Model;

--- a/src/OpenFeature/Model/Structure.cs
+++ b/src/OpenFeature/Model/Structure.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/OpenFeature/Model/StructureBuilder.cs
+++ b/src/OpenFeature/Model/StructureBuilder.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace OpenFeature.Model;

--- a/src/OpenFeature/Model/TrackingEventDetails.cs
+++ b/src/OpenFeature/Model/TrackingEventDetails.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace OpenFeature.Model;

--- a/src/OpenFeature/Model/TrackingEventDetailsBuilder.cs
+++ b/src/OpenFeature/Model/TrackingEventDetailsBuilder.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OpenFeature.Model;
 
 /// <summary>

--- a/src/OpenFeature/Model/Value.cs
+++ b/src/OpenFeature/Model/Value.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace OpenFeature.Model;

--- a/src/OpenFeature/NoOpProvider.cs
+++ b/src/OpenFeature/NoOpProvider.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -1,10 +1,5 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenFeature.Constant;

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenFeature.Constant;

--- a/src/OpenFeature/Providers/Memory/Flag.cs
+++ b/src/OpenFeature/Providers/Memory/Flag.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using OpenFeature.Constant;
 using OpenFeature.Error;
 using OpenFeature.Model;

--- a/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
+++ b/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 

--- a/src/OpenFeature/SharedHookContext.cs
+++ b/src/OpenFeature/SharedHookContext.cs
@@ -1,4 +1,3 @@
-using System;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 

--- a/src/OpenFeature/Telemetry/EvaluationEvent.cs
+++ b/src/OpenFeature/Telemetry/EvaluationEvent.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace OpenFeature.Telemetry;
 
 /// <summary>

--- a/src/OpenFeature/Telemetry/EvaluationEventBuilder.cs
+++ b/src/OpenFeature/Telemetry/EvaluationEventBuilder.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 

--- a/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
+++ b/test/OpenFeature.Benchmarks/OpenFeatureClientBenchmarks.cs
@@ -1,6 +1,5 @@
 
 using System.Collections.Immutable;
-using System.Threading.Tasks;
 using AutoFixture;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;

--- a/test/OpenFeature.DependencyInjection.Tests/FeatureLifecycleManagerTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/FeatureLifecycleManagerTests.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using OpenFeature.Constant;
 using OpenFeature.DependencyInjection.Internal;
 using OpenFeature.Model;
-using Xunit;
 
 namespace OpenFeature.DependencyInjection.Tests;
 

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeature.DependencyInjection.Tests.csproj
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeature.DependencyInjection.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeature.DependencyInjection.Tests.csproj
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeature.DependencyInjection.Tests.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
 
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeature.DependencyInjection.Tests.csproj
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeature.DependencyInjection.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeature.DependencyInjection.Tests.csproj
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeature.DependencyInjection.Tests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenFeature.DependencyInjection.Internal;
 using OpenFeature.Model;
-using Xunit;
 
 namespace OpenFeature.DependencyInjection.Tests;
 

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureServiceCollectionExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureServiceCollectionExtensionsTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
-using Xunit;
 
 namespace OpenFeature.DependencyInjection.Tests;
 

--- a/test/OpenFeature.E2ETests/Steps/BaseStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/BaseStepDefinitions.cs
@@ -1,7 +1,6 @@
 using OpenFeature.E2ETests.Utils;
 using OpenFeature.Model;
 using OpenFeature.Providers.Memory;
-using Reqnroll;
 
 namespace OpenFeature.E2ETests.Steps;
 

--- a/test/OpenFeature.E2ETests/Steps/BaseStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/BaseStepDefinitions.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenFeature.E2ETests.Utils;
 using OpenFeature.Model;
 using OpenFeature.Providers.Memory;

--- a/test/OpenFeature.E2ETests/Steps/ContextMergingPrecedenceStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/ContextMergingPrecedenceStepDefinitions.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using OpenFeature.E2ETests.Utils;
 using Reqnroll;
 using Xunit;

--- a/test/OpenFeature.E2ETests/Steps/ContextMergingPrecedenceStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/ContextMergingPrecedenceStepDefinitions.cs
@@ -1,6 +1,5 @@
 using OpenFeature.E2ETests.Utils;
 using Reqnroll;
-using Xunit;
 
 namespace OpenFeature.E2ETests.Steps;
 

--- a/test/OpenFeature.E2ETests/Steps/ContextMergingPrecedenceStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/ContextMergingPrecedenceStepDefinitions.cs
@@ -1,5 +1,4 @@
 using OpenFeature.E2ETests.Utils;
-using Reqnroll;
 
 namespace OpenFeature.E2ETests.Steps;
 

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -2,7 +2,6 @@ using OpenFeature.Constant;
 using OpenFeature.E2ETests.Utils;
 using OpenFeature.Extension;
 using OpenFeature.Model;
-using Reqnroll;
 
 namespace OpenFeature.E2ETests.Steps;
 

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.E2ETests.Utils;
 using OpenFeature.Extension;

--- a/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/EvaluationStepDefinitions.cs
@@ -3,7 +3,6 @@ using OpenFeature.E2ETests.Utils;
 using OpenFeature.Extension;
 using OpenFeature.Model;
 using Reqnroll;
-using Xunit;
 
 namespace OpenFeature.E2ETests.Steps;
 

--- a/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
@@ -1,6 +1,5 @@
 using OpenFeature.E2ETests.Utils;
 using Reqnroll;
-using Xunit;
 
 namespace OpenFeature.E2ETests.Steps;
 

--- a/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/HooksStepDefinitions.cs
@@ -1,5 +1,4 @@
 using OpenFeature.E2ETests.Utils;
-using Reqnroll;
 
 namespace OpenFeature.E2ETests.Steps;
 

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -1,7 +1,6 @@
 using OpenFeature.E2ETests.Utils;
 using OpenFeature.Model;
 using Reqnroll;
-using Xunit;
 
 namespace OpenFeature.E2ETests.Steps;
 

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using OpenFeature.E2ETests.Utils;
 using OpenFeature.Model;
 using Reqnroll;

--- a/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
+++ b/test/OpenFeature.E2ETests/Steps/MetadataStepDefinitions.cs
@@ -1,6 +1,5 @@
 using OpenFeature.E2ETests.Utils;
 using OpenFeature.Model;
-using Reqnroll;
 
 namespace OpenFeature.E2ETests.Steps;
 

--- a/test/OpenFeature.E2ETests/Utils/ContextStoringProvider.cs
+++ b/test/OpenFeature.E2ETests/Utils/ContextStoringProvider.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
 using OpenFeature.Model;
 
 namespace OpenFeature.E2ETests.Utils;

--- a/test/OpenFeature.E2ETests/Utils/FlagTypesUtil.cs
+++ b/test/OpenFeature.E2ETests/Utils/FlagTypesUtil.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace OpenFeature.E2ETests.Utils;

--- a/test/OpenFeature.E2ETests/Utils/TestHook.cs
+++ b/test/OpenFeature.E2ETests/Utils/TestHook.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenFeature.Model;
 
 namespace OpenFeature.E2ETests.Utils;

--- a/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
+++ b/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
+++ b/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
@@ -22,8 +22,4 @@
     <ProjectReference Include="..\..\src\OpenFeature.Hosting\OpenFeature.Hosting.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Using Include="Xunit" />
-  </ItemGroup>
-
 </Project>

--- a/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
+++ b/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
+++ b/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
 
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
+++ b/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenFeature.Tests/AsyncLocalTransactionContextPropagatorTests.cs
+++ b/test/OpenFeature.Tests/AsyncLocalTransactionContextPropagatorTests.cs
@@ -1,5 +1,4 @@
 using OpenFeature.Model;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace OpenFeature.Tests;
 
 public class ClearOpenFeatureInstanceFixture : IAsyncLifetime

--- a/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Xunit;
 
 namespace OpenFeature.Tests;

--- a/test/OpenFeature.Tests/FeatureProviderExceptionTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderExceptionTests.cs
@@ -1,7 +1,6 @@
 using OpenFeature.Constant;
 using OpenFeature.Error;
 using OpenFeature.Extension;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/FeatureProviderExceptionTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderExceptionTests.cs
@@ -1,4 +1,3 @@
-using System;
 using OpenFeature.Constant;
 using OpenFeature.Error;
 using OpenFeature.Extension;

--- a/test/OpenFeature.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderTests.cs
@@ -3,7 +3,6 @@ using NSubstitute;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderTests.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using AutoFixture;
 using NSubstitute;
 using OpenFeature.Constant;

--- a/test/OpenFeature.Tests/HookDataTests.cs
+++ b/test/OpenFeature.Tests/HookDataTests.cs
@@ -1,5 +1,4 @@
 using OpenFeature.Model;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/HookDataTests.cs
+++ b/test/OpenFeature.Tests/HookDataTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using OpenFeature.Model;
 using Xunit;
 

--- a/test/OpenFeature.Tests/Hooks/LoggingHookTests.cs
+++ b/test/OpenFeature.Tests/Hooks/LoggingHookTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using OpenFeature.Constant;

--- a/test/OpenFeature.Tests/Hooks/LoggingHookTests.cs
+++ b/test/OpenFeature.Tests/Hooks/LoggingHookTests.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging.Testing;
 using OpenFeature.Constant;
 using OpenFeature.Hooks;
 using OpenFeature.Model;
-using Xunit;
 
 namespace OpenFeature.Tests.Hooks;
 

--- a/test/OpenFeature.Tests/ImmutableMetadataTest.cs
+++ b/test/OpenFeature.Tests/ImmutableMetadataTest.cs
@@ -1,6 +1,5 @@
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/ImmutableMetadataTest.cs
+++ b/test/OpenFeature.Tests/ImmutableMetadataTest.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
 using Xunit;

--- a/test/OpenFeature.Tests/Internal/SpecificationAttribute.cs
+++ b/test/OpenFeature.Tests/Internal/SpecificationAttribute.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OpenFeature.Tests.Internal;
 
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -8,7 +8,6 @@ using OpenFeature.Error;
 using OpenFeature.Extension;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using AutoFixture;
 using Microsoft.Extensions.Logging;
 using NSubstitute;

--- a/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
@@ -1,7 +1,6 @@
 using AutoFixture;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEvaluationContextTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using AutoFixture;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -3,7 +3,6 @@ using NSubstitute;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using AutoFixture;
 using NSubstitute;
 using OpenFeature.Constant;

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using AutoFixture;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -6,7 +6,6 @@ using OpenFeature.Constant;
 using OpenFeature.Error;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -2,7 +2,6 @@ using NSubstitute;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using NSubstitute;
 using OpenFeature.Constant;
 using OpenFeature.Model;

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -1,7 +1,6 @@
 using NSubstitute;
 using OpenFeature.Constant;
 using OpenFeature.Model;
-using Xunit;
 
 // We intentionally do not await for purposes of validating behavior.
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 using NSubstitute;
 using OpenFeature.Constant;
 using OpenFeature.Model;

--- a/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
+++ b/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
@@ -2,7 +2,6 @@ using OpenFeature.Constant;
 using OpenFeature.Error;
 using OpenFeature.Model;
 using OpenFeature.Providers.Memory;
-using Xunit;
 
 namespace OpenFeature.Tests.Providers.Memory;
 

--- a/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
+++ b/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Error;
 using OpenFeature.Model;

--- a/test/OpenFeature.Tests/StructureTests.cs
+++ b/test/OpenFeature.Tests/StructureTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using OpenFeature.Model;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/StructureTests.cs
+++ b/test/OpenFeature.Tests/StructureTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using OpenFeature.Model;
 using Xunit;

--- a/test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs
+++ b/test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs
@@ -1,7 +1,6 @@
 using OpenFeature.Constant;
 using OpenFeature.Model;
 using OpenFeature.Telemetry;
-using Xunit;
 
 namespace OpenFeature.Tests.Telemetry;
 

--- a/test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs
+++ b/test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 using OpenFeature.Telemetry;

--- a/test/OpenFeature.Tests/TestImplementations.cs
+++ b/test/OpenFeature.Tests/TestImplementations.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 

--- a/test/OpenFeature.Tests/TestUtils.cs
+++ b/test/OpenFeature.Tests/TestUtils.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 internal class Utils
 {
     /// <summary>

--- a/test/OpenFeature.Tests/TestUtilsTest.cs
+++ b/test/OpenFeature.Tests/TestUtilsTest.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace OpenFeature.Tests;

--- a/test/OpenFeature.Tests/TestUtilsTest.cs
+++ b/test/OpenFeature.Tests/TestUtilsTest.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace OpenFeature.Tests;
 
 public class TestUtilsTest

--- a/test/OpenFeature.Tests/TrackingEventDetailsTest.cs
+++ b/test/OpenFeature.Tests/TrackingEventDetailsTest.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
 using Xunit;

--- a/test/OpenFeature.Tests/TrackingEventDetailsTest.cs
+++ b/test/OpenFeature.Tests/TrackingEventDetailsTest.cs
@@ -1,6 +1,5 @@
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/ValueTests.cs
+++ b/test/OpenFeature.Tests/ValueTests.cs
@@ -1,5 +1,4 @@
 using OpenFeature.Model;
-using Xunit;
 
 namespace OpenFeature.Tests;
 

--- a/test/OpenFeature.Tests/ValueTests.cs
+++ b/test/OpenFeature.Tests/ValueTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using OpenFeature.Model;
 using Xunit;
 


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request introduces several changes to improve project configuration and clean up unused code. The most significant updates include enabling implicit usings globally, removing redundant `Nullable` and `ImplicitUsings` properties from specific project files, and cleaning up unused `using` directives across multiple source files.

### Project configuration improvements:
* Enabled `ImplicitUsings` globally in `build/Common.props` to streamline code and reduce boilerplate. Removed redundant `TreatWarningsAsErrors` configuration for the Release build. [[1]](diffhunk://#diff-3e9cdf5c2ef721be7342fcd07bd9e3567805d13357c97221e15137225f64e063R10) [[2]](diffhunk://#diff-3e9cdf5c2ef721be7342fcd07bd9e3567805d13357c97221e15137225f64e063L21-L24)
* Added conditional `Using` directives for test projects in `build/Common.tests.props`, ensuring proper dependencies for E2E tests.

### Code cleanup:
* Removed redundant `Nullable` and `ImplicitUsings` properties from `OpenFeature.DependencyInjection.csproj` and `OpenFeature.Hosting.csproj` as these are now handled globally. [[1]](diffhunk://#diff-55279cca9fb64343216b7896e3aa5ea96521b091ba68f0b06a2e9430b0a35962L5-L6) [[2]](diffhunk://#diff-1ceba8f8b16fba8e2b45f9f2f2c78e2e92129949e560f4346df2dd99fdbbd5f4L5-L6)
* Cleaned up unused `using` directives across multiple source files, including `Api.cs`, `AsyncLocalTransactionContextPropagator.cs`, and various exception classes, to improve readability and maintainability. [[1]](diffhunk://#diff-dc150fbd3b7be797470374ee7e38c7ab8a31eb9b6b7a52345e05114c2d32a15eL1-L6) [[2]](diffhunk://#diff-d9ca58e32d696079f875c51837dfc6ded087b06eb3aef3513f5ea15ebc22c700L1) [[3]](diffhunk://#diff-a7a382f3d0da52015d1b9e03802692a86c61e7b57580747f31fae37d8dcc5cd6L1) [[4]](diffhunk://#diff-b9fdde9b61e62d7c474069ea5fc2a43d123ab86d93cb9a6d0673254a64536722L1) [[5]](diffhunk://#diff-bb4aadb03ea44e3b6b74b83f12b2b1a258e13836bcf815f996addcd5537a478fL1) [[6]](diffhunk://#diff-89efe60a8b640cc303a38e5b01bc27ad40599e364ff2654a57b7e42138056cdaL1) [[7]](diffhunk://#diff-7a8cbfba7673f1b69d3d927f60eb4ab0aa548403a118fad9eb43b9a22875dc02L1) [[8]](diffhunk://#diff-48ae8447bc31a75ecf4bba768a7b68244fbbc9dd5480db9114d9c74fb10fe2efL1) [[9]](diffhunk://#diff-9a3b5bf7bf3351a6161fc6dd75830bfbaab7aca730cf3f0ae6cd120a76b2f1b1L1) [[10]](diffhunk://#diff-c4388b2e7252e2e3ac0967dbfdd4647a924cdfc54da229667a0db3613b243a7eL1) [[11]](diffhunk://#diff-44c88ae43caf99ee733ec911fa85454a96c57d07fc57d2fadd44e12cd7d31cd4L1) [[12]](diffhunk://#diff-f563baadcf750bb66efaea76d7ec4783320e6efdc45c468effb531c948a2292cL1-L4) [[13]](diffhunk://#diff-f94bf65f426e13a14f798a8db21a5c9dd3306f5941bde1aba79af3e41421bfc0L1-L3) [[14]](diffhunk://#diff-96ebc8fc507d0a19d55b9a5cb57b72a0e8058e09f31ee7d0b39e99b00c5029d8L2-L4) [[15]](diffhunk://#diff-d69e6a4b3c0fb22dcb05a1104cd353a597bc8f54bb29c458ed41d394d8f1c12aL1-L4) [[16]](diffhunk://#diff-ac87556ad78da36624700cf5bea44dc7cf279c59bb486203b6af9689427a8c9cL1)