### PR TITLE
feat: Add Metric Hook Custom Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,24 @@ namespace OpenFeatureTestApp
 
 After running this example, you should be able to see some metrics being generated into the console.
 
+You can specify custom dimensions on the `feature_flag.evaluation_success_total` metric by providing `MetricsHookOptions` when adding the hook:
+
+```csharp
+var options = MetricsHookOptions.CreateBuilder()
+    .AddCustomDimension("custom_dimension_key", "custom_dimension_value")
+    .Build();
+
+OpenFeature.Api.Instance.AddHooks(new MetricsHook(options));
+```
+
+You can also write your own extraction logic against the Flag metadata by providing a callback to `WithFlagEvaluationMetadata`.
+
+```csharp
+var options = MetricsHookOptions.CreateBuilder()
+    .WithFlagEvaluationMetadata("boolean", s => s.GetBool("boolean"))
+    .Build();
+```
+
 <!-- x-hide-in-docs-start -->
 
 ## ⭐️ Support the project

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ You can specify custom dimensions on the `feature_flag.evaluation_success_total`
 
 ```csharp
 var options = MetricsHookOptions.CreateBuilder()
-    .AddCustomDimension("custom_dimension_key", "custom_dimension_value")
+    .WithCustomDimension("custom_dimension_key", "custom_dimension_value")
     .Build();
 
 OpenFeature.Api.Instance.AddHooks(new MetricsHook(options));

--- a/samples/AspNetCore/Program.cs
+++ b/samples/AspNetCore/Program.cs
@@ -27,7 +27,7 @@ builder.Services.AddOpenTelemetry()
 builder.Services.AddOpenFeature(featureBuilder =>
 {
     var metricsHookOptions = MetricsHookOptions.CreateBuilder()
-        .WithCustomDimension("region", "euw")
+        .WithCustomDimension("custom_dimension_key", "custom_dimension_value")
         .WithFlagEvaluationMetadata("boolean", s => s.GetBool("boolean"))
         .Build();
 

--- a/samples/AspNetCore/Program.cs
+++ b/samples/AspNetCore/Program.cs
@@ -26,9 +26,14 @@ builder.Services.AddOpenTelemetry()
 
 builder.Services.AddOpenFeature(featureBuilder =>
 {
+    var metricsHookOptions = MetricsHookOptions.CreateBuilder()
+        .WithCustomDimension("region", "euw")
+        .WithFlagEvaluationMetadata("boolean", s => s.GetBool("boolean"))
+        .Build();
+
     featureBuilder.AddHostedFeatureLifecycle()
         .AddHook(sp => new LoggingHook(sp.GetRequiredService<ILogger<LoggingHook>>()))
-        .AddHook<MetricsHook>()
+        .AddHook(_ => new MetricsHook(metricsHookOptions))
         .AddHook<TraceEnricherHook>()
         .AddInMemoryProvider("InMemory", _ => new Dictionary<string, Flag>()
         {

--- a/src/OpenFeature/Hooks/MetricsHook.cs
+++ b/src/OpenFeature/Hooks/MetricsHook.cs
@@ -24,15 +24,19 @@ public class MetricsHook : Hook
     private readonly Counter<long> _evaluationSuccessCounter;
     private readonly Counter<long> _evaluationErrorCounter;
 
+    private readonly MetricsHookOptions _options;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="MetricsHook"/> class.
     /// </summary>
-    public MetricsHook()
+    /// <param name="options">Optional configuration for the metrics hook.</param>
+    public MetricsHook(MetricsHookOptions? options = null)
     {
         this._evaluationActiveUpDownCounter = Meter.CreateUpDownCounter<long>(MetricsConstants.ActiveCountName, description: MetricsConstants.ActiveDescription);
         this._evaluationRequestCounter = Meter.CreateCounter<long>(MetricsConstants.RequestsTotalName, "{request}", MetricsConstants.RequestsDescription);
         this._evaluationSuccessCounter = Meter.CreateCounter<long>(MetricsConstants.SuccessTotalName, "{impression}", MetricsConstants.SuccessDescription);
         this._evaluationErrorCounter = Meter.CreateCounter<long>(MetricsConstants.ErrorTotalName, description: MetricsConstants.ErrorDescription);
+        this._options = options ?? MetricsHookOptions.Default;
     }
 
     /// <inheritdoc/>
@@ -60,6 +64,11 @@ public class MetricsHook : Hook
             { TelemetryConstants.Provider, context.ProviderMetadata.Name },
             { TelemetryConstants.Reason, details.Reason ?? Reason.Unknown.ToString() }
         };
+
+        foreach (var metadata in this._options.CustomDimensions)
+        {
+            tagList.Add(metadata.Key, metadata.Value);
+        }
 
         this._evaluationSuccessCounter.Add(1, tagList);
 

--- a/src/OpenFeature/Hooks/MetricsHook.cs
+++ b/src/OpenFeature/Hooks/MetricsHook.cs
@@ -21,7 +21,7 @@ public class MetricsHook : Hook
 
     private readonly UpDownCounter<long> _evaluationActiveUpDownCounter;
     private readonly Counter<long> _evaluationRequestCounter;
-    private readonly Counter<long> _evaluationSuccessCounter;
+    internal readonly Counter<long> _evaluationSuccessCounter;
     private readonly Counter<long> _evaluationErrorCounter;
 
     private readonly MetricsHookOptions _options;
@@ -71,7 +71,7 @@ public class MetricsHook : Hook
         }
 
         var metadata = details.FlagMetadata ?? new ImmutableMetadata();
-        foreach (var item in this._options.FlagMetadataExpressions)
+        foreach (var item in this._options.FlagMetadataCallbacks)
         {
             var flagMetadataCallback = item.Value;
             var value = flagMetadataCallback(metadata);

--- a/src/OpenFeature/Hooks/MetricsHook.cs
+++ b/src/OpenFeature/Hooks/MetricsHook.cs
@@ -65,9 +65,18 @@ public class MetricsHook : Hook
             { TelemetryConstants.Reason, details.Reason ?? Reason.Unknown.ToString() }
         };
 
-        foreach (var metadata in this._options.CustomDimensions)
+        foreach (var customDimension in this._options.CustomDimensions)
         {
-            tagList.Add(metadata.Key, metadata.Value);
+            tagList.Add(customDimension.Key, customDimension.Value);
+        }
+
+        var metadata = details.FlagMetadata ?? new ImmutableMetadata();
+        foreach (var item in this._options.FlagMetadataExpressions)
+        {
+            var flagMetadataCallback = item.Value;
+            var value = flagMetadataCallback(metadata);
+
+            tagList.Add(item.Key, value);
         }
 
         this._evaluationSuccessCounter.Add(1, tagList);

--- a/src/OpenFeature/Hooks/MetricsHookOptions.cs
+++ b/src/OpenFeature/Hooks/MetricsHookOptions.cs
@@ -1,0 +1,58 @@
+namespace OpenFeature.Hooks;
+
+/// <summary>
+/// Configuration options for the <see cref="MetricsHook"/>.
+/// </summary>
+public sealed class MetricsHookOptions
+{
+    /// <summary>
+    /// The default options for the <see cref="MetricsHook"/>.
+    /// </summary>
+    public static MetricsHookOptions Default { get; } = new MetricsHookOptions();
+
+    /// <summary>
+    /// Custom dimensions or tags to be associated with Meters in <see cref="MetricsHook"/>.
+    /// </summary>
+    public IReadOnlyCollection<KeyValuePair<string, object?>> CustomDimensions { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetricsHookOptions"/> class.
+    /// </summary>
+    /// <param name="customDimensions">Optional custom dimensions to tag Counter increments with.</param>
+    public MetricsHookOptions(IReadOnlyCollection<KeyValuePair<string, object?>>? customDimensions = null)
+    {
+        this.CustomDimensions = customDimensions ?? [];
+    }
+
+    /// <summary>
+    /// Creates a new builder for <see cref="MetricsHookOptions"/>.
+    /// </summary>
+    public static MetricsHookOptionsBuilder CreateBuilder() => new MetricsHookOptionsBuilder();
+
+    /// <summary>
+    /// A builder for constructing <see cref="MetricsHookOptions"/> instances.
+    /// </summary>
+    public sealed class MetricsHookOptionsBuilder
+    {
+        private readonly List<KeyValuePair<string, object?>> _customDimensions = new List<KeyValuePair<string, object?>>();
+
+        /// <summary>
+        /// Adds a custom dimension.
+        /// </summary>
+        /// <param name="key">The key for the custom dimension.</param>
+        /// <param name="value">The value for the custom dimension.</param>
+        public MetricsHookOptionsBuilder WithCustomDimension(string key, object? value)
+        {
+            this._customDimensions.Add(new KeyValuePair<string, object?>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the <see cref="MetricsHookOptions"/> instance.
+        /// </summary>
+        public MetricsHookOptions Build()
+        {
+            return new MetricsHookOptions(this._customDimensions.AsReadOnly());
+        }
+    }
+}

--- a/src/OpenFeature/Hooks/MetricsHookOptions.cs
+++ b/src/OpenFeature/Hooks/MetricsHookOptions.cs
@@ -1,4 +1,3 @@
-using System.Linq.Expressions;
 using OpenFeature.Model;
 
 namespace OpenFeature.Hooks;
@@ -21,7 +20,7 @@ public sealed class MetricsHookOptions
     /// <summary>
     /// 
     /// </summary>
-    internal IReadOnlyCollection<KeyValuePair<string, Func<ImmutableMetadata, object?>>> FlagMetadataExpressions { get; }
+    internal IReadOnlyCollection<KeyValuePair<string, Func<ImmutableMetadata, object?>>> FlagMetadataCallbacks { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MetricsHookOptions"/> class with default values.
@@ -39,7 +38,7 @@ public sealed class MetricsHookOptions
         IReadOnlyCollection<KeyValuePair<string, Func<ImmutableMetadata, object?>>>? flagMetadataSelectors = null)
     {
         this.CustomDimensions = customDimensions ?? [];
-        this.FlagMetadataExpressions = flagMetadataSelectors ?? [];
+        this.FlagMetadataCallbacks = flagMetadataSelectors ?? [];
     }
 
     /// <summary>
@@ -70,11 +69,10 @@ public sealed class MetricsHookOptions
         /// Provide a callback to evaluate flag metadata for a specific flag key.
         /// </summary>
         /// <param name="key">The key for the custom dimension.</param>
-        /// <param name="expression">The callback to retrieve the value to tag successful flag evaluations.</param>
+        /// <param name="flagMetadataCallback">The callback to retrieve the value to tag successful flag evaluations.</param>
         /// <returns></returns>
-        public MetricsHookOptionsBuilder WithFlagEvaluationMetadata(string key, Expression<Func<ImmutableMetadata, object?>> expression)
+        public MetricsHookOptionsBuilder WithFlagEvaluationMetadata(string key, Func<ImmutableMetadata, object?> flagMetadataCallback)
         {
-            var flagMetadataCallback = expression.Compile();
             var kvp = new KeyValuePair<string, Func<ImmutableMetadata, object?>>(key, flagMetadataCallback);
 
             this._flagMetadataExpressions.Add(kvp);

--- a/test/OpenFeature.Tests/Hooks/MetricsHookOptionsTests.cs
+++ b/test/OpenFeature.Tests/Hooks/MetricsHookOptionsTests.cs
@@ -1,0 +1,84 @@
+using OpenFeature.Hooks;
+using OpenFeature.Model;
+
+namespace OpenFeature.Tests.Hooks;
+
+public class MetricsHookOptionsTests
+{
+    [Fact]
+    public void Default_Options_Should_Be_Initialized_Correctly()
+    {
+        // Arrange & Act
+        var options = MetricsHookOptions.Default;
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.Empty(options.CustomDimensions);
+        Assert.Empty(options.FlagMetadataCallbacks);
+    }
+
+    [Fact]
+    public void CreateBuilder_Should_Return_New_Builder_Instance()
+    {
+        // Arrange & Act
+        var builder = MetricsHookOptions.CreateBuilder();
+
+        // Assert
+        Assert.NotNull(builder);
+        Assert.IsType<MetricsHookOptions.MetricsHookOptionsBuilder>(builder);
+    }
+
+    [Fact]
+    public void Build_Should_Return_Options()
+    {
+        // Arrange
+        var builder = MetricsHookOptions.CreateBuilder();
+
+        // Act
+        var options = builder.Build();
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.IsType<MetricsHookOptions>(options);
+    }
+
+    [Theory]
+    [InlineData("custom_dimension_value")]
+    [InlineData(1.0)]
+    [InlineData(2025)]
+    [InlineData(null)]
+    [InlineData(true)]
+    public void Builder_Should_Allow_Adding_Custom_Dimensions(object? value)
+    {
+        // Arrange
+        var builder = MetricsHookOptions.CreateBuilder();
+        var key = "custom_dimension_key";
+
+        // Act
+        builder.WithCustomDimension(key, value);
+        var options = builder.Build();
+
+        // Assert
+        Assert.Single(options.CustomDimensions);
+        Assert.Equal(key, options.CustomDimensions.First().Key);
+        Assert.Equal(value, options.CustomDimensions.First().Value);
+    }
+
+    [Fact]
+    public void Builder_Should_Allow_Adding_Flag_Metadata_Expressions()
+    {
+        // Arrange
+        var builder = MetricsHookOptions.CreateBuilder();
+        var key = "flag_metadata_key";
+        static object? expression(ImmutableMetadata m) => m.GetString("flag_metadata_key");
+
+        // Act
+        builder.WithFlagEvaluationMetadata(key, expression);
+        var options = builder.Build();
+
+        // Assert
+        Assert.Single(options.FlagMetadataCallbacks);
+        Assert.Equal(key, options.FlagMetadataCallbacks.First().Key);
+        Assert.Equal(expression, options.FlagMetadataCallbacks.First().Value);
+    }
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Adds new `MetricsHookOptions` and `MetricsHookOptionsBuilder` to  optionally configure custom attributes that can be tagged on the `feature_flag.evaluation_success_total` metric. Example usage:

```csharp
var options = MetricsHookOptions.CreateBuilder()
    .WithCustomDimension("custom_dimension_key", "custom_dimension_value")
    .WithFlagEvaluationMetadata("boolean", s => s.GetBool("boolean"))
    .Build();

OpenFeature.Api.Instance.AddHooks(new MetricsHook(options));
```

Screenshot below shows the AspNetCore sample application tagging the `feature_flag.evaluation_success_total` counter with the specified dimensions.

![image](https://github.com/user-attachments/assets/e8cda7d8-404a-4d54-96a5-066188d5c18a)


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #509

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

