### PR TITLE
chore: Add comparison to Value

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,13 +10,19 @@
 
   <ItemGroup Label="src">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"
+      Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions"
+      Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+      Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"
+      Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Collections.Immutable" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource"
+      Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.Channels" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
   </ItemGroup>

--- a/src/OpenFeature/OpenFeature.csproj
+++ b/src/OpenFeature/OpenFeature.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>

--- a/test/OpenFeature.Tests/ValueTests.cs
+++ b/test/OpenFeature.Tests/ValueTests.cs
@@ -230,4 +230,561 @@ public class ValueTests
         // Assert
         Assert.Null(actualValue);
     }
+
+    #region Equality Tests
+
+    [Fact]
+    public void Equals_WithNullValue_ReturnsFalse()
+    {
+        // Arrange
+        var value = new Value("test");
+
+        // Act & Assert
+        Assert.False(value.Equals((Value?)null));
+    }
+
+    [Fact]
+    public void Equals_WithSameReference_ReturnsTrue()
+    {
+        // Arrange
+        var value = new Value("test");
+
+        // Act & Assert
+        Assert.True(value.Equals(value));
+    }
+
+    [Fact]
+    public void Equals_WithBothNull_ReturnsTrue()
+    {
+        // Arrange
+        var value1 = new Value();
+        var value2 = new Value();
+
+        // Act & Assert
+        Assert.True(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithOneNullOneNotNull_ReturnsFalse()
+    {
+        // Arrange
+        var nullValue = new Value();
+        var stringValue = new Value("test");
+
+        // Act & Assert
+        Assert.False(nullValue.Equals(stringValue));
+        Assert.False(stringValue.Equals(nullValue));
+    }
+
+    [Fact]
+    public void Equals_WithDifferentTypes_ReturnsFalse()
+    {
+        // Arrange
+        var stringValue = new Value("test");
+        var intValue = new Value(42);
+        var boolValue = new Value(true);
+
+        // Act & Assert
+        Assert.False(stringValue.Equals(intValue));
+        Assert.False(stringValue.Equals(boolValue));
+        Assert.False(intValue.Equals(boolValue));
+    }
+
+    [Fact]
+    public void Equals_WithSameStringValues_ReturnsTrue()
+    {
+        // Arrange
+        var value1 = new Value("test");
+        var value2 = new Value("test");
+
+        // Act & Assert
+        Assert.True(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithDifferentStringValues_ReturnsFalse()
+    {
+        // Arrange
+        var value1 = new Value("test1");
+        var value2 = new Value("test2");
+
+        // Act & Assert
+        Assert.False(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithSameBooleanValues_ReturnsTrue()
+    {
+        // Arrange
+        var value1 = new Value(true);
+        var value2 = new Value(true);
+        var value3 = new Value(false);
+        var value4 = new Value(false);
+
+        // Act & Assert
+        Assert.True(value1.Equals(value2));
+        Assert.True(value3.Equals(value4));
+    }
+
+    [Fact]
+    public void Equals_WithDifferentBooleanValues_ReturnsFalse()
+    {
+        // Arrange
+        var value1 = new Value(true);
+        var value2 = new Value(false);
+
+        // Act & Assert
+        Assert.False(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithSameNumberValues_ReturnsTrue()
+    {
+        // Arrange
+        var value1 = new Value(42.5);
+        var value2 = new Value(42.5);
+        var intValue1 = new Value(42);
+        var intValue2 = new Value(42);
+
+        // Act & Assert
+        Assert.True(value1.Equals(value2));
+        Assert.True(intValue1.Equals(intValue2));
+    }
+
+    [Fact]
+    public void Equals_WithDifferentNumberValues_ReturnsFalse()
+    {
+        // Arrange
+        var value1 = new Value(42.5);
+        var value2 = new Value(42.6);
+
+        // Act & Assert
+        Assert.False(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithSameDateTimeValues_ReturnsTrue()
+    {
+        // Arrange
+        var dateTime = DateTime.Now;
+        var value1 = new Value(dateTime);
+        var value2 = new Value(dateTime);
+
+        // Act & Assert
+        Assert.True(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithDifferentDateTimeValues_ReturnsFalse()
+    {
+        // Arrange
+        var value1 = new Value(DateTime.Now);
+        var value2 = new Value(DateTime.Now.AddDays(1));
+
+        // Act & Assert
+        Assert.False(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithSameStructureValues_ReturnsTrue()
+    {
+        // Arrange
+        var structure1 = Structure.Builder()
+            .Set("key1", new Value("value1"))
+            .Set("key2", new Value(42))
+            .Build();
+        var structure2 = Structure.Builder()
+            .Set("key1", new Value("value1"))
+            .Set("key2", new Value(42))
+            .Build();
+        var value1 = new Value(structure1);
+        var value2 = new Value(structure2);
+
+        // Act & Assert
+        Assert.True(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithDifferentStructureValues_ReturnsFalse()
+    {
+        // Arrange
+        var structure1 = Structure.Builder()
+            .Set("key1", new Value("value1"))
+            .Build();
+        var structure2 = Structure.Builder()
+            .Set("key1", new Value("value2"))
+            .Build();
+        var value1 = new Value(structure1);
+        var value2 = new Value(structure2);
+
+        // Act & Assert
+        Assert.False(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithStructuresDifferentKeyCounts_ReturnsFalse()
+    {
+        // Arrange
+        var structure1 = Structure.Builder()
+            .Set("key1", new Value("value1"))
+            .Build();
+        var structure2 = Structure.Builder()
+            .Set("key1", new Value("value1"))
+            .Set("key2", new Value("value2"))
+            .Build();
+        var value1 = new Value(structure1);
+        var value2 = new Value(structure2);
+
+        // Act & Assert
+        Assert.False(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithSameListValues_ReturnsTrue()
+    {
+        // Arrange
+        var list1 = new List<Value> { new Value("test"), new Value(42), new Value(true) };
+        var list2 = new List<Value> { new Value("test"), new Value(42), new Value(true) };
+        var value1 = new Value(list1);
+        var value2 = new Value(list2);
+
+        // Act & Assert
+        Assert.True(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithDifferentListValues_ReturnsFalse()
+    {
+        // Arrange
+        var list1 = new List<Value> { new Value("test1"), new Value(42) };
+        var list2 = new List<Value> { new Value("test2"), new Value(42) };
+        var value1 = new Value(list1);
+        var value2 = new Value(list2);
+
+        // Act & Assert
+        Assert.False(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithListsDifferentLengths_ReturnsFalse()
+    {
+        // Arrange
+        var list1 = new List<Value> { new Value("test") };
+        var list2 = new List<Value> { new Value("test"), new Value(42) };
+        var value1 = new Value(list1);
+        var value2 = new Value(list2);
+
+        // Act & Assert
+        Assert.False(value1.Equals(value2));
+    }
+
+    [Fact]
+    public void Equals_WithObject_CallsTypedEquals()
+    {
+        // Arrange
+        var value1 = new Value("test");
+        var value2 = new Value("test");
+        object obj = value2;
+
+        // Act & Assert
+        Assert.True(value1.Equals(obj));
+    }
+
+    [Fact]
+    public void Equals_WithNonValueObject_ReturnsFalse()
+    {
+        // Arrange
+        var value = new Value("test");
+        object obj = "test";
+
+        // Act & Assert
+        Assert.False(value.Equals(obj));
+    }
+
+    #endregion
+
+    #region Operator Tests
+
+    [Fact]
+    public void OperatorEquals_WithBothNull_ReturnsTrue()
+    {
+        // Arrange
+        Value? value1 = null;
+        Value? value2 = null;
+
+        // Act & Assert
+        Assert.True(value1 == value2);
+    }
+
+    [Fact]
+    public void OperatorEquals_WithOneNull_ReturnsFalse()
+    {
+        // Arrange
+        Value? value1 = null;
+        Value value2 = new Value("test");
+
+        // Act & Assert
+        Assert.False(value1 == value2);
+        Assert.False(value2 == value1);
+    }
+
+    [Fact]
+    public void OperatorEquals_WithEqualValues_ReturnsTrue()
+    {
+        // Arrange
+        var value1 = new Value("test");
+        var value2 = new Value("test");
+
+        // Act & Assert
+        Assert.True(value1 == value2);
+    }
+
+    [Fact]
+    public void OperatorEquals_WithDifferentValues_ReturnsFalse()
+    {
+        // Arrange
+        var value1 = new Value("test1");
+        var value2 = new Value("test2");
+
+        // Act & Assert
+        Assert.False(value1 == value2);
+    }
+
+    [Fact]
+    public void OperatorNotEquals_WithEqualValues_ReturnsFalse()
+    {
+        // Arrange
+        var value1 = new Value("test");
+        var value2 = new Value("test");
+
+        // Act & Assert
+        Assert.False(value1 != value2);
+    }
+
+    [Fact]
+    public void OperatorNotEquals_WithDifferentValues_ReturnsTrue()
+    {
+        // Arrange
+        var value1 = new Value("test1");
+        var value2 = new Value("test2");
+
+        // Act & Assert
+        Assert.True(value1 != value2);
+    }
+
+    #endregion
+
+    #region GetHashCode Tests
+
+    [Fact]
+    public void GetHashCode_WithNullValue_ReturnsZero()
+    {
+        // Arrange
+        var value = new Value();
+
+        // Act
+        var hashCode = value.GetHashCode();
+
+        // Assert
+        Assert.Equal(0, hashCode);
+    }
+
+    [Fact]
+    public void GetHashCode_WithEqualValues_ReturnsSameHashCode()
+    {
+        // Arrange
+        var value1 = new Value("test");
+        var value2 = new Value("test");
+
+        // Act
+        var hashCode1 = value1.GetHashCode();
+        var hashCode2 = value2.GetHashCode();
+
+        // Assert
+        Assert.Equal(hashCode1, hashCode2);
+    }
+
+    [Fact]
+    public void GetHashCode_WithBooleanValues_ReturnsConsistentHashCode()
+    {
+        // Arrange
+        var value1 = new Value(true);
+        var value2 = new Value(true);
+        var value3 = new Value(false);
+
+        // Act
+        var hashCode1 = value1.GetHashCode();
+        var hashCode2 = value2.GetHashCode();
+        var hashCode3 = value3.GetHashCode();
+
+        // Assert
+        Assert.Equal(hashCode1, hashCode2);
+        Assert.NotEqual(hashCode1, hashCode3);
+    }
+
+    [Fact]
+    public void GetHashCode_WithNumberValues_ReturnsConsistentHashCode()
+    {
+        // Arrange
+        var value1 = new Value(42.5);
+        var value2 = new Value(42.5);
+        var value3 = new Value(42.6);
+
+        // Act
+        var hashCode1 = value1.GetHashCode();
+        var hashCode2 = value2.GetHashCode();
+        var hashCode3 = value3.GetHashCode();
+
+        // Assert
+        Assert.Equal(hashCode1, hashCode2);
+        Assert.NotEqual(hashCode1, hashCode3);
+    }
+
+    [Fact]
+    public void GetHashCode_WithStringValues_ReturnsConsistentHashCode()
+    {
+        // Arrange
+        var value1 = new Value("test");
+        var value2 = new Value("test");
+        var value3 = new Value("different");
+
+        // Act
+        var hashCode1 = value1.GetHashCode();
+        var hashCode2 = value2.GetHashCode();
+        var hashCode3 = value3.GetHashCode();
+
+        // Assert
+        Assert.Equal(hashCode1, hashCode2);
+        Assert.NotEqual(hashCode1, hashCode3);
+    }
+
+    [Fact]
+    public void GetHashCode_WithDateTimeValues_ReturnsConsistentHashCode()
+    {
+        // Arrange
+        var dateTime = DateTime.Now;
+        var value1 = new Value(dateTime);
+        var value2 = new Value(dateTime);
+        var value3 = new Value(dateTime.AddDays(1));
+
+        // Act
+        var hashCode1 = value1.GetHashCode();
+        var hashCode2 = value2.GetHashCode();
+        var hashCode3 = value3.GetHashCode();
+
+        // Assert
+        Assert.Equal(hashCode1, hashCode2);
+        Assert.NotEqual(hashCode1, hashCode3);
+    }
+
+    [Fact]
+    public void GetHashCode_WithStructureValues_ReturnsConsistentHashCode()
+    {
+        // Arrange
+        var structure1 = Structure.Builder()
+            .Set("key1", new Value("value1"))
+            .Set("key2", new Value(42))
+            .Build();
+        var structure2 = Structure.Builder()
+            .Set("key1", new Value("value1"))
+            .Set("key2", new Value(42))
+            .Build();
+        var value1 = new Value(structure1);
+        var value2 = new Value(structure2);
+
+        // Act
+        var hashCode1 = value1.GetHashCode();
+        var hashCode2 = value2.GetHashCode();
+
+        // Assert
+        Assert.Equal(hashCode1, hashCode2);
+    }
+
+    [Fact]
+    public void GetHashCode_WithListValues_ReturnsConsistentHashCode()
+    {
+        // Arrange
+        var list1 = new List<Value> { new Value("test"), new Value(42) };
+        var list2 = new List<Value> { new Value("test"), new Value(42) };
+        var value1 = new Value(list1);
+        var value2 = new Value(list2);
+
+        // Act
+        var hashCode1 = value1.GetHashCode();
+        var hashCode2 = value2.GetHashCode();
+
+        // Assert
+        Assert.Equal(hashCode1, hashCode2);
+    }
+
+    #endregion
+
+    #region Complex Nested Tests
+
+    [Fact]
+    public void Equals_WithNestedStructuresAndLists_ReturnsTrue()
+    {
+        // Arrange
+        var innerList1 = new List<Value> { new Value("nested"), new Value(123) };
+        var innerList2 = new List<Value> { new Value("nested"), new Value(123) };
+
+        var innerStructure1 = Structure.Builder()
+            .Set("nested_key", new Value("nested_value"))
+            .Set("nested_list", new Value(innerList1))
+            .Build();
+        var innerStructure2 = Structure.Builder()
+            .Set("nested_key", new Value("nested_value"))
+            .Set("nested_list", new Value(innerList2))
+            .Build();
+
+        var outerStructure1 = Structure.Builder()
+            .Set("outer_key", new Value("outer_value"))
+            .Set("inner", new Value(innerStructure1))
+            .Build();
+        var outerStructure2 = Structure.Builder()
+            .Set("outer_key", new Value("outer_value"))
+            .Set("inner", new Value(innerStructure2))
+            .Build();
+
+        var value1 = new Value(outerStructure1);
+        var value2 = new Value(outerStructure2);
+
+        // Act & Assert
+        Assert.True(value1.Equals(value2));
+        Assert.Equal(value1.GetHashCode(), value2.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_WithDeeplyNestedDifferences_ReturnsFalse()
+    {
+        // Arrange
+        var innerList1 = new List<Value> { new Value("nested"), new Value(123) };
+        var innerList2 = new List<Value> { new Value("nested"), new Value(124) }; // Different value
+
+        var innerStructure1 = Structure.Builder()
+            .Set("nested_key", new Value("nested_value"))
+            .Set("nested_list", new Value(innerList1))
+            .Build();
+        var innerStructure2 = Structure.Builder()
+            .Set("nested_key", new Value("nested_value"))
+            .Set("nested_list", new Value(innerList2))
+            .Build();
+
+        var outerStructure1 = Structure.Builder()
+            .Set("outer_key", new Value("outer_value"))
+            .Set("inner", new Value(innerStructure1))
+            .Build();
+        var outerStructure2 = Structure.Builder()
+            .Set("outer_key", new Value("outer_value"))
+            .Set("inner", new Value(innerStructure2))
+            .Build();
+
+        var value1 = new Value(outerStructure1);
+        var value2 = new Value(outerStructure2);
+
+        // Act & Assert
+        Assert.False(value1.Equals(value2));
+    }
+
+    #endregion
 }

--- a/test/OpenFeature.Tests/ValueTests.cs
+++ b/test/OpenFeature.Tests/ValueTests.cs
@@ -240,7 +240,7 @@ public class ValueTests
         var value = new Value("test");
 
         // Act & Assert
-        Assert.False(value.Equals((Value?)null));
+        Assert.False(value.Equals(null));
     }
 
     [Fact]
@@ -443,8 +443,8 @@ public class ValueTests
     public void Equals_WithSameListValues_ReturnsTrue()
     {
         // Arrange
-        var list1 = new List<Value> { new Value("test"), new Value(42), new Value(true) };
-        var list2 = new List<Value> { new Value("test"), new Value(42), new Value(true) };
+        var list1 = new List<Value> { new("test"), new(42), new(true) };
+        var list2 = new List<Value> { new("test"), new(42), new(true) };
         var value1 = new Value(list1);
         var value2 = new Value(list2);
 
@@ -456,8 +456,8 @@ public class ValueTests
     public void Equals_WithDifferentListValues_ReturnsFalse()
     {
         // Arrange
-        var list1 = new List<Value> { new Value("test1"), new Value(42) };
-        var list2 = new List<Value> { new Value("test2"), new Value(42) };
+        var list1 = new List<Value> { new("test1"), new(42) };
+        var list2 = new List<Value> { new("test2"), new(42) };
         var value1 = new Value(list1);
         var value2 = new Value(list2);
 
@@ -469,8 +469,8 @@ public class ValueTests
     public void Equals_WithListsDifferentLengths_ReturnsFalse()
     {
         // Arrange
-        var list1 = new List<Value> { new Value("test") };
-        var list2 = new List<Value> { new Value("test"), new Value(42) };
+        var list1 = new List<Value> { new("test") };
+        var list2 = new List<Value> { new("test"), new(42) };
         var value1 = new Value(list1);
         var value2 = new Value(list2);
 
@@ -704,8 +704,8 @@ public class ValueTests
     public void GetHashCode_WithListValues_ReturnsConsistentHashCode()
     {
         // Arrange
-        var list1 = new List<Value> { new Value("test"), new Value(42) };
-        var list2 = new List<Value> { new Value("test"), new Value(42) };
+        var list1 = new List<Value> { new("test"), new(42) };
+        var list2 = new List<Value> { new("test"), new(42) };
         var value1 = new Value(list1);
         var value2 = new Value(list2);
 
@@ -725,8 +725,8 @@ public class ValueTests
     public void Equals_WithNestedStructuresAndLists_ReturnsTrue()
     {
         // Arrange
-        var innerList1 = new List<Value> { new Value("nested"), new Value(123) };
-        var innerList2 = new List<Value> { new Value("nested"), new Value(123) };
+        var innerList1 = new List<Value> { new("nested"), new(123) };
+        var innerList2 = new List<Value> { new("nested"), new(123) };
 
         var innerStructure1 = Structure.Builder()
             .Set("nested_key", new Value("nested_value"))
@@ -758,8 +758,8 @@ public class ValueTests
     public void Equals_WithDeeplyNestedDifferences_ReturnsFalse()
     {
         // Arrange
-        var innerList1 = new List<Value> { new Value("nested"), new Value(123) };
-        var innerList2 = new List<Value> { new Value("nested"), new Value(124) }; // Different value
+        var innerList1 = new List<Value> { new("nested"), new(123) };
+        var innerList2 = new List<Value> { new("nested"), new(124) }; // Different value
 
         var innerStructure1 = Structure.Builder()
             .Set("nested_key", new Value("nested_value"))


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request introduces enhancements to the `Value` class in the `OpenFeature.Model` namespace, ensuring better equality handling, and updates dependencies to include `Microsoft.Bcl.HashCode`. The most significant changes include implementing equality comparison for `Value`, adding hash code generation, and updating project files to include the new dependency.

### Enhancements to `Value` class:

* [`src/OpenFeature/Model/Value.cs`](diffhunk://#diff-336aacd3c42458899187108a2064648ae21e439b2b11e6ca7f25b7b7fef00609L9-R9): The `Value` class now implements `IEquatable<Value>` and includes methods for equality comparison (`Equals`, `==`, `!=`), hash code generation (`GetHashCode`), and internal helpers for comparing complex types like structures and lists. This ensures more robust and consistent equality checks. [[1]](diffhunk://#diff-336aacd3c42458899187108a2064648ae21e439b2b11e6ca7f25b7b7fef00609L9-R9) [[2]](diffhunk://#diff-336aacd3c42458899187108a2064648ae21e439b2b11e6ca7f25b7b7fef00609R187-R378)

### Dependency updates:

* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L13-R25): Added `Microsoft.Bcl.HashCode` as a dependency for hash code generation. Other package references were reformatted for consistency.
* [`src/OpenFeature/OpenFeature.csproj`](diffhunk://#diff-711ea17cbdebe419375c7684c8c39a1423d2bebcf8976ddd7bdd78deaab65b21R11): Included `Microsoft.Bcl.HashCode` for specific target frameworks (`net462` and `netstandard2.0`).

### Notes
<!-- any additional notes for this PR -->
This implementation is necessary for the comparison in the MultiProvider. See: https://github.com/open-feature/dotnet-sdk/pull/488#discussion_r2201848459