### PR TITLE
feat: Implement hooks in multi provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,9 +443,11 @@ Built a new hook? [Let us know](https://github.com/open-feature/openfeature.dev/
 ### Multi-Provider
 
 > [!NOTE]
-> The Multi-Provider feature is currently experimental. Hooks and events are not supported at the moment.
+> The Multi-Provider feature is currently experimental. Events are not fully supported at the moment.
 
 The Multi-Provider enables the use of multiple underlying feature flag providers simultaneously, allowing different providers to be used for different flag keys or based on specific evaluation strategies.
+
+The Multi-Provider supports provider hooks and executes them in accordance with the OpenFeature specification. Each provider's hooks are executed with context isolation, ensuring that context modifications by one provider's hooks do not affect other providers.
 
 #### Basic Usage
 
@@ -524,9 +526,7 @@ The Multi-Provider supports two evaluation modes:
 
 #### Limitations
 
--   **Hooks are not supported**: Multi-Provider does not currently support hook registration or execution
--   **Events are not supported**: Provider events are not propagated from underlying providers
--   **Experimental status**: The API may change in future releases
+- **Experimental status**: The API may change in future releases
 
 For a complete example, see the [AspNetCore sample](./samples/AspNetCore/README.md) which demonstrates Multi-Provider usage.
 

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ Built a new hook? [Let us know](https://github.com/open-feature/openfeature.dev/
 ### Multi-Provider
 
 > [!NOTE]
-> The Multi-Provider feature is currently experimental. Events are not fully supported at the moment.
+> The Multi-Provider feature is currently experimental.
 
 The Multi-Provider enables the use of multiple underlying feature flag providers simultaneously, allowing different providers to be used for different flag keys or based on specific evaluation strategies.
 

--- a/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
+++ b/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -74,21 +73,6 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
 
     /// <inheritdoc/>
     public override Metadata GetMetadata() => this._metadata;
-
-    /// <inheritdoc/>
-    public override IImmutableList<Hook> GetProviderHooks()
-    {
-        var hooks = new List<Hook>();
-
-        foreach (var registeredProvider in this._registeredProviders)
-        {
-            var providerHooks = registeredProvider.Provider.GetProviderHooks();
-            hooks.AddRange(providerHooks);
-        }
-
-        // Should we return this?
-        return hooks.ToImmutableList();
-    }
 
     /// <inheritdoc/>
     internal override ProviderStatus Status

--- a/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
+++ b/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
@@ -79,13 +79,14 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
     public override IImmutableList<Hook> GetProviderHooks()
     {
         var hooks = new List<Hook>();
-        
+
         foreach (var registeredProvider in this._registeredProviders)
         {
             var providerHooks = registeredProvider.Provider.GetProviderHooks();
             hooks.AddRange(providerHooks);
         }
-        
+
+        // Should we return this?
         return hooks.ToImmutableList();
     }
 
@@ -285,7 +286,7 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
                 continue;
             }
 
-            var result = await registeredProvider.Provider.EvaluateAsync(providerContext, evaluationContext, defaultValue, cancellationToken).ConfigureAwait(false);
+            var result = await registeredProvider.Provider.EvaluateAsync(providerContext, evaluationContext, defaultValue, this._logger, cancellationToken).ConfigureAwait(false);
             resolutions.Add(result);
 
             if (!this._evaluationStrategy.ShouldEvaluateNextProvider(providerContext, evaluationContext, result))
@@ -312,7 +313,7 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
 
             if (this._evaluationStrategy.ShouldEvaluateThisProvider(providerContext, evaluationContext))
             {
-                tasks.Add(registeredProvider.Provider.EvaluateAsync(providerContext, evaluationContext, defaultValue, cancellationToken));
+                tasks.Add(registeredProvider.Provider.EvaluateAsync(providerContext, evaluationContext, defaultValue, this._logger, cancellationToken));
             }
         }
 

--- a/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
+++ b/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -73,6 +74,20 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
 
     /// <inheritdoc/>
     public override Metadata GetMetadata() => this._metadata;
+
+    /// <inheritdoc/>
+    public override IImmutableList<Hook> GetProviderHooks()
+    {
+        var hooks = new List<Hook>();
+        
+        foreach (var registeredProvider in this._registeredProviders)
+        {
+            var providerHooks = registeredProvider.Provider.GetProviderHooks();
+            hooks.AddRange(providerHooks);
+        }
+        
+        return hooks.ToImmutableList();
+    }
 
     /// <inheritdoc/>
     internal override ProviderStatus Status

--- a/src/OpenFeature.Providers.MultiProvider/ProviderExtensions.cs
+++ b/src/OpenFeature.Providers.MultiProvider/ProviderExtensions.cs
@@ -15,7 +15,7 @@ internal static class ProviderExtensions
         StrategyPerProviderContext<T> providerContext,
         EvaluationContext? evaluationContext,
         T defaultValue,
