### PR TITLE
feat: Add Hook Dependency Injection extension method with Hook instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ builder.Services.AddOpenFeature(featureBuilder => {
         .AddHostedFeatureLifecycle()
         .AddContext((contextBuilder, serviceProvider) => { /* Custom context configuration */ })
         .AddHook((serviceProvider) => new LoggingHook( /* Custom configuration */ ))
+        .AddHook(new MetricsHook())
         .AddInMemoryProvider("name1")
         .AddInMemoryProvider("name2")
         .AddPolicyName(options => {

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -302,11 +302,7 @@ public static partial class OpenFeatureBuilderExtensions
     public static OpenFeatureBuilder AddHook<THook>(this OpenFeatureBuilder builder, string hookName, THook hook)
         where THook : Hook
     {
-        builder.Services.PostConfigure<OpenFeatureOptions>(options => options.AddHookName(hookName));
-
-        builder.Services.TryAddKeyedSingleton<Hook>(hookName, hook);
-
-        return builder;
+        return builder.AddHook(hookName, _ => hook);
     }
 
     /// <summary>

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -279,6 +279,37 @@ public static partial class OpenFeatureBuilderExtensions
     }
 
     /// <summary>
+    /// Adds a feature hook to the service collection. Hooks added here are not domain-bound.
+    /// </summary>
+    /// <typeparam name="THook">The type of<see cref="Hook"/> to be added.</typeparam>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance.</param>
+    /// <param name="hook">Instance of Hook to inject into the OpenFeature context.</param>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance.</returns>
+    public static OpenFeatureBuilder AddHook<THook>(this OpenFeatureBuilder builder, THook hook)
+        where THook : Hook
+    {
+        return builder.AddHook(typeof(THook).Name, _ => hook);
+    }
+
+    /// <summary>
+    /// Adds a feature hook to the service collection with a specified name. Hooks added here are not domain-bound.
+    /// </summary>
+    /// <typeparam name="THook">The type of<see cref="Hook"/> to be added.</typeparam>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance.</param>
+    /// <param name="hookName">The name of the <see cref="Hook"/> that is being added.</param>
+    /// <param name="hook">Instance of Hook to inject into the OpenFeature context.</param>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance.</returns>
+    public static OpenFeatureBuilder AddHook<THook>(this OpenFeatureBuilder builder, string hookName, THook hook)
+        where THook : Hook
+    {
+        builder.Services.PostConfigure<OpenFeatureOptions>(options => options.AddHookName(hookName));
+
+        builder.Services.TryAddKeyedSingleton<Hook, THook>(hook);
+
+        return builder;
+    }
+
+    /// <summary>
     /// Adds a feature hook to the service collection using a factory method and specified name. Hooks added here are not domain-bound.
     /// </summary>
     /// <typeparam name="THook">The type of<see cref="Hook"/> to be added.</typeparam>

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -288,7 +288,7 @@ public static partial class OpenFeatureBuilderExtensions
     public static OpenFeatureBuilder AddHook<THook>(this OpenFeatureBuilder builder, THook hook)
         where THook : Hook
     {
-        return builder.AddHook(typeof(THook).Name, _ => hook);
+        return builder.AddHook(typeof(THook).Name, hook);
     }
 
     /// <summary>

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -304,7 +304,7 @@ public static partial class OpenFeatureBuilderExtensions
     {
         builder.Services.PostConfigure<OpenFeatureOptions>(options => options.AddHookName(hookName));
 
-        builder.Services.TryAddKeyedSingleton<Hook, THook>(hook);
+        builder.Services.TryAddKeyedSingleton<Hook>(hookName, hook);
 
         return builder;
     }

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -303,6 +303,40 @@ public partial class OpenFeatureBuilderExtensionsTests
     }
 
     [Fact]
+    public void AddHook_WithInstance_AddsHookAsKeyedService()
+    {
+        // Arrange
+        var expectedHook = new NoOpHook();
+        _systemUnderTest.AddHook(expectedHook);
+
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Act
+        var actualHook = serviceProvider.GetKeyedService<Hook>("NoOpHook");
+
+        // Assert
+        Assert.NotNull(actualHook);
+        Assert.Equal(expectedHook, actualHook);
+    }
+
+    [Fact]
+    public void AddHook_WithSpecifiedNameAndInstance_AddsHookAsKeyedService()
+    {
+        // Arrange
+        var expectedHook = new NoOpHook();
+        _systemUnderTest.AddHook("custom-hook", expectedHook);
+
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Act
+        var actualHook = serviceProvider.GetKeyedService<Hook>("custom-hook");
+
+        // Assert
+        Assert.NotNull(actualHook);
+        Assert.Equal(expectedHook, actualHook);
+    }
+
+    [Fact]
     public void AddHandler_AddsEventHandlerDelegateWrapperAsKeyedService()
     {
         // Arrange


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

In #512 I needed to tweak the sample AspNetCore application to pass Hook options to the MetricsHook. I noticed that in order to pass the options I needed to use the delegate based approach, while discarding the `serviceProvider`, like:

```csharp
featureBuilder.AddHostedFeatureLifecycle()
        .AddHook(_ => new MetricsHook(metricsHookOptions))
```

It would be simpler and easier for devs to interact with a third overload that allows them to pass an instance of the hook that they want to interact with, like so:

```csharp
featureBuilder.AddHostedFeatureLifecycle()
    .AddHook(new MetricsHook())
```

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

