### PR TITLE
docs: Add AspNetCore sample app

### DIFF
--- a/OpenFeature.slnx
+++ b/OpenFeature.slnx
@@ -39,9 +39,16 @@
   <Folder Name="/.root/build/">
     <File Path="build/Common.prod.props" />
     <File Path="build/Common.props" />
+    <File Path="build/Common.samples.props" />
     <File Path="build/Common.tests.props" />
     <File Path="build/openfeature-icon.png" />
     <File Path="build/xunit.runner.json" />
+  </Folder>
+  <Folder Name="/samples/">
+    <File Path="samples/Directory.Build.props" />
+  </Folder>
+  <Folder Name="/samples/aspnetcore/">
+    <Project Path="samples/AspNetCore/Samples.AspNetCore.csproj" />
   </Folder>
   <Folder Name="/src/">
     <File Path="src/Directory.Build.props" />

--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ public async Task Example()
 }
 ```
 
+### Samples
+
+The [`samples/`](./samples) folder contains example applications demonstrating how to use OpenFeature in different .NET scenarios.
+
+| Sample Name                                       | Description                                                    |
+|---------------------------------------------------|----------------------------------------------------------------|
+| [AspNetCore](/samples/AspNetCore/README.md)       | Feature flags in an ASP.NET Core Web API.                      |
+
+**Getting Started with a Sample:**
+
+1. Navigate to the sample directory
+
+   ```shell
+   cd samples/AspNetCore
+   ```
+
+2. Restore dependencies and run
+
+   ```shell
+   dotnet run
+   ```
+
+Want to contribute a new sample? See our [CONTRIBUTING](#-contributing) guide!
+
 ## 🌟 Features
 
 | Status | Features                                                            | Description                                                                                                                                                   |

--- a/build/Common.samples.props
+++ b/build/Common.samples.props
@@ -1,4 +1,12 @@
 <Project>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
   <!-- Stops warning to use the .ConfigureAwait method. Tests should configure the await context as opposed to library code -->
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA2007</NoWarn>

--- a/build/Common.samples.props
+++ b/build/Common.samples.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Stops warning to use the .ConfigureAwait method. Tests should configure the await context as opposed to library code -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/samples/AspNetCore/Program.cs
+++ b/samples/AspNetCore/Program.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Mvc;
+using OpenFeature;
+using OpenFeature.DependencyInjection.Providers.Memory;
+using OpenFeature.Hooks;
+using OpenFeature.Providers.Memory;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddProblemDetails();
+
+builder.Services.AddOpenFeature(builder =>
+{
+    builder.AddHostedFeatureLifecycle()
+        .AddHook(sp => new LoggingHook(sp.GetRequiredService<ILogger<LoggingHook>>()))
+        .AddInMemoryProvider("InMemory", provider => new Dictionary<string, Flag>()
+        {
+            {
+                "welcome-message", new Flag<bool>(
+                    new Dictionary<string, bool> { { "show", true }, { "hide", false } }, "show")
+            }
+        });
+});
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+app.UseExceptionHandler();
+
+app.MapGet("/welcome", async ([FromServices] IFeatureClient featureClient) =>
+{
+    var welcomeMessageEnabled = await featureClient.GetBooleanValueAsync("welcome-message", false);
+
+    if (welcomeMessageEnabled)
+    {
+        return TypedResults.Ok("Hello world! The welcome-message feature flag was enabled!");
+    }
+
+    return TypedResults.Ok("Hello world!");
+});
+
+app.Run();

--- a/samples/AspNetCore/Properties/launchSettings.json
+++ b/samples/AspNetCore/Properties/launchSettings.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "welcome",
+      "applicationUrl": "http://localhost:5412",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "welcome",
+      "applicationUrl": "https://localhost:7381;http://localhost:5412",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/AspNetCore/README.md
+++ b/samples/AspNetCore/README.md
@@ -1,0 +1,35 @@
+# OpenFeature Dotnet Web Sample
+
+This sample demonstrates how to use the OpenFeature .NET Web Application. It includes a simple .NET 9 web application that retrieves and evaluates feature flags using the OpenFeature client. The sample is set up with the `InMemoryProvider` and a relatively simple boolean `welcome-message` feature flag.
+
+The sample can easily extended with alternative providers, which you can find in the [dotnet-sdk-contrib](https://github.com/open-feature/dotnet-sdk-contrib) repository.
+
+## Prerequisites
+
+- [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) installed on your machine.
+
+## Setup
+
+1. Clone the repository:
+
+   ```shell
+   git clone https://github.com/open-feature/dotnet-sdk.git openfeature-dotnet-sdk
+   ```
+
+1. Navigate to the Web sample project directory:
+
+   ```shell
+   cd openfeature-dotnet-sdk/samples/AspNetCore
+   ```
+
+1. Run the following command to start the application:
+
+   ```shell
+   dotnet run
+   ```
+
+1. Open your web browser and navigate to `http://localhost:5412/welcome` to see the application in action.
+
+### Enable OpenFeature debug logging
+
+You can enable OpenFeature debug logging by setting the `Logging:LogLevel:OpenFeature.*` setting in [appsettings.Development.json](appsettings.Development.json) to `Debug`. This will provide detailed logs of the OpenFeature SDK's operations, which can be helpful for troubleshooting and understanding how feature flags are being evaluated.

