### PR TITLE
feat: Add TraceEnricherHookOptions Custom Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,17 +604,17 @@ namespace OpenFeatureTestApp
 
 After running this example, you will be able to see the traces, including the events sent by the hook in your Jaeger UI.
 
-You can specify custom dimensions on spans created by the `TraceEnricherHook` by providing `TraceEnricherHookOptions` when adding the hook:
+You can specify custom tags on spans created by the `TraceEnricherHook` by providing `TraceEnricherHookOptions` when adding the hook:
 
 ```csharp
 var options = TraceEnricherHookOptions.CreateBuilder()
-    .WithCustomDimension("custom_dimension_key", "custom_dimension_value")
+    .WithTag("custom_dimension_key", "custom_dimension_value")
     .Build();
 
 OpenFeature.Api.Instance.AddHooks(new TraceEnricherHook(options));
 ```
 
-You can also write your own extraction logic against the Flag metadata by providing a callback to `WithFlagEvaluationMetadata`.
+You can also write your own extraction logic against the Flag metadata by providing a callback to `WithFlagEvaluationMetadata`. The below example will add a tag to the span with the key `boolean` and a value specified by the callback.
 
 ```csharp
 var options = TraceEnricherHookOptions.CreateBuilder()

--- a/README.md
+++ b/README.md
@@ -604,6 +604,24 @@ namespace OpenFeatureTestApp
 
 After running this example, you will be able to see the traces, including the events sent by the hook in your Jaeger UI.
 
+You can specify custom dimensions on spans created by the `TraceEnricherHook` by providing `TraceEnricherHookOptions` when adding the hook:
+
+```csharp
+var options = TraceEnricherHookOptions.CreateBuilder()
+    .WithCustomDimension("custom_dimension_key", "custom_dimension_value")
+    .Build();
+
+OpenFeature.Api.Instance.AddHooks(new TraceEnricherHook(options));
+```
+
+You can also write your own extraction logic against the Flag metadata by providing a callback to `WithFlagEvaluationMetadata`.
+
+```csharp
+var options = TraceEnricherHookOptions.CreateBuilder()
+    .WithFlagEvaluationMetadata("boolean", s => s.GetBool("boolean"))
+    .Build();
+```
+
 ### Metrics Hook
 
 For this hook to function correctly a global `MeterProvider` must be set.

--- a/src/OpenFeature/Hooks/TraceEnricherHook.cs
+++ b/src/OpenFeature/Hooks/TraceEnricherHook.cs
@@ -42,23 +42,23 @@ public class TraceEnricherHook : Hook
             tags[kvp.Key] = kvp.Value;
         }
 
-        this.AddCustomDimensions(tags);
-        this.AddFlagMetadataDimensions(details.FlagMetadata, tags);
+        this.AddCustomTags(tags);
+        this.AddFlagMetadataTags(details.FlagMetadata, tags);
 
         Activity.Current?.AddEvent(new ActivityEvent(evaluationEvent.Name, tags: tags));
 
         return base.FinallyAsync(context, details, hints, cancellationToken);
     }
 
-    private void AddCustomDimensions(ActivityTagsCollection tagList)
+    private void AddCustomTags(ActivityTagsCollection tagList)
     {
-        foreach (var customDimension in this._options.CustomDimensions)
+        foreach (var customDimension in this._options.Tags)
         {
             tagList.Add(customDimension.Key, customDimension.Value);
         }
     }
 
-    private void AddFlagMetadataDimensions(ImmutableMetadata? flagMetadata, ActivityTagsCollection tagList)
+    private void AddFlagMetadataTags(ImmutableMetadata? flagMetadata, ActivityTagsCollection tagList)
     {
         flagMetadata ??= new ImmutableMetadata();
 

--- a/src/OpenFeature/Hooks/TraceEnricherHookOptions.cs
+++ b/src/OpenFeature/Hooks/TraceEnricherHookOptions.cs
@@ -13,9 +13,9 @@ public sealed class TraceEnricherHookOptions
     public static TraceEnricherHookOptions Default { get; } = new TraceEnricherHookOptions();
 
     /// <summary>
-    /// Custom dimensions or tags to be associated with current <see cref="System.Diagnostics.Activity"/> in <see cref="TraceEnricherHook"/>.
+    /// Custom tags to be associated with current <see cref="System.Diagnostics.Activity"/> in <see cref="TraceEnricherHook"/>.
     /// </summary>
-    public IReadOnlyCollection<KeyValuePair<string, object?>> CustomDimensions { get; }
+    public IReadOnlyCollection<KeyValuePair<string, object?>> Tags { get; }
 
     /// <summary>
     /// Flag metadata callbacks to be associated with current <see cref="System.Diagnostics.Activity"/>.
@@ -32,12 +32,12 @@ public sealed class TraceEnricherHookOptions
     /// <summary>
     /// Initializes a new instance of the <see cref="TraceEnricherHookOptions"/> class.
     /// </summary>
-    /// <param name="customDimensions">Optional custom dimensions to tag Counter increments with.</param>
+    /// <param name="tags">Optional custom tags to tag Counter increments with.</param>
     /// <param name="flagMetadataSelectors">Optional flag metadata callbacks to be associated with current <see cref="System.Diagnostics.Activity"/>.</param>
-    internal TraceEnricherHookOptions(IReadOnlyCollection<KeyValuePair<string, object?>>? customDimensions = null,
+    internal TraceEnricherHookOptions(IReadOnlyCollection<KeyValuePair<string, object?>>? tags = null,
         IReadOnlyCollection<KeyValuePair<string, Func<ImmutableMetadata, object?>>>? flagMetadataSelectors = null)
     {
-        this.CustomDimensions = customDimensions ?? [];
+        this.Tags = tags ?? [];
         this.FlagMetadataCallbacks = flagMetadataSelectors ?? [];
     }
 
@@ -51,24 +51,24 @@ public sealed class TraceEnricherHookOptions
     /// </summary>
     public sealed class TraceEnricherHookOptionsBuilder
     {
-        private readonly List<KeyValuePair<string, object?>> _customDimensions = new List<KeyValuePair<string, object?>>();
+        private readonly List<KeyValuePair<string, object?>> _customTags = new List<KeyValuePair<string, object?>>();
         private readonly List<KeyValuePair<string, Func<ImmutableMetadata, object?>>> _flagMetadataExpressions = new List<KeyValuePair<string, Func<ImmutableMetadata, object?>>>();
 
         /// <summary>
-        /// Adds a custom dimension.
+        /// Adds a custom tag to the <see cref="TraceEnricherHookOptionsBuilder"/>.
         /// </summary>
         /// <param name="key">The key for the custom dimension.</param>
         /// <param name="value">The value for the custom dimension.</param>
-        public TraceEnricherHookOptionsBuilder WithCustomDimension(string key, object? value)
+        public TraceEnricherHookOptionsBuilder WithTag(string key, object? value)
         {
-            this._customDimensions.Add(new KeyValuePair<string, object?>(key, value));
+            this._customTags.Add(new KeyValuePair<string, object?>(key, value));
             return this;
         }
 
         /// <summary>
-        /// Provide a callback to evaluate flag metadata and add it as a custom dimension on the current <see cref="System.Diagnostics.Activity"/>.
+        /// Provide a callback to evaluate flag metadata and add it as a custom tag on the current <see cref="System.Diagnostics.Activity"/>.
         /// </summary>
-        /// <param name="key">The key for the custom dimension.</param>
+        /// <param name="key">The key for the custom tag.</param>
         /// <param name="flagMetadataCallback">The callback to retrieve the value to tag successful flag evaluations.</param>
         /// <returns></returns>
         public TraceEnricherHookOptionsBuilder WithFlagEvaluationMetadata(string key, Func<ImmutableMetadata, object?> flagMetadataCallback)
@@ -85,7 +85,7 @@ public sealed class TraceEnricherHookOptions
         /// </summary>
         public TraceEnricherHookOptions Build()
         {
-            return new TraceEnricherHookOptions(this._customDimensions.AsReadOnly(), this._flagMetadataExpressions.AsReadOnly());
+            return new TraceEnricherHookOptions(this._customTags.AsReadOnly(), this._flagMetadataExpressions.AsReadOnly());
         }
     }
 }

--- a/src/OpenFeature/Hooks/TraceEnricherHookOptions.cs
+++ b/src/OpenFeature/Hooks/TraceEnricherHookOptions.cs
@@ -1,0 +1,91 @@
+using OpenFeature.Model;
+
+namespace OpenFeature.Hooks;
+
+/// <summary>
+/// Configuration options for the <see cref="TraceEnricherHookOptions"/>.
+/// </summary>
+public sealed class TraceEnricherHookOptions
+{
+    /// <summary>
+    /// The default options for the <see cref="TraceEnricherHookOptions"/>.
+    /// </summary>
+    public static TraceEnricherHookOptions Default { get; } = new TraceEnricherHookOptions();
+
+    /// <summary>
+    /// Custom dimensions or tags to be associated with current <see cref="System.Diagnostics.Activity"/> in <see cref="TraceEnricherHook"/>.
+    /// </summary>
+    public IReadOnlyCollection<KeyValuePair<string, object?>> CustomDimensions { get; }
+
+    /// <summary>
+    /// Flag metadata callbacks to be associated with current <see cref="System.Diagnostics.Activity"/>.
+    /// </summary>
+    internal IReadOnlyCollection<KeyValuePair<string, Func<ImmutableMetadata, object?>>> FlagMetadataCallbacks { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TraceEnricherHookOptions"/> class with default values.
+    /// </summary>
+    private TraceEnricherHookOptions() : this(null, null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TraceEnricherHookOptions"/> class.
+    /// </summary>
+    /// <param name="customDimensions">Optional custom dimensions to tag Counter increments with.</param>
+    /// <param name="flagMetadataSelectors">Optional flag metadata callbacks to be associated with current <see cref="System.Diagnostics.Activity"/>.</param>
+    internal TraceEnricherHookOptions(IReadOnlyCollection<KeyValuePair<string, object?>>? customDimensions = null,
+        IReadOnlyCollection<KeyValuePair<string, Func<ImmutableMetadata, object?>>>? flagMetadataSelectors = null)
+    {
+        this.CustomDimensions = customDimensions ?? [];
+        this.FlagMetadataCallbacks = flagMetadataSelectors ?? [];
+    }
+
+    /// <summary>
+    /// Creates a new builder for <see cref="TraceEnricherHookOptions"/>.
+    /// </summary>
+    public static TraceEnricherHookOptionsBuilder CreateBuilder() => new TraceEnricherHookOptionsBuilder();
+
+    /// <summary>
+    /// A builder for constructing <see cref="TraceEnricherHookOptions"/> instances.
+    /// </summary>
+    public sealed class TraceEnricherHookOptionsBuilder
+    {
+        private readonly List<KeyValuePair<string, object?>> _customDimensions = new List<KeyValuePair<string, object?>>();
+        private readonly List<KeyValuePair<string, Func<ImmutableMetadata, object?>>> _flagMetadataExpressions = new List<KeyValuePair<string, Func<ImmutableMetadata, object?>>>();
+
+        /// <summary>
+        /// Adds a custom dimension.
+        /// </summary>
+        /// <param name="key">The key for the custom dimension.</param>
+        /// <param name="value">The value for the custom dimension.</param>
+        public TraceEnricherHookOptionsBuilder WithCustomDimension(string key, object? value)
+        {
+            this._customDimensions.Add(new KeyValuePair<string, object?>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Provide a callback to evaluate flag metadata and add it as a custom dimension on the current <see cref="System.Diagnostics.Activity"/>.
+        /// </summary>
+        /// <param name="key">The key for the custom dimension.</param>
+        /// <param name="flagMetadataCallback">The callback to retrieve the value to tag successful flag evaluations.</param>
+        /// <returns></returns>
+        public TraceEnricherHookOptionsBuilder WithFlagEvaluationMetadata(string key, Func<ImmutableMetadata, object?> flagMetadataCallback)
+        {
+            var kvp = new KeyValuePair<string, Func<ImmutableMetadata, object?>>(key, flagMetadataCallback);
+
+            this._flagMetadataExpressions.Add(kvp);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the <see cref="TraceEnricherHookOptions"/> instance.
+        /// </summary>
+        public TraceEnricherHookOptions Build()
+        {
+            return new TraceEnricherHookOptions(this._customDimensions.AsReadOnly(), this._flagMetadataExpressions.AsReadOnly());
+        }
+    }
+}

--- a/test/OpenFeature.Tests/Hooks/TraceEnricherHookOptionsTests.cs
+++ b/test/OpenFeature.Tests/Hooks/TraceEnricherHookOptionsTests.cs
@@ -13,7 +13,7 @@ public class TraceEnricherHookOptionsTests
 
         // Assert
         Assert.NotNull(options);
-        Assert.Empty(options.CustomDimensions);
+        Assert.Empty(options.Tags);
         Assert.Empty(options.FlagMetadataCallbacks);
     }
 
@@ -55,13 +55,13 @@ public class TraceEnricherHookOptionsTests
         var key = "custom_dimension_key";
 
         // Act
-        builder.WithCustomDimension(key, value);
+        builder.WithTag(key, value);
         var options = builder.Build();
 
         // Assert
-        Assert.Single(options.CustomDimensions);
-        Assert.Equal(key, options.CustomDimensions.First().Key);
-        Assert.Equal(value, options.CustomDimensions.First().Value);
+        Assert.Single(options.Tags);
+        Assert.Equal(key, options.Tags.First().Key);
+        Assert.Equal(value, options.Tags.First().Value);
     }
 
     [Fact]

--- a/test/OpenFeature.Tests/Hooks/TraceEnricherHookOptionsTests.cs
+++ b/test/OpenFeature.Tests/Hooks/TraceEnricherHookOptionsTests.cs
@@ -1,0 +1,84 @@
+using OpenFeature.Hooks;
+using OpenFeature.Model;
+
+namespace OpenFeature.Tests.Hooks;
+
+public class TraceEnricherHookOptionsTests
+{
+    [Fact]
+    public void Default_Options_Should_Be_Initialized_Correctly()
+    {
+        // Arrange & Act
+        var options = TraceEnricherHookOptions.Default;
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.Empty(options.CustomDimensions);
+        Assert.Empty(options.FlagMetadataCallbacks);
+    }
+
+    [Fact]
+    public void CreateBuilder_Should_Return_New_Builder_Instance()
+    {
+        // Arrange & Act
+        var builder = TraceEnricherHookOptions.CreateBuilder();
+
+        // Assert
+        Assert.NotNull(builder);
+        Assert.IsType<TraceEnricherHookOptions.TraceEnricherHookOptionsBuilder>(builder);
+    }
+
+    [Fact]
+    public void Build_Should_Return_Options()
+    {
+        // Arrange
+        var builder = TraceEnricherHookOptions.CreateBuilder();
+
+        // Act
+        var options = builder.Build();
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.IsType<TraceEnricherHookOptions>(options);
+    }
+
+    [Theory]
+    [InlineData("custom_dimension_value")]
+    [InlineData(1.0)]
+    [InlineData(2025)]
+    [InlineData(null)]
+    [InlineData(true)]
+    public void Builder_Should_Allow_Adding_Custom_Dimensions(object? value)
+    {
+        // Arrange
+        var builder = TraceEnricherHookOptions.CreateBuilder();
+        var key = "custom_dimension_key";
+
+        // Act
+        builder.WithCustomDimension(key, value);
+        var options = builder.Build();
+
+        // Assert
+        Assert.Single(options.CustomDimensions);
+        Assert.Equal(key, options.CustomDimensions.First().Key);
+        Assert.Equal(value, options.CustomDimensions.First().Value);
+    }
+
+    [Fact]
+    public void Builder_Should_Allow_Adding_Flag_Metadata_Expressions()
+    {
+        // Arrange
+        var builder = TraceEnricherHookOptions.CreateBuilder();
+        var key = "flag_metadata_key";
+        static object? expression(ImmutableMetadata m) => m.GetString("flag_metadata_key");
+
+        // Act
+        builder.WithFlagEvaluationMetadata(key, expression);
+        var options = builder.Build();
+
+        // Assert
+        Assert.Single(options.FlagMetadataCallbacks);
+        Assert.Equal(key, options.FlagMetadataCallbacks.First().Key);
+        Assert.Equal(expression, options.FlagMetadataCallbacks.First().Value);
+    }
+}

--- a/test/OpenFeature.Tests/Hooks/TraceEnricherHookTests.cs
+++ b/test/OpenFeature.Tests/Hooks/TraceEnricherHookTests.cs
@@ -70,6 +70,84 @@ public class TraceEnricherHookTests : IDisposable
     }
 
     [Fact]
+    public async Task TestFinally_WithCustomDimension()
+    {
+        // Arrange
+        var traceHookOptions = TraceEnricherHookOptions.CreateBuilder()
+            .WithCustomDimension("custom_dimension_key", "custom_dimension_value")
+            .Build();
+        var traceEnricherHook = new TraceEnricherHook(traceHookOptions);
+        var evaluationContext = EvaluationContext.Empty;
+        var ctx = new HookContext<string>("my-flag", "foo", Constant.FlagValueType.String,
+            new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
+
+        // Act
+        var span = this._tracer.StartActiveSpan("my-span");
+        await traceEnricherHook.FinallyAsync(ctx,
+            new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"),
+            new Dictionary<string, object>()).ConfigureAwait(true);
+        span.End();
+
+        this._tracerProvider.ForceFlush();
+
+        // Assert
+        Assert.Single(this._exportedItems);
+        var rootSpan = this._exportedItems.First();
+
+        Assert.Single(rootSpan.Events);
+        ActivityEvent ev = rootSpan.Events.First();
+        Assert.Equal("feature_flag.evaluation", ev.Name);
+
+        Assert.Contains(new KeyValuePair<string, object?>("custom_dimension_key", "custom_dimension_value"), ev.Tags);
+    }
+
+    [Fact]
+    public async Task TestFinally_WithFlagEvaluationMetadata()
+    {
+        // Arrange
+        var traceHookOptions = TraceEnricherHookOptions.CreateBuilder()
+            .WithFlagEvaluationMetadata("double", metadata => metadata.GetDouble("double"))
+            .WithFlagEvaluationMetadata("int", metadata => metadata.GetInt("int"))
+            .WithFlagEvaluationMetadata("bool", metadata => metadata.GetBool("bool"))
+            .WithFlagEvaluationMetadata("string", metadata => metadata.GetString("string"))
+            .Build();
+        var traceEnricherHook = new TraceEnricherHook(traceHookOptions);
+        var evaluationContext = EvaluationContext.Empty;
+        var ctx = new HookContext<string>("my-flag", "foo", Constant.FlagValueType.String,
+            new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
+
+        var flagMetadata = new ImmutableMetadata(new Dictionary<string, object>
+        {
+            { "double", 1.0 },
+            { "int", 2025 },
+            { "bool", true },
+            { "string", "foo" }
+        });
+
+        // Act
+        var span = this._tracer.StartActiveSpan("my-span");
+        await traceEnricherHook.FinallyAsync(ctx,
+            new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default", flagMetadata: flagMetadata),
+            new Dictionary<string, object>()).ConfigureAwait(true);
+        span.End();
+
+        this._tracerProvider.ForceFlush();
+
+        // Assert
+        Assert.Single(this._exportedItems);
+        var rootSpan = this._exportedItems.First();
+
+        Assert.Single(rootSpan.Events);
+        ActivityEvent ev = rootSpan.Events.First();
+        Assert.Equal("feature_flag.evaluation", ev.Name);
+
+        Assert.Contains(new KeyValuePair<string, object?>("double", 1.0), ev.Tags);
+        Assert.Contains(new KeyValuePair<string, object?>("int", 2025), ev.Tags);
+        Assert.Contains(new KeyValuePair<string, object?>("bool", true), ev.Tags);
+        Assert.Contains(new KeyValuePair<string, object?>("string", "foo"), ev.Tags);
+    }
+
+    [Fact]
     public async Task TestFinally_NoSpan()
     {
         // Arrange

--- a/test/OpenFeature.Tests/Hooks/TraceEnricherHookTests.cs
+++ b/test/OpenFeature.Tests/Hooks/TraceEnricherHookTests.cs
@@ -74,7 +74,7 @@ public class TraceEnricherHookTests : IDisposable
     {
         // Arrange
         var traceHookOptions = TraceEnricherHookOptions.CreateBuilder()
-            .WithCustomDimension("custom_dimension_key", "custom_dimension_value")
+            .WithTag("custom_dimension_key", "custom_dimension_value")
             .Build();
         var traceEnricherHook = new TraceEnricherHook(traceHookOptions);
         var evaluationContext = EvaluationContext.Empty;


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Adds `TraceEnricherHookOptions`, largely a copy of `MetricHookOptions` from #512, to enrich the `feature_flag.evaluation` span event.

Example usage:

```csharp
var traceHookOptions = TraceEnricherHookOptions.CreateBuilder()
    .WithCustomDimension("key1", "value1")
    .WithFlagEvaluationMetadata("provider", s => s.GetString("provider"))
    .Build();

featureBuilder.AddHostedFeatureLifecycle()
    .AddHook(new TraceEnricherHook(traceHookOptions));
```

These adds tags to the event associated with the span. Below is an example with the above custom dimension and metadata callback:

<img width="1857" height="792" alt="image" src="https://github.com/user-attachments/assets/00613efd-051a-457c-ade8-be0456386643" />

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #516

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

I kept the builder method names `WithCustomDimension` and `WithFlagEvaluationMetadata`, maybe this should be different for Traces? In the Java implementation the both hook options look very similar: [TracesHookOptions.java](https://github.com/open-feature/java-sdk-contrib/blob/main/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/TracesHookOptions.java) and [MetricHookOptions.java](https://github.com/open-feature/java-sdk-contrib/blob/main/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricHookOptions.java)

### How to test
<!-- if applicable, add testing instructions under this section -->

