### PR TITLE
fix: update DI lifecycle to use container instead of static instance

### DIFF
--- a/src/OpenFeature.DependencyInjection/OpenFeatureServiceCollectionExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ public static partial class OpenFeatureServiceCollectionExtensions
         Guard.ThrowIfNull(configure);
 
         // Register core OpenFeature services as singletons.
-        services.TryAddSingleton(Api.Instance);
+        services.TryAddSingleton(new Api());
         services.TryAddSingleton<IFeatureLifecycleManager, FeatureLifecycleManager>();
 
         var builder = new OpenFeatureBuilder(services);

--- a/src/OpenFeature.DependencyInjection/OpenFeatureServiceCollectionExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureServiceCollectionExtensions.cs
@@ -24,7 +24,9 @@ public static partial class OpenFeatureServiceCollectionExtensions
         Guard.ThrowIfNull(configure);
 
         // Register core OpenFeature services as singletons.
-        services.TryAddSingleton(new Api());
+        var api = new Api();
+        Api.SetInstance(api);
+        services.TryAddSingleton(api);
         services.TryAddSingleton<IFeatureLifecycleManager, FeatureLifecycleManager>();
 
         var builder = new OpenFeatureBuilder(services);

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -121,7 +121,7 @@ public sealed class Api : IEventBus
     /// <returns><see cref="FeatureClient"/></returns>
     public FeatureClient GetClient(string? name = null, string? version = null, ILogger? logger = null,
         EvaluationContext? context = null) =>
-        new FeatureClient(() => this._repository.GetProvider(name), name, version, this, logger, context);
+        new FeatureClient(this, () => this._repository.GetProvider(name), name, version, logger, context);
 
     /// <summary>
     /// Appends list of hooks to global hooks list

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -121,7 +121,7 @@ public sealed class Api : IEventBus
     /// <returns><see cref="FeatureClient"/></returns>
     public FeatureClient GetClient(string? name = null, string? version = null, ILogger? logger = null,
         EvaluationContext? context = null) =>
-        new FeatureClient(() => this._repository.GetProvider(name), name, version, logger, context);
+        new FeatureClient(() => this._repository.GetProvider(name), name, version, this, logger, context);
 
     /// <summary>
     /// Appends list of hooks to global hooks list

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -360,4 +360,12 @@ public sealed class Api : IEventBus
     {
         Instance = new Api();
     }
+
+    /// <summary>
+    /// This method should only be used in the Dependency Injection setup. It will set the singleton instance of the API using the provided instance.
+    /// </summary>
+    internal static void SetInstance(Api api)
+    {
+        Instance = api;
+    }
 }

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -32,7 +32,7 @@ public sealed class Api : IEventBus
     // not to mark type as beforeFieldInit
     // IE Lazy way of ensuring this is thread safe without using locks
     static Api() { }
-    private Api() { }
+    internal Api() { }
 
     /// <summary>
     /// Sets the default feature provider. In order to wait for the provider to be set, and initialization to complete,

--- a/src/OpenFeature/OpenFeature.csproj
+++ b/src/OpenFeature/OpenFeature.csproj
@@ -19,6 +19,7 @@
     <InternalsVisibleTo Include="OpenFeature.Benchmarks" />
     <InternalsVisibleTo Include="OpenFeature.Tests" />
     <InternalsVisibleTo Include="OpenFeature.E2ETests" />
+    <InternalsVisibleTo Include="OpenFeature.DependencyInjection" />
     <None Include="../../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -70,20 +70,20 @@ public sealed partial class FeatureClient : IFeatureClient
     /// <summary>
     /// Initializes a new instance of the <see cref="FeatureClient"/> class.
     /// </summary>
+    /// <param name="api">The API instance for accessing global state and providers</param>
     /// <param name="providerAccessor">Function to retrieve current provider</param>
     /// <param name="name">Name of client <see cref="ClientMetadata"/></param>
     /// <param name="version">Version of client <see cref="ClientMetadata"/></param>
-    /// <param name="api">The API instance for accessing global state and providers</param>
     /// <param name="logger">Logger used by client</param>
     /// <param name="context">Context given to this client</param>
     /// <exception cref="ArgumentNullException">Throws if any of the required parameters are null</exception>
-    internal FeatureClient(Func<FeatureProvider> providerAccessor, string? name, string? version, Api? api = null, ILogger? logger = null, EvaluationContext? context = null)
+    internal FeatureClient(Api api, Func<FeatureProvider> providerAccessor, string? name, string? version, ILogger? logger = null, EvaluationContext? context = null)
     {
+        this._api = api;
+        this._providerAccessor = providerAccessor;
         this._metadata = new ClientMetadata(name, version);
         this._logger = logger ?? NullLogger<FeatureClient>.Instance;
         this._evaluationContext = context ?? EvaluationContext.Empty;
-        this._providerAccessor = providerAccessor;
-        this._api = api ?? Api.Instance;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request refactors the `Api` class and its integration with `FeatureClient` to improve testability and dependency management by replacing the singleton access pattern with dependency injection. It also includes minor project configuration updates. Below are the key changes grouped by theme:

### Refactoring `Api` and Dependency Injection:

* Changed the `Api` constructor from `private` to `internal`, allowing it to be instantiated directly for dependency injection purposes (`src/OpenFeature/Api.cs`, [src/OpenFeature/Api.csL35-R35](diffhunk://#diff-dc150fbd3b7be797470374ee7e38c7ab8a31eb9b6b7a52345e05114c2d32a15eL35-R35)).
* Updated `AddOpenFeature` in `OpenFeatureServiceCollectionExtensions` to register a new instance of `Api` instead of using the singleton `Api.Instance` (`src/OpenFeature.DependencyInjection/OpenFeatureServiceCollectionExtensions.cs`, [src/OpenFeature.DependencyInjection/OpenFeatureServiceCollectionExtensions.csL27-R27](diffhunk://#diff-cda6bc81ad25c28afd42716109c7c5c2fd644c0b792295d35a83bfd4d8dca6d8L27-R27)).
* Modified `FeatureClient` to accept an `Api` instance as a constructor parameter, defaulting to `Api.Instance` if not provided. Updated all internal references to use the injected `Api` instance (`src/OpenFeature/OpenFeatureClient.cs`, [[1]](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907R21) [[2]](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907R76-R86) [[3]](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907L102-R111) [[4]](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907L216-R225) [[5]](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907L313-R316).

### Updates to `FeatureClient`:

* Added a private `_api` field to store the injected `Api` instance and replaced all direct calls to `Api.Instance` with `_api` to improve testability (`src/OpenFeature/OpenFeatureClient.cs`, [[1]](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907R21) [[2]](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907L43-R44) [[3]](diffhunk://#diff-c23c8a3ea4538fbdcf6b1cf93ea3de456906e4d267fc4b2ba3f8b1cb186a7907L102-R111).

### Project Configuration:

* Added `InternalsVisibleTo` for `OpenFeature.DependencyInjection` to allow access to internal members of the `OpenFeature` assembly (`src/OpenFeature/OpenFeature.csproj`, [src/OpenFeature/OpenFeature.csprojR22](diffhunk://#diff-711ea17cbdebe419375c7684c8c39a1423d2bebcf8976ddd7bdd78deaab65b21R22)).

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #533 

### Notes
<!-- any additional notes for this PR -->

As pointed out, I made a couple of changes in the `FeatureClient` class to use the same reference all the time for the `Api`. I checked the rest of the codebase and the `Api.Instance` is only used in the testing projects.
This change doesn't affect any external methods.
