### PR TITLE
ci: update renovate configuration to include package rules for security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,15 @@
     "github>open-feature/community-tooling"
   ],
   "dependencyDashboardApproval": true,
-  "recreateWhen": "never"
+  "recreateWhen": "never",
+  "packageRules": [
+    {
+      "description": "Create PRs for security updates without dashboard approval",
+      "matchCategories": [
+        "security"
+      ],
+      "dependencyDashboardApproval": false,
+      "automerge": false
+    }
+  ]
 }


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the `renovate.json` configuration to enhance dependency management rules. The most notable change introduces a new `packageRules` section to handle security updates differently than other dependencies.

Dependency management improvements:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L7-R17): Added a `packageRules` section to create pull requests for security updates without requiring dashboard approval. These updates will not be automatically merged, ensuring manual review.