-        ILogger? logger = null,
+        ILogger logger,
         CancellationToken cancellationToken = default)
     {
         var key = providerContext.FlagKey;
@@ -87,7 +87,7 @@ internal static class ProviderExtensions
         string key,
         T defaultValue,
         EvaluationContext? evaluationContext,
-        ILogger? logger,
+        ILogger logger,
         CancellationToken cancellationToken)
     {
         try
@@ -101,7 +101,7 @@ internal static class ProviderExtensions
             );
 
             var initialContext = evaluationContext ?? EvaluationContext.Empty;
-            var hookRunner = new HookRunner<T>([.. hooks], initialContext, sharedHookContext, logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+            var hookRunner = new HookRunner<T>([.. hooks], initialContext, sharedHookContext, logger);
 
             // Execute before hooks for this provider
             var modifiedContext = await hookRunner.TriggerBeforeHooksAsync(null, cancellationToken).ConfigureAwait(false);
@@ -129,7 +129,7 @@ internal static class ProviderExtensions
         T defaultValue,
         EvaluationContext? evaluationContext,
         ResolutionDetails<T> result,
-        ILogger? logger,
+        ILogger logger,
         CancellationToken cancellationToken)
     {
         try
@@ -142,7 +142,7 @@ internal static class ProviderExtensions
                 provider.GetMetadata()
             );
 
-            var hookRunner = new HookRunner<T>([.. hooks], evaluationContext ?? EvaluationContext.Empty, sharedHookContext, logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+            var hookRunner = new HookRunner<T>([.. hooks], evaluationContext ?? EvaluationContext.Empty, sharedHookContext, logger);
 
             var evaluationDetails = result.ToFlagEvaluationDetails();
 
@@ -161,7 +161,7 @@ internal static class ProviderExtensions
         catch (Exception hookEx)
         {
             // Log hook execution errors but don't fail the evaluation
-            logger?.LogWarning(hookEx, "Provider after/finally hook execution failed for provider {ProviderName}", provider.GetMetadata()?.Name ?? "unknown");
+            logger.LogWarning(hookEx, "Provider after/finally hook execution failed for provider {ProviderName}", provider.GetMetadata()?.Name ?? "unknown");
         }
     }
 

--- a/src/OpenFeature.Providers.MultiProvider/ProviderExtensions.cs
+++ b/src/OpenFeature.Providers.MultiProvider/ProviderExtensions.cs
@@ -1,4 +1,8 @@
+using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using OpenFeature.Constant;
+using OpenFeature.Error;
+using OpenFeature.Extension;
 using OpenFeature.Model;
 using OpenFeature.Providers.MultiProvider.Strategies.Models;
 
@@ -11,23 +15,56 @@ internal static class ProviderExtensions
         StrategyPerProviderContext<T> providerContext,
         EvaluationContext? evaluationContext,
         T defaultValue,
