### PR TITLE
ci: Fix config for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
         id: release
         with:
           token: ${{secrets.RELEASE_PLEASE_ACTION_TOKEN}}
-          release-type: simple
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       release_tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request includes a small change to the `.github/workflows/release.yml` file. The change removes the `release-type: simple` configuration from the `jobs:` section, potentially altering the release behavior.
I would imagine, since we are putting this setting here, it won't read from the configuration file.
