### PR TITLE
fix: update provider status to Fatal during disposal

### DIFF
--- a/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
+++ b/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
@@ -280,6 +280,7 @@ public sealed class MultiProvider : FeatureProvider, IAsyncDisposable
         {
             this._initializationSemaphore.Dispose();
             this._shutdownSemaphore.Dispose();
+            this._providerStatus = ProviderStatus.Fatal;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request makes a small change to the `DisposeAsync` method in `MultiProvider.cs`. After disposing of the semaphores, it now sets the `_providerStatus` to `ProviderStatus.Fatal` to ensure the provider's status accurately reflects its disposed state.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #569 