-        CancellationToken cancellationToken)
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
     {
         var key = providerContext.FlagKey;
 
         try
         {
+            // Execute provider hooks for this specific provider
+            var providerHooks = provider.GetProviderHooks();
+            EvaluationContext? contextForThisProvider = evaluationContext;
+
+            if (providerHooks.Count > 0)
+            {
+                // Execute hooks for this provider with context isolation
+                var (modifiedContext, hookResult) = await ExecuteBeforeEvaluationHooksAsync(
+                    provider,
+                    providerHooks,
+                    key,
+                    defaultValue,
+                    evaluationContext,
+                    logger,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (hookResult != null)
+                {
+                    return hookResult;
+                }
+
+                contextForThisProvider = modifiedContext ?? evaluationContext;
+            }
+
+            // Evaluate the flag with the (possibly modified) context
             var result = defaultValue switch
             {
-                bool boolDefaultValue => (ResolutionDetails<T>)(object)await provider.ResolveBooleanValueAsync(key, boolDefaultValue, evaluationContext, cancellationToken).ConfigureAwait(false),
-                string stringDefaultValue => (ResolutionDetails<T>)(object)await provider.ResolveStringValueAsync(key, stringDefaultValue, evaluationContext, cancellationToken).ConfigureAwait(false),
-                int intDefaultValue => (ResolutionDetails<T>)(object)await provider.ResolveIntegerValueAsync(key, intDefaultValue, evaluationContext, cancellationToken).ConfigureAwait(false),
-                double doubleDefaultValue => (ResolutionDetails<T>)(object)await provider.ResolveDoubleValueAsync(key, doubleDefaultValue, evaluationContext, cancellationToken).ConfigureAwait(false),
-                Value valueDefaultValue => (ResolutionDetails<T>)(object)await provider.ResolveStructureValueAsync(key, valueDefaultValue, evaluationContext, cancellationToken).ConfigureAwait(false),
-                null when typeof(T) == typeof(string) => (ResolutionDetails<T>)(object)await provider.ResolveStringValueAsync(key, (string)(object)defaultValue!, evaluationContext, cancellationToken).ConfigureAwait(false),
-                null when typeof(T) == typeof(Value) => (ResolutionDetails<T>)(object)await provider.ResolveStructureValueAsync(key, (Value)(object)defaultValue!, evaluationContext, cancellationToken).ConfigureAwait(false),
+                bool boolDefaultValue => (ResolutionDetails<T>)(object)await provider.ResolveBooleanValueAsync(key, boolDefaultValue, contextForThisProvider, cancellationToken).ConfigureAwait(false),
+                string stringDefaultValue => (ResolutionDetails<T>)(object)await provider.ResolveStringValueAsync(key, stringDefaultValue, contextForThisProvider, cancellationToken).ConfigureAwait(false),
+                int intDefaultValue => (ResolutionDetails<T>)(object)await provider.ResolveIntegerValueAsync(key, intDefaultValue, contextForThisProvider, cancellationToken).ConfigureAwait(false),
+                double doubleDefaultValue => (ResolutionDetails<T>)(object)await provider.ResolveDoubleValueAsync(key, doubleDefaultValue, contextForThisProvider, cancellationToken).ConfigureAwait(false),
+                Value valueDefaultValue => (ResolutionDetails<T>)(object)await provider.ResolveStructureValueAsync(key, valueDefaultValue, contextForThisProvider, cancellationToken).ConfigureAwait(false),
+                null when typeof(T) == typeof(string) => (ResolutionDetails<T>)(object)await provider.ResolveStringValueAsync(key, (string)(object)defaultValue!, contextForThisProvider, cancellationToken).ConfigureAwait(false),
+                null when typeof(T) == typeof(Value) => (ResolutionDetails<T>)(object)await provider.ResolveStructureValueAsync(key, (Value)(object)defaultValue!, contextForThisProvider, cancellationToken).ConfigureAwait(false),
                 _ => throw new ArgumentException($"Unsupported flag type: {typeof(T)}")
             };
+
+            // Execute after/finally hooks for this provider if we have them
+            if (providerHooks.Count > 0)
+            {
+                await ExecuteAfterEvaluationHooksAsync(provider, providerHooks, key, defaultValue, contextForThisProvider, result, logger, cancellationToken).ConfigureAwait(false);
+            }
+
             return new ProviderResolutionResult<T>(provider, providerContext.ProviderName, result);
         }
         catch (Exception ex)
@@ -42,5 +79,102 @@ internal static class ProviderExtensions
 
             return new ProviderResolutionResult<T>(provider, providerContext.ProviderName, errorResult, ex);
         }
+    }
+
+    private static async Task<(EvaluationContext?, ProviderResolutionResult<T>?)> ExecuteBeforeEvaluationHooksAsync<T>(
+        FeatureProvider provider,
+        IImmutableList<Hook> hooks,
+        string key,
+        T defaultValue,
+        EvaluationContext? evaluationContext,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var sharedHookContext = new SharedHookContext<T>(
+                key,
+                defaultValue,
+                GetFlagValueType<T>(),
+                null, // Provide a client metadata instead of null?
+                provider.GetMetadata()
+            );
+
+            var initialContext = evaluationContext ?? EvaluationContext.Empty;
+            var hookRunner = new HookRunner<T>([.. hooks], initialContext, sharedHookContext, logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+            // Execute before hooks for this provider
+            var modifiedContext = await hookRunner.TriggerBeforeHooksAsync(null, cancellationToken).ConfigureAwait(false);
+            return (modifiedContext, null);
+        }
+        catch (Exception hookEx)
+        {
+            // If before hooks fail, return error result
+            var errorResult = new ResolutionDetails<T>(
+                key,
+                defaultValue,
+                ErrorType.General,
+                Reason.Error,
+                errorMessage: $"Provider hook execution failed: {hookEx.Message}");
+
+            var result = new ProviderResolutionResult<T>(provider, provider.GetMetadata()?.Name ?? "unknown", errorResult, hookEx);
+            return (null, result);
+        }
+    }
+
+    private static async Task ExecuteAfterEvaluationHooksAsync<T>(
+        FeatureProvider provider,
+        IImmutableList<Hook> hooks,
+        string key,
+        T defaultValue,
+        EvaluationContext? evaluationContext,
+        ResolutionDetails<T> result,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var sharedHookContext = new SharedHookContext<T>(
+                key,
+                defaultValue,
+                GetFlagValueType<T>(),
+                null, // Provide a client metadata instead of null?
+                provider.GetMetadata()
+            );
+
+            var hookRunner = new HookRunner<T>([.. hooks], evaluationContext ?? EvaluationContext.Empty, sharedHookContext, logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+            var evaluationDetails = result.ToFlagEvaluationDetails();
+
+            if (result.ErrorType == ErrorType.None)
+            {
+                await hookRunner.TriggerAfterHooksAsync(evaluationDetails, null, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                var exception = new FeatureProviderException(result.ErrorType, result.ErrorMessage);
+                await hookRunner.TriggerErrorHooksAsync(exception, null, cancellationToken).ConfigureAwait(false);
+            }
+
+            await hookRunner.TriggerFinallyHooksAsync(evaluationDetails, null, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception hookEx)
+        {
+            // Log hook execution errors but don't fail the evaluation
+            logger?.LogWarning(hookEx, "Provider after/finally hook execution failed for provider {ProviderName}", provider.GetMetadata()?.Name ?? "unknown");
+        }
+    }
+
+    private static FlagValueType GetFlagValueType<T>()
+    {
+        return typeof(T) switch
+        {
+            _ when typeof(T) == typeof(bool) => FlagValueType.Boolean,
+            _ when typeof(T) == typeof(string) => FlagValueType.String,
+            _ when typeof(T) == typeof(int) => FlagValueType.Number,
+            _ when typeof(T) == typeof(double) => FlagValueType.Number,
+            _ when typeof(T) == typeof(Value) => FlagValueType.Object,
+            _ => FlagValueType.Object // Default fallback
+        };
     }
 }

--- a/src/OpenFeature.Providers.MultiProvider/ProviderExtensions.cs
+++ b/src/OpenFeature.Providers.MultiProvider/ProviderExtensions.cs
@@ -165,7 +165,7 @@ internal static class ProviderExtensions
         }
     }
 
