### PR TITLE
fix: Add generic to evaluation event builder

### DIFF
--- a/src/OpenFeature/Telemetry/EvaluationEventBuilder.cs
+++ b/src/OpenFeature/Telemetry/EvaluationEventBuilder.cs
@@ -6,14 +6,14 @@ namespace OpenFeature.Telemetry;
 /// <summary>
 /// Class for creating evaluation events for feature flags.
 /// </summary>
-public sealed class EvaluationEventBuilder
+public sealed class EvaluationEventBuilder<T>
 {
     private const string EventName = "feature_flag.evaluation";
 
     /// <summary>
-    /// Gets the default instance of the <see cref="EvaluationEventBuilder"/>.
+    /// Gets the default instance of the <see cref="EvaluationEventBuilder{T}"/>.
     /// </summary>
-    public static EvaluationEventBuilder Default { get; } = new();
+    public static EvaluationEventBuilder<T> Default { get; } = new();
 
     /// <summary>
     /// Creates an evaluation event based on the provided hook context and flag evaluation details.
@@ -21,7 +21,7 @@ public sealed class EvaluationEventBuilder
     /// <param name="hookContext">The context of the hook containing flag key and provider metadata.</param>
     /// <param name="details">The details of the flag evaluation including reason, variant, and metadata.</param>
     /// <returns>An instance of <see cref="EvaluationEvent"/> containing the event name, attributes, and body.</returns>
-    public EvaluationEvent Build(HookContext<Value> hookContext, FlagEvaluationDetails<Value> details)
+    public static EvaluationEvent Build(HookContext<T> hookContext, FlagEvaluationDetails<T> details)
     {
         var attributes = new Dictionary<string, object?>
         {

--- a/test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs
+++ b/test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs
@@ -6,8 +6,6 @@ namespace OpenFeature.Tests.Telemetry;
 
 public class EvaluationEventBuilderTests
 {
-    private readonly EvaluationEventBuilder<Value> _builder = EvaluationEventBuilder<Value>.Default;
-
     [Fact]
     public void Build_ShouldReturnEventWithCorrectAttributes()
     {

--- a/test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs
+++ b/test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs
@@ -25,7 +25,7 @@ public class EvaluationEventBuilderTests
             reason: "reason", variant: "variant", flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = _builder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
 
         // Assert
         Assert.Equal("feature_flag.evaluation", evaluationEvent.Name);
@@ -55,7 +55,7 @@ public class EvaluationEventBuilderTests
             errorMessage: "errorMessage", reason: "reason", variant: "variant", flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = _builder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
 
         // Assert
         Assert.Equal("general", evaluationEvent.Attributes[TelemetryConstants.ErrorCode]);
@@ -79,7 +79,7 @@ public class EvaluationEventBuilderTests
             reason: "reason", variant: null, flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = _builder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
 
         // Assert
         Assert.Null(evaluationEvent.Attributes[TelemetryConstants.Variant]);
@@ -98,7 +98,7 @@ public class EvaluationEventBuilderTests
             reason: "reason", variant: "", flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = _builder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
 
         // Assert
         Assert.Null(evaluationEvent.Attributes[TelemetryConstants.ContextId]);
@@ -122,7 +122,7 @@ public class EvaluationEventBuilderTests
             reason: reason, variant: "", flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = _builder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
 
         // Assert
         Assert.Equal(Reason.Unknown.ToLowerInvariant(), evaluationEvent.Attributes[TelemetryConstants.Reason]);
@@ -144,7 +144,7 @@ public class EvaluationEventBuilderTests
             errorMessage: errorMessage, reason: "reason", variant: "", flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = _builder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
 
         // Assert
         Assert.Equal("general", evaluationEvent.Attributes[TelemetryConstants.ErrorCode]);
@@ -164,7 +164,7 @@ public class EvaluationEventBuilderTests
             reason: "reason", variant: "variant", flagMetadata: new ImmutableMetadata());
 
         // Act
-        var evaluationEvent = _builder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
 
         // Assert
         Assert.Equal(testValue, evaluationEvent.Attributes[TelemetryConstants.Value]);

--- a/test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs
+++ b/test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs
@@ -6,7 +6,7 @@ namespace OpenFeature.Tests.Telemetry;
 
 public class EvaluationEventBuilderTests
 {
-    private readonly EvaluationEventBuilder _builder = EvaluationEventBuilder.Default;
+    private readonly EvaluationEventBuilder<Value> _builder = EvaluationEventBuilder<Value>.Default;
 
     [Fact]
     public void Build_ShouldReturnEventWithCorrectAttributes()
@@ -25,7 +25,7 @@ public class EvaluationEventBuilderTests
             reason: "reason", variant: "variant", flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder<Value>.Build(hookContext, details);
 
         // Assert
         Assert.Equal("feature_flag.evaluation", evaluationEvent.Name);
@@ -55,7 +55,7 @@ public class EvaluationEventBuilderTests
             errorMessage: "errorMessage", reason: "reason", variant: "variant", flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder<Value>.Build(hookContext, details);
 
         // Assert
         Assert.Equal("general", evaluationEvent.Attributes[TelemetryConstants.ErrorCode]);
@@ -79,7 +79,7 @@ public class EvaluationEventBuilderTests
             reason: "reason", variant: null, flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder<Value>.Build(hookContext, details);
 
         // Assert
         Assert.Null(evaluationEvent.Attributes[TelemetryConstants.Variant]);
@@ -98,7 +98,7 @@ public class EvaluationEventBuilderTests
             reason: "reason", variant: "", flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder<Value>.Build(hookContext, details);
 
         // Assert
         Assert.Null(evaluationEvent.Attributes[TelemetryConstants.ContextId]);
@@ -122,7 +122,7 @@ public class EvaluationEventBuilderTests
             reason: reason, variant: "", flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder<Value>.Build(hookContext, details);
 
         // Assert
         Assert.Equal(Reason.Unknown.ToLowerInvariant(), evaluationEvent.Attributes[TelemetryConstants.Reason]);
@@ -144,7 +144,7 @@ public class EvaluationEventBuilderTests
             errorMessage: errorMessage, reason: "reason", variant: "", flagMetadata: flagMetadata);
 
         // Act
-        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder<Value>.Build(hookContext, details);
 
         // Assert
         Assert.Equal("general", evaluationEvent.Attributes[TelemetryConstants.ErrorCode]);
@@ -164,7 +164,7 @@ public class EvaluationEventBuilderTests
             reason: "reason", variant: "variant", flagMetadata: new ImmutableMetadata());
 
         // Act
-        var evaluationEvent = EvaluationEventBuilder.Build(hookContext, details);
+        var evaluationEvent = EvaluationEventBuilder<Value>.Build(hookContext, details);
 
         // Assert
         Assert.Equal(testValue, evaluationEvent.Attributes[TelemetryConstants.Value]);


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request introduces a generic type parameter `T` to the `EvaluationEventBuilder` class to enhance its flexibility and adaptability for different data types. Corresponding updates have been made to the test suite to accommodate this change.

### Updates to `EvaluationEventBuilder`:
* The `EvaluationEventBuilder` class now includes a generic type parameter `T`, allowing it to handle different data types for evaluation events. This change affects its definition, the `Default` property, and the `Build` method. (`src/OpenFeature/Telemetry/EvaluationEventBuilder.cs`, [src/OpenFeature/Telemetry/EvaluationEventBuilder.csL9-R24](diffhunk://#diff-6bccdfe3ff3572320900eca32b1f88adaffd0ca3dfb9c01a152a7aa16d271746L9-R24))

### Updates to Tests:
* Updated the `EvaluationEventBuilderTests` class to use the generic `EvaluationEventBuilder<Value>` instead of the non-generic version. (`test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs`, [test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.csL9-R9](diffhunk://#diff-50b44bc4b6b9c4acb573dc64527b72c44689c88df4c8417ae94460b0bfe0fffbL9-R9))
* Modified all test cases in `EvaluationEventBuilderTests` to call the static `Build` method on `EvaluationEventBuilder<Value>` directly, ensuring compatibility with the new generic implementation. (`test/OpenFeature.Tests/Telemetry/EvaluationEventBuilderTests.cs`, [[1]](diffhunk://#diff-50b44bc4b6b9c4acb573dc64527b72c44689c88df4c8417ae94460b0bfe0fffbL28-R28) [[2]](diffhunk://#diff-50b44bc4b6b9c4acb573dc64527b72c44689c88df4c8417ae94460b0bfe0fffbL58-R58) [[3]](diffhunk://#diff-50b44bc4b6b9c4acb573dc64527b72c44689c88df4c8417ae94460b0bfe0fffbL82-R82) [[4]](diffhunk://#diff-50b44bc4b6b9c4acb573dc64527b72c44689c88df4c8417ae94460b0bfe0fffbL101-R101) [[5]](diffhunk://#diff-50b44bc4b6b9c4acb573dc64527b72c44689c88df4c8417ae94460b0bfe0fffbL125-R125) [[6]](diffhunk://#diff-50b44bc4b6b9c4acb573dc64527b72c44689c88df4c8417ae94460b0bfe0fffbL147-R147) [[7]](diffhunk://#diff-50b44bc4b6b9c4acb573dc64527b72c44689c88df4c8417ae94460b0bfe0fffbL167-R167)