### PR TITLE
fix: ArgumentNullException when creating a client with optional name

### DIFF
--- a/src/OpenFeature/EventExecutor.cs
+++ b/src/OpenFeature/EventExecutor.cs
@@ -315,7 +315,7 @@ internal sealed partial class EventExecutor : IAsyncDisposable
 
     private static string GetClientName(string client)
     {
-        if (string.IsNullOrEmpty(client))
+        if (string.IsNullOrWhiteSpace(client))
         {
             return _defaultClientName.ToString();
         }

--- a/src/OpenFeature/EventExecutor.cs
+++ b/src/OpenFeature/EventExecutor.cs
@@ -14,6 +14,9 @@ internal sealed partial class EventExecutor : IAsyncDisposable
     private readonly Dictionary<string, FeatureProvider> _namedProviderReferences = [];
     private readonly List<FeatureProvider> _activeSubscriptions = [];
 
+    /// placeholder for anonymous clients
+    private static Guid _defaultClientName = Guid.NewGuid();
+
     private readonly Dictionary<ProviderEventTypes, List<EventHandlerDelegate>> _apiHandlers = [];
     private readonly Dictionary<string, Dictionary<ProviderEventTypes, List<EventHandlerDelegate>>> _clientHandlers = [];
 
@@ -58,25 +61,27 @@ internal sealed partial class EventExecutor : IAsyncDisposable
 
     internal void AddClientHandler(string client, ProviderEventTypes eventType, EventHandlerDelegate handler)
     {
+        var clientName = GetClientName(client);
+
         lock (this._lockObj)
         {
             // check if there is already a list of handlers for the given client and event type
-            if (!this._clientHandlers.TryGetValue(client, out var registry))
+            if (!this._clientHandlers.TryGetValue(clientName, out var registry))
             {
                 registry = [];
-                this._clientHandlers[client] = registry;
+                this._clientHandlers[clientName] = registry;
             }
 
-            if (!this._clientHandlers[client].TryGetValue(eventType, out var eventHandlers))
+            if (!this._clientHandlers[clientName].TryGetValue(eventType, out var eventHandlers))
             {
                 eventHandlers = [];
-                this._clientHandlers[client][eventType] = eventHandlers;
+                this._clientHandlers[clientName][eventType] = eventHandlers;
             }
 
-            this._clientHandlers[client][eventType].Add(handler);
+            this._clientHandlers[clientName][eventType].Add(handler);
 
             this.EmitOnRegistration(
-                this._namedProviderReferences.TryGetValue(client, out var clientProviderReference)
+                this._namedProviderReferences.TryGetValue(clientName, out var clientProviderReference)
                     ? clientProviderReference
                     : this._defaultProvider, eventType, handler);
         }
@@ -84,9 +89,11 @@ internal sealed partial class EventExecutor : IAsyncDisposable
 
     internal void RemoveClientHandler(string client, ProviderEventTypes type, EventHandlerDelegate handler)
     {
+        var clientName = GetClientName(client);
+
         lock (this._lockObj)
         {
-            if (this._clientHandlers.TryGetValue(client, out var clientEventHandlers))
+            if (this._clientHandlers.TryGetValue(clientName, out var clientEventHandlers))
             {
                 if (clientEventHandlers.TryGetValue(type, out var eventHandlers))
                 {
@@ -118,15 +125,18 @@ internal sealed partial class EventExecutor : IAsyncDisposable
         {
             return;
         }
+
+        var clientName = GetClientName(client);
+
         lock (this._lockObj)
         {
             FeatureProvider? oldProvider = null;
-            if (this._namedProviderReferences.TryGetValue(client, out var foundOldProvider))
+            if (this._namedProviderReferences.TryGetValue(clientName, out var foundOldProvider))
             {
                 oldProvider = foundOldProvider;
             }
 
-            this._namedProviderReferences[client] = provider;
+            this._namedProviderReferences[clientName] = provider;
 
             this.StartListeningAndShutdownOld(provider, oldProvider);
         }
@@ -303,6 +313,14 @@ internal sealed partial class EventExecutor : IAsyncDisposable
         }
     }
 
+    private static string GetClientName(string client)
+    {
+        if (string.IsNullOrEmpty(client))
+        {
+            return _defaultClientName.ToString();
+        }
+        return client;
+    }
 
     // map events to provider status as per spec: https://openfeature.dev/specification/sections/events/#requirement-535
     private static void UpdateProviderStatus(FeatureProvider provider, ProviderEventPayload eventPayload)

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -600,6 +600,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
     [Theory]
     [InlineData(null)]
     [InlineData("")]
+    [InlineData("   ")]
     public async Task PassingBlankClientName_DoesNotThrowArgumentNullException(string? clientName)
     {
         var provider = new TestProvider();

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -597,6 +597,20 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         Assert.Throws<ArgumentException>(() => client.Track(" \n "));
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task PassingBlankClientName_DoesNotThrowArgumentNullException(string? clientName)
+    {
+        var provider = new TestProvider();
+        await Api.Instance.SetProviderAsync(provider);
+        var client = Api.Instance.GetClient(clientName);
+
+        var ex = Record.Exception(() => client.AddHandler(ProviderEventTypes.ProviderReady, (args) => { }));
+
+        Assert.Null(ex);
+    }
+
     public static TheoryData<string, EvaluationContext?, EvaluationContext?, EvaluationContext?, string> GenerateMergeEvaluationContextTestData()
     {
         const string key = "key";


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Adds a default placeholder name that gets generated when a Client is generated. This is inspired from the Java SDK (see [EventSource.java](https://github.com/open-feature/java-sdk/blob/0515ad54c4f71863373eb1b7f429393923b27d90/src/main/java/dev/openfeature/sdk/EventSupport.java#L40)). The exception is thrown when an optional client name is specified when retrieving a client from `Api.Instance`. When no name is specified we use a generated one.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #491

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