-    private static FlagValueType GetFlagValueType<T>()
+    internal static FlagValueType GetFlagValueType<T>()
     {
         return typeof(T) switch
         {

--- a/src/OpenFeature.Providers.MultiProvider/ProviderExtensions.cs
+++ b/src/OpenFeature.Providers.MultiProvider/ProviderExtensions.cs
@@ -96,7 +96,7 @@ internal static class ProviderExtensions
                 key,
                 defaultValue,
                 GetFlagValueType<T>(),
-                null, // Provide a client metadata instead of null?
+                new ClientMetadata(MultiProviderConstants.ProviderName, null),
                 provider.GetMetadata()
             );
 
@@ -138,7 +138,7 @@ internal static class ProviderExtensions
                 key,
                 defaultValue,
                 GetFlagValueType<T>(),
-                null, // Provide a client metadata instead of null?
+                new ClientMetadata(MultiProviderConstants.ProviderName, null),
                 provider.GetMetadata()
             );
 

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -843,5 +844,257 @@ public class MultiProviderClassTests
             multiProvider.ResolveStructureValueAsync(TestFlagKey, new Value()));
         Assert.Equal(nameof(MultiProvider), structureException.ObjectName);
     }
+
+    #region Hook Tests
+
+    [Fact]
+    public void GetProviderHooks_WithNoProviders_ReturnsEmptyList()
+    {
+        // Arrange - Create provider without hooks
+        var provider = Substitute.For<FeatureProvider>();
+        provider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
+        var providerEntries = new List<ProviderEntry> { new(provider, Provider1Name) };
+
+        // Act
+        var multiProvider = new MultiProvider(providerEntries, this._mockStrategy);
+        var hooks = multiProvider.GetProviderHooks();
+
+        // Assert
+        Assert.Empty(hooks);
+    }
+
+    [Fact]
+    public void GetProviderHooks_WithSingleProviderWithHooks_ReturnsProviderHooks()
+    {
+        // Arrange
+        var hook1 = Substitute.For<Hook>();
+        var hook2 = Substitute.For<Hook>();
+        var providerHooks = ImmutableList.Create(hook1, hook2);
+
+        var provider = Substitute.For<FeatureProvider>();
+        provider.GetProviderHooks().Returns(providerHooks);
+        var providerEntries = new List<ProviderEntry> { new(provider, Provider1Name) };
+
+        // Act
+        var multiProvider = new MultiProvider(providerEntries, this._mockStrategy);
+        var hooks = multiProvider.GetProviderHooks();
+
+        // Assert
+        Assert.Equal(2, hooks.Count);
+        Assert.Contains(hook1, hooks);
+        Assert.Contains(hook2, hooks);
+    }
+
+    [Fact]
+    public void GetProviderHooks_WithMultipleProvidersWithHooks_ReturnsAllHooks()
+    {
+        // Arrange
+        var hook1 = Substitute.For<Hook>();
+        var hook2 = Substitute.For<Hook>();
+        var hook3 = Substitute.For<Hook>();
+
+        this._mockProvider1.GetProviderHooks().Returns(ImmutableList.Create(hook1, hook2));
+        this._mockProvider2.GetProviderHooks().Returns(ImmutableList.Create(hook3));
+
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._mockProvider1, Provider1Name),
+            new(this._mockProvider2, Provider2Name)
+        };
+
+        // Act
+        var multiProvider = new MultiProvider(providerEntries, this._mockStrategy);
+        var hooks = multiProvider.GetProviderHooks();
+
+        // Assert
+        Assert.Equal(3, hooks.Count);
+        Assert.Contains(hook1, hooks);
+        Assert.Contains(hook2, hooks);
+        Assert.Contains(hook3, hooks);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithProviderHooks_ExecutesHooksForEachProvider()
+    {
+        // Arrange
+        var hook1 = Substitute.For<Hook>();
+        var hook2 = Substitute.For<Hook>();
+
+        // Setup hooks to return modified context
+        var modifiedContext = new EvaluationContextBuilder()
+            .Set("modified", "value")
+            .Build();
+
+        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>())
+            .Returns(modifiedContext);
+        hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>())
+            .Returns(EvaluationContext.Empty);
+
+        this._mockProvider1.GetProviderHooks().Returns(ImmutableList.Create(hook1));
+        this._mockProvider2.GetProviderHooks().Returns(ImmutableList.Create(hook2));
+
+        // Setup providers to return successful results
+        const bool expectedValue = true;
+        var expectedDetails = new ResolutionDetails<bool>(TestFlagKey, expectedValue, ErrorType.None, Reason.Static, TestVariant);
+
+        this._mockProvider1.ResolveBooleanValueAsync(TestFlagKey, false, Arg.Any<EvaluationContext>(), Arg.Any<CancellationToken>())
+            .Returns(expectedDetails);
+        this._mockProvider2.ResolveBooleanValueAsync(TestFlagKey, false, Arg.Any<EvaluationContext>(), Arg.Any<CancellationToken>())
+            .Returns(expectedDetails);
+
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._mockProvider1, Provider1Name),
+            new(this._mockProvider2, Provider2Name)
+        };
+
+        // Setup strategy to evaluate both providers
+        this._mockStrategy.ShouldEvaluateThisProvider(Arg.Any<StrategyPerProviderContext<bool>>(), Arg.Any<EvaluationContext>()).Returns(true);
+        this._mockStrategy.ShouldEvaluateNextProvider(Arg.Any<StrategyPerProviderContext<bool>>(), Arg.Any<EvaluationContext>(), Arg.Any<ProviderResolutionResult<bool>>()).Returns(true);
+        this._mockStrategy.DetermineFinalResult(Arg.Any<StrategyEvaluationContext<bool>>(), TestFlagKey, false, Arg.Any<EvaluationContext>(), Arg.Any<List<ProviderResolutionResult<bool>>>())
+            .Returns(new FinalResult<bool>(expectedDetails, this._mockProvider1, Provider1Name, null));
+
+        var multiProvider = new MultiProvider(providerEntries, this._mockStrategy);
+
+        // Act
+        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, false, this._evaluationContext);
+
+        // Assert
+        Assert.Equal(expectedValue, result.Value);
+
+        // Verify hooks were called
+        await hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>());
+        await hook2.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>());
+
+        // Verify after hooks were called
+        await hook1.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>());
+        await hook2.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>());
+
+        // Verify finally hooks were called
+        await hook1.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>());
+        await hook2.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithHookContextModification_IsolatesContextBetweenProviders()
+    {
+        // Arrange
+        var hook1 = Substitute.For<Hook>();
+        var hook2 = Substitute.For<Hook>();
+
+        // Setup hook1 to modify context
+        var modifiedContext1 = new EvaluationContextBuilder()
+            .Set("provider1", "modified")
+            .Build();
+
+        // Setup hook2 to modify context differently
+        var modifiedContext2 = new EvaluationContextBuilder()
+            .Set("provider2", "modified")
+            .Build();
+
+        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>())
+            .Returns(modifiedContext1);
+        hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>())
+            .Returns(modifiedContext2);
+
+        this._mockProvider1.GetProviderHooks().Returns(ImmutableList.Create(hook1));
+        this._mockProvider2.GetProviderHooks().Returns(ImmutableList.Create(hook2));
+
+        // Setup providers to return results and capture context
+        EvaluationContext? capturedContext1 = null;
+        EvaluationContext? capturedContext2 = null;
+
+        const bool expectedValue = true;
+        var expectedDetails = new ResolutionDetails<bool>(TestFlagKey, expectedValue, ErrorType.None, Reason.Static, TestVariant);
+
+        this._mockProvider1.ResolveBooleanValueAsync(TestFlagKey, false, Arg.Do<EvaluationContext?>(ctx => capturedContext1 = ctx), Arg.Any<CancellationToken>())
+            .Returns(expectedDetails);
+        this._mockProvider2.ResolveBooleanValueAsync(TestFlagKey, false, Arg.Do<EvaluationContext?>(ctx => capturedContext2 = ctx), Arg.Any<CancellationToken>())
+            .Returns(expectedDetails);
+
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._mockProvider1, Provider1Name),
+            new(this._mockProvider2, Provider2Name)
+        };
+
+        // Setup strategy to evaluate both providers
+        this._mockStrategy.ShouldEvaluateThisProvider(Arg.Any<StrategyPerProviderContext<bool>>(), Arg.Any<EvaluationContext>()).Returns(true);
+        this._mockStrategy.ShouldEvaluateNextProvider(Arg.Any<StrategyPerProviderContext<bool>>(), Arg.Any<EvaluationContext>(), Arg.Any<ProviderResolutionResult<bool>>()).Returns(true);
+        this._mockStrategy.DetermineFinalResult(Arg.Any<StrategyEvaluationContext<bool>>(), TestFlagKey, false, Arg.Any<EvaluationContext>(), Arg.Any<List<ProviderResolutionResult<bool>>>())
+            .Returns(new FinalResult<bool>(expectedDetails, this._mockProvider1, Provider1Name, null));
+
+        var multiProvider = new MultiProvider(providerEntries, this._mockStrategy);
+
+        // Act
+        await multiProvider.ResolveBooleanValueAsync(TestFlagKey, false, this._evaluationContext);
+
+        // Assert - Verify context isolation
+        Assert.NotNull(capturedContext1);
+        Assert.NotNull(capturedContext2);
+
+        // Provider1 should have received the context modified by hook1
+        Assert.True(capturedContext1!.ContainsKey("provider1"));
+        Assert.Equal("modified", capturedContext1.GetValue("provider1").AsString);
+        Assert.False(capturedContext1.ContainsKey("provider2"));
+
+        // Provider2 should have received the context modified by hook2
+        Assert.True(capturedContext2!.ContainsKey("provider2"));
+        Assert.Equal("modified", capturedContext2.GetValue("provider2").AsString);
+        Assert.False(capturedContext2.ContainsKey("provider1"));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithHookError_HandlesErrorAndContinuesEvaluation()
+    {
+        // Arrange
+        var throwingHook = Substitute.For<Hook>();
+        var normalHook = Substitute.For<Hook>();
+
+        // Setup throwing hook to throw exception in before hook
+        throwingHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("Hook error"));
+
+        // Setup normal hook
+        normalHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>())
+            .Returns(EvaluationContext.Empty);
+
+        this._mockProvider1.GetProviderHooks().Returns(ImmutableList.Create(throwingHook));
+        this._mockProvider2.GetProviderHooks().Returns(ImmutableList.Create(normalHook));
+
+        // Setup provider2 to return successful result
+        const bool expectedValue = true;
+        var expectedDetails = new ResolutionDetails<bool>(TestFlagKey, expectedValue, ErrorType.None, Reason.Static, TestVariant);
+
+        this._mockProvider2.ResolveBooleanValueAsync(TestFlagKey, false, Arg.Any<EvaluationContext>(), Arg.Any<CancellationToken>())
+            .Returns(expectedDetails);
+
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._mockProvider1, Provider1Name),
+            new(this._mockProvider2, Provider2Name)
+        };
+
+        // Setup strategy to continue evaluation after first provider error
+        this._mockStrategy.ShouldEvaluateThisProvider(Arg.Any<StrategyPerProviderContext<bool>>(), Arg.Any<EvaluationContext>()).Returns(true);
+        this._mockStrategy.ShouldEvaluateNextProvider(Arg.Any<StrategyPerProviderContext<bool>>(), Arg.Any<EvaluationContext>(), Arg.Any<ProviderResolutionResult<bool>>()).Returns(true);
+        this._mockStrategy.DetermineFinalResult(Arg.Any<StrategyEvaluationContext<bool>>(), TestFlagKey, false, Arg.Any<EvaluationContext>(), Arg.Any<List<ProviderResolutionResult<bool>>>())
+            .Returns(new FinalResult<bool>(expectedDetails, this._mockProvider2, Provider2Name, null));
+
+        var multiProvider = new MultiProvider(providerEntries, this._mockStrategy);
+
+        // Act
+        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, false, this._evaluationContext);
+
+        // Assert
+        Assert.Equal(expectedValue, result.Value);
+
+        // Verify that the first provider returned an error due to hook failure
+        // and the second provider succeeded
+        await this._mockProvider1.DidNotReceive().ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), Arg.Any<CancellationToken>());
+        await this._mockProvider2.Received(1).ResolveBooleanValueAsync(TestFlagKey, false, Arg.Any<EvaluationContext>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
 
 }

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTests.cs
@@ -864,7 +864,7 @@ public class MultiProviderClassTests
     }
 
     [Fact]
