### PR TITLE
refactor: Clean up project files by removing TargetFrameworks and formatting

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import
     Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenFeature.slnx'))\build\Common.prod.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net462</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <!-- Enable native AOT related analyzers
     https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers -->
     <IsAotCompatible>$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))</IsAotCompatible>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,10 @@
 <Project>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenFeature.slnx'))\build\Common.prod.props" />
+  <Import
+    Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenFeature.slnx'))\build\Common.prod.props" />
   <PropertyGroup>
-    <!-- Enable native AOT related analyzers https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers -->
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net462</TargetFrameworks>
+    <!-- Enable native AOT related analyzers
+    https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers -->
     <IsAotCompatible>$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))</IsAotCompatible>
   </PropertyGroup>
 </Project>

--- a/src/OpenFeature.DependencyInjection/OpenFeature.DependencyInjection.csproj
+++ b/src/OpenFeature.DependencyInjection/OpenFeature.DependencyInjection.csproj
@@ -1,24 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net462</TargetFrameworks>
-    <RootNamespace>OpenFeature.DependencyInjection</RootNamespace>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <RootNamespace>OpenFeature.DependencyInjection</RootNamespace>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Options" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\OpenFeature\OpenFeature.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\OpenFeature\OpenFeature.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="$(AssemblyName).Tests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-    <None Include="README.md" Pack="true" PackagePath="/" />
-  </ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+        <None Include="README.md" Pack="true" PackagePath="/" />
+    </ItemGroup>
 
 </Project>

--- a/src/OpenFeature.Hosting/OpenFeature.Hosting.csproj
+++ b/src/OpenFeature.Hosting/OpenFeature.Hosting.csproj
@@ -1,23 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net462</TargetFrameworks>
-    <RootNamespace>OpenFeature</RootNamespace>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <RootNamespace>OpenFeature</RootNamespace>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\OpenFeature\OpenFeature.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\OpenFeature\OpenFeature.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="$(AssemblyName).Tests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-    <None Include="README.md" Pack="true" PackagePath="/" />
-  </ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+        <None Include="README.md" Pack="true" PackagePath="/" />
+    </ItemGroup>
 
 </Project>

--- a/src/OpenFeature.Providers.MultiProvider/OpenFeature.Providers.MultiProvider.csproj
+++ b/src/OpenFeature.Providers.MultiProvider/OpenFeature.Providers.MultiProvider.csproj
@@ -1,18 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;netstandard2.0;net462</TargetFrameworks>
-    <RootNamespace>OpenFeature.Providers.MultiProvider</RootNamespace>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <RootNamespace>OpenFeature.Providers.MultiProvider</RootNamespace>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-    <InternalsVisibleTo Include="OpenFeature.Providers.MultiProvider.Tests" />
-    <None Include="README.md" Pack="true" PackagePath="/" />
-  </ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+        <InternalsVisibleTo Include="OpenFeature.Providers.MultiProvider.Tests" />
+        <None Include="README.md" Pack="true" PackagePath="/" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\OpenFeature\OpenFeature.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\OpenFeature\OpenFeature.csproj" />
+    </ItemGroup>
 </Project>

--- a/src/OpenFeature/OpenFeature.csproj
+++ b/src/OpenFeature/OpenFeature.csproj
@@ -1,28 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;netstandard2.0;net462</TargetFrameworks>
-    <RootNamespace>OpenFeature</RootNamespace>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <RootNamespace>OpenFeature</RootNamespace>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="System.Text.Json" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces"
+            Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
+        <PackageReference Include="Microsoft.Bcl.HashCode"
+            Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource"
+            Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
+        <PackageReference Include="System.Text.Json"
+            Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-    <InternalsVisibleTo Include="OpenFeature.Benchmarks" />
-    <InternalsVisibleTo Include="OpenFeature.Tests" />
-    <InternalsVisibleTo Include="OpenFeature.E2ETests" />
-    <InternalsVisibleTo Include="OpenFeature.DependencyInjection" />
-    <InternalsVisibleTo Include="OpenFeature.Providers.MultiProvider" />
-    <InternalsVisibleTo Include="OpenFeature.Providers.MultiProvider.Tests" />
-    <None Include="../../README.md" Pack="true" PackagePath="/" />
-  </ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+        <InternalsVisibleTo Include="OpenFeature.Benchmarks" />
+        <InternalsVisibleTo Include="OpenFeature.Tests" />
+        <InternalsVisibleTo Include="OpenFeature.E2ETests" />
+        <InternalsVisibleTo Include="OpenFeature.DependencyInjection" />
+        <InternalsVisibleTo Include="OpenFeature.Providers.MultiProvider" />
+        <InternalsVisibleTo Include="OpenFeature.Providers.MultiProvider.Tests" />
+        <None Include="../../README.md" Pack="true" PackagePath="/" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the target frameworks configuration for several projects to centralize and simplify framework management. The main change is moving the `TargetFrameworks` property from individual project files to the shared `Directory.Build.props` file, ensuring consistency across all projects. Minor formatting improvements were also made for readability.

**Centralized Target Frameworks Configuration:**

* Moved the `TargetFrameworks` property from each individual `.csproj` file (`OpenFeature`, `OpenFeature.DependencyInjection`, `OpenFeature.Hosting`, and `OpenFeature.Providers.MultiProvider`) to the shared `Directory.Build.props` file for unified management. [[1]](diffhunk://#diff-55279cca9fb64343216b7896e3aa5ea96521b091ba68f0b06a2e9430b0a35962L4) [[2]](diffhunk://#diff-1ceba8f8b16fba8e2b45f9f2f2c78e2e92129949e560f4346df2dd99fdbbd5f4L4) [[3]](diffhunk://#diff-01e876fff0de5b0d10b904726ff92feb80b821a557114778ee6795168a3b924bL4) [[4]](diffhunk://#diff-711ea17cbdebe419375c7684c8c39a1423d2bebcf8976ddd7bdd78deaab65b21L4-R17) [[5]](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907L2-R7)

**Formatting Improvements:**

* Improved formatting of `Import` and `PackageReference` elements in `Directory.Build.props` and `OpenFeature/OpenFeature.csproj` for better readability and maintainability. [[1]](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907L2-R7) [[2]](diffhunk://#diff-711ea17cbdebe419375c7684c8c39a1423d2bebcf8976ddd7bdd78deaab65b21L4-R17)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #610