### PR TITLE
fix: Ensure AddPolicyName without adding a Provider does not get stuck in infinite loop

### DIFF
--- a/src/OpenFeature.Hosting/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.Hosting/OpenFeatureBuilderExtensions.cs
@@ -223,12 +223,6 @@ public static partial class OpenFeatureBuilderExtensions
         {
             var policy = provider.GetRequiredService<IOptions<PolicyNameOptions>>().Value;
             var name = policy.DefaultNameSelector(provider);
-
-            if (name == null)
-            {
-                return ResolveFeatureClient(provider);
-            }
-
             return ResolveFeatureClient(provider, name);
         });
 
@@ -238,20 +232,9 @@ public static partial class OpenFeatureBuilderExtensions
     private static IFeatureClient ResolveFeatureClient(IServiceProvider provider, string? name = null)
     {
         var api = provider.GetRequiredService<Api>();
+        var client = api.GetClient(name);
         var context = provider.GetService<EvaluationContext>();
-        FeatureClient client;
-        if (name == null)
-        {
-            client = api.GetClient();
-            if (context is not null)
-            {
-                client.SetContext(context);
-            }
-            return client;
-        }
-
-        client = api.GetClient(name);
-        if (context is not null)
+        if (context != null)
         {
             client.SetContext(context);
         }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Updates the code such that it does not rely on any previous registration of a `IFeatureClient`. If you fail to specify a Provider and instruct the FeatureBuilder to introduce a policy for determining which provider to use, the code will get stuck infinitely trying to resolve `IFeatureClient`. For example:

```csharp
var builder = WebApplication.CreateSlimBuilder(args);

builder.Services.AddOpenFeature(featureBuilder =>
{
    featureBuilder
        .AddPolicyName(policy =>
        {
            policy.DefaultNameSelector = provider =>
            {
                return null;
            };
        });
});

var app = builder.Build();

app.MapGet("/welcome", async ([FromServices] IFeatureClient featureClient) =>
{
    var welcomeMessageEnabled = await featureClient.GetBooleanValueAsync("welcome-message", false);

    if (welcomeMessageEnabled)
    {
        return TypedResults.Ok("Hello world! The welcome-message feature flag was enabled!");
    }

    return TypedResults.Ok("Hello world!");
});

app.Run();
```

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #543

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