-    public void GetProviderHooks_WithSingleProviderWithHooks_ReturnsProviderHooks()
+    public void GetProviderHooks_WithSingleProviderWithHooks_ReturnsEmptyList()
     {
         // Arrange
         var hook1 = Substitute.For<Hook>();
@@ -880,13 +880,11 @@ public class MultiProviderClassTests
         var hooks = multiProvider.GetProviderHooks();
 
         // Assert
-        Assert.Equal(2, hooks.Count);
-        Assert.Contains(hook1, hooks);
-        Assert.Contains(hook2, hooks);
+        Assert.Empty(hooks);
     }
 
     [Fact]
-    public void GetProviderHooks_WithMultipleProvidersWithHooks_ReturnsAllHooks()
+    public void GetProviderHooks_WithMultipleProvidersWithHooks_ReturnsEmptyList()
     {
         // Arrange
         var hook1 = Substitute.For<Hook>();
@@ -907,10 +905,7 @@ public class MultiProviderClassTests
         var hooks = multiProvider.GetProviderHooks();
 
         // Assert
-        Assert.Equal(3, hooks.Count);
-        Assert.Contains(hook1, hooks);
-        Assert.Contains(hook2, hooks);
-        Assert.Contains(hook3, hooks);
+        Assert.Empty(hooks);
     }
 
     [Fact]

