### PR TITLE
ci: Update changelog publish details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,8 +140,6 @@ Only certain types are visible in the generated changelog:
 -   `refactor`: 🔧 Refactoring - Code changes that neither fix bugs nor add features
 -   `revert`: 🔙 Reverts - Reverted changes
 
-### Changelog
-
 ## Design Choices
 
 As with other OpenFeature SDKs, dotnet-sdk follows the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,18 @@ Please make sure you follow the latest [conventions](https://www.conventionalcom
 
 If you want to point out a breaking change, you should use `!` after the type. For example: `feat!: excellent new feature`.
 
+### Changelog Visibility and Release Triggers
+
+Only certain types are visible in the generated changelog:
+
+-   `feat`: ✨ New Features - New functionality added
+-   `fix`: 🐛 Bug Fixes - Bug fixes and corrections
+-   `perf`: 🚀 Performance - Performance improvements
+-   `refactor`: 🔧 Refactoring - Code changes that neither fix bugs nor add features
+-   `revert`: 🔙 Reverts - Reverted changes
+
+### Changelog
+
 ## Design Choices
 
 As with other OpenFeature SDKs, dotnet-sdk follows the

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,10 +23,12 @@
     },
     {
       "type": "chore",
+      "hidden": true,
       "section": "🧹 Chore"
     },
     {
       "type": "docs",
+      "hidden": true,
       "section": "📚 Documentation"
     },
     {
@@ -40,6 +42,7 @@
     },
     {
       "type": "deps",
+      "hidden": true,
       "section": "📦 Dependencies"
     },
     {
@@ -49,7 +52,7 @@
     },
     {
       "type": "refactor",
-      "section": "🔄 Refactoring"
+      "section": "🔧 Refactoring"
     },
     {
       "type": "revert",


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates changelog visibility rules and release configuration to clarify which commit types appear in the changelog and to hide less relevant types. The main changes ensure that only important changes are highlighted in release notes and that commit type sections are clearly labeled.

**Changelog and Release Configuration Updates:**

_Changelog Documentation:_
* Added a new section to `CONTRIBUTING.md` explaining which commit types are visible in the changelog and their meanings, improving contributor guidance.

_Release Configuration:_
* Updated `release-please-config.json` to hide `chore`, `docs`, and `deps` commit types from the changelog, so only feature, fix, performance, refactor, and revert types are shown. [[1]](diffhunk://#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2bR26-R31) [[2]](diffhunk://#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2bR45)
* Changed the section label for `refactor` commits from "🔄 Refactoring" to "🔧 Refactoring" for consistency with documentation.