### PR TITLE
fix: Ensure EvaluationContext is reliably added to the injected FeatureClient

### DIFF
--- a/src/OpenFeature.Hosting/OpenFeatureBuilder.cs
+++ b/src/OpenFeature.Hosting/OpenFeatureBuilder.cs
@@ -12,6 +12,13 @@ public class OpenFeatureBuilder(IServiceCollection services)
     public IServiceCollection Services { get; } = services;
 
     /// <summary>
+    /// Indicates whether the evaluation context has been configured.
+    /// This property is used to determine if specific configurations or services
+    /// should be initialized based on the presence of an evaluation context.
+    /// </summary>
+    public bool IsContextConfigured { get; internal set; }
+
+    /// <summary>
     /// Indicates whether the policy has been configured.
     /// </summary>
     public bool IsPolicyConfigured { get; internal set; }

--- a/src/OpenFeature.Hosting/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.Hosting/OpenFeatureBuilderExtensions.cs
@@ -40,6 +40,7 @@ public static partial class OpenFeatureBuilderExtensions
         Guard.ThrowIfNull(builder);
         Guard.ThrowIfNull(configure);
 
+        builder.IsContextConfigured = true;
         builder.Services.TryAddTransient(provider =>
         {
             var contextBuilder = EvaluationContext.Builder();

--- a/test/OpenFeature.Hosting.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.Hosting.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -28,6 +28,7 @@ public partial class OpenFeatureBuilderExtensionsTests
 
         // Assert
         Assert.Equal(_systemUnderTest, featureBuilder);
+        Assert.True(_systemUnderTest.IsContextConfigured, "The context should be configured.");
         Assert.Single(_services, serviceDescriptor =>
             serviceDescriptor.ServiceType == typeof(EvaluationContext) &&
             serviceDescriptor.Lifetime == ServiceLifetime.Transient);
@@ -51,6 +52,7 @@ public partial class OpenFeatureBuilderExtensionsTests
         var context = serviceProvider.GetService<EvaluationContext>();
 
         // Assert
+        Assert.True(_systemUnderTest.IsContextConfigured, "The context should be configured.");
         Assert.NotNull(context);
         Assert.True(delegateCalled, "The delegate should be invoked.");
     }
@@ -76,6 +78,7 @@ public partial class OpenFeatureBuilderExtensionsTests
         };
 
         // Assert
+        Assert.False(_systemUnderTest.IsContextConfigured, "The context should not be configured.");
         Assert.Equal(expectsDefaultProvider, _systemUnderTest.HasDefaultProvider);
         Assert.False(_systemUnderTest.IsPolicyConfigured, "The policy should not be configured.");
         Assert.Equal(expectsDomainBoundProvider, _systemUnderTest.DomainBoundProviderRegistrationCount);
@@ -166,6 +169,7 @@ public partial class OpenFeatureBuilderExtensionsTests
         };
 
         // Assert
+        Assert.False(_systemUnderTest.IsContextConfigured, "The context should not be configured.");
         Assert.Equal(expectsDefaultProvider, _systemUnderTest.HasDefaultProvider);
         Assert.False(_systemUnderTest.IsPolicyConfigured, "The policy should not be configured.");
         Assert.Equal(expectsDomainBoundProvider, _systemUnderTest.DomainBoundProviderRegistrationCount);


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Fixes an issue with the `EvaluationContext` not being added to the API FeatureClient if a call to `AddContext()` was made after adding the Provider. For example, the following would fail to inject the `EvaluationContext`:

```csharp
builder.Services.AddOpenFeature(featureBuilder =>
{
    featureBuilder
        .AddInMemoryProvider(_ => new Dictionary<string, Flag>()
        {
            {
                "welcome-message", new Flag<bool>(
                    new Dictionary<string, bool> { { "show", true }, { "hide", false } }, "show")
            }
        })
        .AddContext(ctx => ctx.Set("region", "euw"));
});
```

The fix is not ported to the old Dependency Injection code as we are actively deprecating it.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #542

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

#### Before
<img width="788" height="494" alt="Screenshot 2025-10-20 201025" src="https://github.com/user-attachments/assets/210dbd49-d0fc-4052-a847-5ea78bcd210d" />

#### After
<img width="784" height="523" alt="image" src="https://github.com/user-attachments/assets/fde692a8-b269-49a0-b83e-2a24eb11319e" />