--- a/test/OpenFeature.Providers.MultiProvider.Tests/ProviderExtensionsTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/ProviderExtensionsTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using OpenFeature.Constant;
@@ -15,6 +16,7 @@ public class ProviderExtensionsTests
     private readonly FeatureProvider _mockProvider = Substitute.For<FeatureProvider>();
     private readonly EvaluationContext _evaluationContext = new EvaluationContextBuilder().Build();
     private readonly CancellationToken _cancellationToken = CancellationToken.None;
+    private readonly ILogger _mockLogger = Substitute.For<ILogger>();
 
     [Fact]
     public async Task EvaluateAsync_WithBooleanType_CallsResolveBooleanValueAsync()
@@ -29,7 +31,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._mockLogger, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -53,7 +55,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._mockLogger, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -77,7 +79,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._mockLogger, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -101,7 +103,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._mockLogger, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -125,7 +127,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._mockLogger, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -144,7 +146,7 @@ public class ProviderExtensionsTests
         var providerContext = new StrategyPerProviderContext<DateTime>(this._mockProvider, TestProviderName, ProviderStatus.Ready, TestFlagKey);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._mockLogger, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -171,7 +173,7 @@ public class ProviderExtensionsTests
             .ThrowsAsync(expectedException);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._mockLogger, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -198,7 +200,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, null, defaultValue, null, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, null, defaultValue, this._mockLogger, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -223,7 +225,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, customCancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._mockLogger, customCancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -244,7 +246,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue!, null, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue!, this._mockLogger, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -266,7 +268,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._mockLogger, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -294,7 +296,7 @@ public class ProviderExtensionsTests
             });
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, cancellationTokenSource.Token);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._mockLogger, cancellationTokenSource.Token);
 
         // Assert
         Assert.NotNull(result);
@@ -325,7 +327,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, complexContext, defaultValue, null, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, complexContext, defaultValue, this._mockLogger, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);

--- a/test/OpenFeature.Providers.MultiProvider.Tests/ProviderExtensionsTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/ProviderExtensionsTests.cs
@@ -383,4 +383,23 @@ public class ProviderExtensionsTests
         // Verify finally hook was called
         await mockHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>());
     }
+
+    [Theory]
+    [InlineData(typeof(bool), FlagValueType.Boolean)]
+    [InlineData(typeof(string), FlagValueType.String)]
+    [InlineData(typeof(int), FlagValueType.Number)]
+    [InlineData(typeof(double), FlagValueType.Number)]
+    [InlineData(typeof(Value), FlagValueType.Object)]
+    [InlineData(typeof(ProviderExtensionsTests), FlagValueType.Object)] // fallback path
+    public void GetFlagValueType_ReturnsExpectedFlagValueType(Type inputType, FlagValueType expected)
+    {
+        FlagValueType result = inputType == typeof(bool) ? ProviderExtensions.GetFlagValueType<bool>()
+            : inputType == typeof(string) ? ProviderExtensions.GetFlagValueType<string>()
+            : inputType == typeof(int) ? ProviderExtensions.GetFlagValueType<int>()
+            : inputType == typeof(double) ? ProviderExtensions.GetFlagValueType<double>()
+            : inputType == typeof(Value) ? ProviderExtensions.GetFlagValueType<Value>()
+            : ProviderExtensions.GetFlagValueType<ProviderExtensionsTests>();
+
+        Assert.Equal(expected, result);
+    }
 }

--- a/test/OpenFeature.Providers.MultiProvider.Tests/ProviderExtensionsTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/ProviderExtensionsTests.cs
@@ -29,7 +29,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -53,7 +53,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -77,7 +77,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -101,7 +101,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -125,7 +125,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -144,7 +144,7 @@ public class ProviderExtensionsTests
         var providerContext = new StrategyPerProviderContext<DateTime>(this._mockProvider, TestProviderName, ProviderStatus.Ready, TestFlagKey);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -171,7 +171,7 @@ public class ProviderExtensionsTests
             .ThrowsAsync(expectedException);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -198,7 +198,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, null, defaultValue, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, null, defaultValue, null, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -223,7 +223,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, customCancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, customCancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -244,7 +244,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue!, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue!, null, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -266,7 +266,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -294,7 +294,7 @@ public class ProviderExtensionsTests
             });
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, cancellationTokenSource.Token);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, this._evaluationContext, defaultValue, null, cancellationTokenSource.Token);
 
         // Assert
         Assert.NotNull(result);
