### PR TITLE
ci: Add SonarCloud CI steps to code-coverage workflow

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -46,22 +46,15 @@ jobs:
         run: dotnet tool install --global dotnet-sonarscanner --version 10.3.0
 
       - name: Begin SonarCloud analysis
-        env:
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
         run: |
-          dotnet sonarscanner begin /k:"open-feature_dotnet-sdk" \
-                                    /o:"kylejuliandev" \
-                                    /d:sonar.token="$SONAR_TOKEN" \
-                                    /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+          dotnet sonarscanner begin /k:"open-feature_dotnet-sdk" /o:"kylejuliandev" /d:sonar.token="${{ secrets.SONARCLOUD_TOKEN }}" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
 
       - name: Run Test
         run: dotnet test --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
 
       - name: End SonarCloud analysis
-        env:
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
         run: |
-          dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"
+          dotnet sonarscanner end /d:sonar.token="${{ secrets.SONARCLOUD_TOKEN }}"
 
       - uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -42,8 +42,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
+      - name: Install SonarCloud
+        run: dotnet tool install --global dotnet-sonarscanner --version 10.3.0
+
+      - name: Begin SonarCloud analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+        run: |
+          dotnet sonarscanner begin /k:"open-feature_dotnet-sdk" \
+                                    /o:"open-feature" \
+                                    /d:sonar.token="$SONAR_TOKEN" \
+                                    /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+
       - name: Run Test
         run: dotnet test --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+
+      - name: End SonarCloud analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+        run: |
+          dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"
 
       - uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -50,7 +50,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
         run: |
           dotnet sonarscanner begin /k:"open-feature_dotnet-sdk" \
-                                    /o:"open-feature" \
+                                    /o:"kylejuliandev" \
                                     /d:sonar.token="$SONAR_TOKEN" \
                                     /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Adds SonarCloud analysis to the dotnet-sdk repository.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #553

### Notes
<!-- any additional notes for this PR -->

Currently analyzes the project in a private organisation within SonarCloud until permissions can be sorted. OpenFeature also appears to be on a free-tier, so I'm not sure how many lines of code can be analyzed before it starts to error.

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