--- a/samples/AspNetCore/README.md
+++ b/samples/AspNetCore/README.md
@@ -2,7 +2,7 @@
 
 This sample demonstrates how to use the OpenFeature .NET Web Application. It includes a simple .NET 9 web application that retrieves and evaluates feature flags using the OpenFeature client. The sample is set up with the `InMemoryProvider` and a relatively simple boolean `welcome-message` feature flag.
 
-The sample can easily extended with alternative providers, which you can find in the [dotnet-sdk-contrib](https://github.com/open-feature/dotnet-sdk-contrib) repository.
+The sample can easily be extended with alternative providers, which you can find in the [dotnet-sdk-contrib](https://github.com/open-feature/dotnet-sdk-contrib) repository.
 
 ## Prerequisites
 

--- a/samples/AspNetCore/Samples.AspNetCore.csproj
+++ b/samples/AspNetCore/Samples.AspNetCore.csproj
@@ -1,12 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenFeature.DependencyInjection\OpenFeature.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\src\OpenFeature.Hosting\OpenFeature.Hosting.csproj" />

--- a/samples/AspNetCore/Samples.AspNetCore.csproj
+++ b/samples/AspNetCore/Samples.AspNetCore.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenFeature.DependencyInjection\OpenFeature.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\src\OpenFeature.Hosting\OpenFeature.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\OpenFeature\OpenFeature.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AspNetCore/appsettings.Development.json
+++ b/samples/AspNetCore/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "OpenFeature.*": "Information"
+    }
+  }
+}

--- a/samples/AspNetCore/appsettings.json
+++ b/samples/AspNetCore/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenFeature.slnx'))\build\Common.samples.props" />
+</Project>


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Adds simple a AspNetCore web application with a `/welcome` minimal API that will show one of two messages based the configuration of the `InMemory` feature provider.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

While the [README](https://github.com/open-feature/dotnet-sdk/blob/6c44db9237748735a22a162a88f61b2de7f3e9bd/README.md) for OpenFeature dotnet is pretty comprehensive, I think it can be quite intimidating to developers who are unfamilar with feature flagging and OpenFeature. Providing a basic application that can be cloned locally and run with minimal setup would improve the onboarding and upskill experience.

Additionally, as a contributor I find myself frequently creating simple applications to test out changes to OpenFeature. This would save the effort of stashing local changes and make it easier to more quickly test or prototype changes.

The example could be extended with endpoints that explore the other types of feature flags and how you might utilise them within an application.

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

Update the [README](https://github.com/open-feature/dotnet-sdk/blob/6c44db9237748735a22a162a88f61b2de7f3e9bd/README.md) with a reference to the sample application to help guide developers.

### How to test
<!-- if applicable, add testing instructions under this section -->