@@ -325,7 +325,7 @@ public class ProviderExtensionsTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await this._mockProvider.EvaluateAsync(providerContext, complexContext, defaultValue, this._cancellationToken);
+        var result = await this._mockProvider.EvaluateAsync(providerContext, complexContext, defaultValue, null, this._cancellationToken);
 
         // Assert
         Assert.NotNull(result);

--- a/test/OpenFeature.Providers.MultiProvider.Tests/ProviderExtensionsTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/ProviderExtensionsTests.cs
@@ -341,7 +341,7 @@ public class ProviderExtensionsTests
     {
         // Arrange
         var mockHook = Substitute.For<Hook>();
-        
+
         // Setup hook to return evaluation context successfully
         mockHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>())
             .Returns(EvaluationContext.Empty);
@@ -353,13 +353,13 @@ public class ProviderExtensionsTests
 
         const bool defaultValue = false;
         var errorDetails = new ResolutionDetails<bool>(
-            TestFlagKey, 
-            defaultValue, 
-            ErrorType.FlagNotFound, 
-            Reason.Error, 
-            TestVariant, 
+            TestFlagKey,
+            defaultValue,
+            ErrorType.FlagNotFound,
+            Reason.Error,
+            TestVariant,
             errorMessage: "Flag not found");
-        
+
         var providerContext = new StrategyPerProviderContext<bool>(this._mockProvider, TestProviderName, ProviderStatus.Ready, TestFlagKey);
 
         this._mockProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, Arg.Any<EvaluationContext>(), this._cancellationToken)
@@ -375,11 +375,11 @@ public class ProviderExtensionsTests
 
         // Verify before hook was called
         await mockHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>());
-        
+
         // Verify error hook was called (not after hook)
         await mockHook.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>());
         await mockHook.DidNotReceive().AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>());
-        
+
         // Verify finally hook was called
         await mockHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request introduces support for provider hooks in the Multi-Provider feature, ensuring that each provider's hooks are executed with context isolation as per the OpenFeature specification. It also updates the documentation to reflect these changes and refines how evaluation contexts and logging are handled in provider evaluations.

**Enhancements to Multi-Provider hook support:**

* Added execution of provider hooks for each underlying provider in Multi-Provider, with context isolation so that modifications by one provider's hooks do not affect others. This is implemented in `ProviderExtensions.cs` and integrated into the evaluation logic in `MultiProvider.cs`. [[1]](diffhunk://#diff-ca654537e60b595e68e4f9f1d48958a339bf9f00f37066feb295a9e11649b44fL14-R67) [[2]](diffhunk://#diff-ca654537e60b595e68e4f9f1d48958a339bf9f00f37066feb295a9e11649b44fR83-R179) [[3]](diffhunk://#diff-c8bc3d83c706a7332716c6d2773556d86f89ccbdf1d081f54aa9982f183d874aL273-R273) [[4]](diffhunk://#diff-c8bc3d83c706a7332716c6d2773556d86f89ccbdf1d081f54aa9982f183d874aL300-R300)
* Introduced helper methods `ExecuteBeforeEvaluationHooksAsync` and `ExecuteAfterEvaluationHooksAsync` in `ProviderExtensions.cs` to manage hook execution and error handling for each provider.

**Documentation updates:**

* Updated the `README.md` to clarify that provider hooks are now supported in Multi-Provider, and events are not fully supported. The limitations section was revised to remove the statement that hooks are not supported. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L446-R451) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L527-L528)

**Internal improvements:**

* Updated method signatures and usages in `ProviderExtensions.cs` and `MultiProvider.cs` to pass a logger instance for better diagnostics and error logging during hook execution. [[1]](diffhunk://#diff-ca654537e60b595e68e4f9f1d48958a339bf9f00f37066feb295a9e11649b44fL14-R67) [[2]](diffhunk://#diff-c8bc3d83c706a7332716c6d2773556d86f89ccbdf1d081f54aa9982f183d874aL273-R273) [[3]](diffhunk://#diff-c8bc3d83c706a7332716c6d2773556d86f89ccbdf1d081f54aa9982f183d874aL300-R300)
* Added necessary using directives to support new functionality, such as `System.Collections.Immutable` and `Microsoft.Extensions.Logging`. [[1]](diffhunk://#diff-ca654537e60b595e68e4f9f1d48958a339bf9f00f37066feb295a9e11649b44fR1-R5) [[2]](diffhunk://#diff-adfd68b1408ea5259fe85a61d86182f02a8e12ed47cf986ad4fc4c73845fb93fR1)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #551 