### PR TITLE
feat: Add tracking to multi-provider

### DIFF
--- a/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
+++ b/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
@@ -133,7 +133,7 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
                 registeredProvider.Provider,
                 registeredProvider.Name,
                 registeredProvider.Status,
-                string.Empty); // Empty flag key for tracking context
+                string.Empty); // Tracking operations are not flag-specific, so the flag key is intentionally set to an empty string
 
             if (this._evaluationStrategy.ShouldTrackWithThisProvider(providerContext, evaluationContext, trackingEventName, trackingEventDetails))
             {

--- a/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
+++ b/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
@@ -676,9 +676,9 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
     [LoggerMessage(EventId = 1, Level = LogLevel.Debug, Message = "Provider {ProviderName} is already being listened to")]
     private partial void LogProviderAlreadyBeingListenedTo(string providerName);
 
-    [LoggerMessage(EventId = 2, Level = LogLevel.Debug, Message = "Error tracking event {TrackingEventName} with provider {ProviderName}")]
+    [LoggerMessage(EventId = 2, Level = LogLevel.Error, Message = "Error tracking event {TrackingEventName} with provider {ProviderName}")]
     private partial void LogErrorTrackingEvent(string providerName, string trackingEventName, Exception exception);
 
-    [LoggerMessage(EventId = 3, Level = LogLevel.Debug, Message = "Tracking event with empty name is not allowed")]
+    [LoggerMessage(EventId = 3, Level = LogLevel.Error, Message = "Tracking event with empty name is not allowed")]
     private partial void LogErrorTrackingEventEmptyName();
 }

--- a/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
+++ b/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
@@ -121,6 +121,12 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
             throw new ObjectDisposedException(nameof(MultiProvider));
         }
 
+        if (string.IsNullOrWhiteSpace(trackingEventName))
+        {
+            this.LogErrorTrackingEventEmptyName();
+            return;
+        }
+
         foreach (var registeredProvider in this._registeredProviders)
         {
             var providerContext = new StrategyPerProviderContext<object>(
@@ -672,4 +678,7 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
 
     [LoggerMessage(EventId = 2, Level = LogLevel.Debug, Message = "Error tracking event {TrackingEventName} with provider {ProviderName}")]
     private partial void LogErrorTrackingEvent(string providerName, string trackingEventName, Exception exception);
+
+    [LoggerMessage(EventId = 3, Level = LogLevel.Debug, Message = "Tracking event with empty name is not allowed")]
+    private partial void LogErrorTrackingEventEmptyName();
 }

--- a/src/OpenFeature.Providers.MultiProvider/Strategies/BaseEvaluationStrategy.cs
+++ b/src/OpenFeature.Providers.MultiProvider/Strategies/BaseEvaluationStrategy.cs
@@ -66,7 +66,7 @@ public abstract class BaseEvaluationStrategy
     /// <param name="trackingEventName">The name of the tracking event.</param>
     /// <param name="trackingEventDetails">The tracking event details.</param>
     /// <returns>True if the provider should receive tracking events, false otherwise.</returns>
-    public virtual bool ShouldTrackWithThisProvider(StrategyPerProviderContext<object> strategyContext, EvaluationContext? evaluationContext, string trackingEventName, TrackingEventDetails? trackingEventDetails)
+    public virtual bool ShouldTrackWithThisProvider<T>(StrategyPerProviderContext<T> strategyContext, EvaluationContext? evaluationContext, string trackingEventName, TrackingEventDetails? trackingEventDetails)
     {
         // By default, track with providers that are ready
         return strategyContext.ProviderStatus == ProviderStatus.Ready;

--- a/src/OpenFeature.Providers.MultiProvider/Strategies/BaseEvaluationStrategy.cs
+++ b/src/OpenFeature.Providers.MultiProvider/Strategies/BaseEvaluationStrategy.cs
@@ -59,6 +59,20 @@ public abstract class BaseEvaluationStrategy
     public abstract FinalResult<T> DetermineFinalResult<T>(StrategyEvaluationContext<T> strategyContext, string key, T defaultValue, EvaluationContext? evaluationContext, List<ProviderResolutionResult<T>> resolutions);
 
     /// <summary>
+    /// Determines whether a specific provider should receive tracking events.
+    /// </summary>
+    /// <param name="strategyContext">Context information about the provider.</param>
+    /// <param name="evaluationContext">The evaluation context for the tracking event.</param>
+    /// <param name="trackingEventName">The name of the tracking event.</param>
+    /// <param name="trackingEventDetails">The tracking event details.</param>
+    /// <returns>True if the provider should receive tracking events, false otherwise.</returns>
+    public virtual bool ShouldTrackWithThisProvider(StrategyPerProviderContext<object> strategyContext, EvaluationContext? evaluationContext, string trackingEventName, TrackingEventDetails? trackingEventDetails)
+    {
+        // By default, track with providers that are ready
+        return strategyContext.ProviderStatus == ProviderStatus.Ready;
+    }
+
+    /// <summary>
     /// Checks if a resolution result represents an error.
     /// </summary>
     /// <typeparam name="T">The type of the resolved value.</typeparam>

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTrackingTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTrackingTests.cs
@@ -1,0 +1,299 @@
+using NSubstitute;
+using OpenFeature.Constant;
+using OpenFeature.Model;
+using OpenFeature.Providers.MultiProvider.Models;
+using OpenFeature.Providers.MultiProvider.Strategies;
+using OpenFeature.Providers.MultiProvider.Strategies.Models;
+using OpenFeature.Providers.MultiProvider.Tests.Utils;
+
+namespace OpenFeature.Providers.MultiProvider.Tests;
+
+public class MultiProviderTrackingTests
+{
+    private const string TestTrackingEventName = "test-event";
+    private const string Provider1Name = "provider1";
+    private const string Provider2Name = "provider2";
+    private const string Provider3Name = "provider3";
+
+    private readonly TestProvider _testProvider1 = new(Provider1Name);
+    private readonly TestProvider _testProvider2 = new(Provider2Name);
+    private readonly TestProvider _testProvider3 = new(Provider3Name);
+    private readonly EvaluationContext _evaluationContext = EvaluationContext.Builder().Build();
+
+    [Fact]
+    public async Task Track_WithMultipleReadyProviders_CallsTrackOnAllReadyProviders()
+    {
+        // Arrange
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._testProvider1, Provider1Name),
+            new(this._testProvider2, Provider2Name),
+            new(this._testProvider3, Provider3Name)
+        };
+
+        var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
+        await multiProvider.InitializeAsync(this._evaluationContext);
+
+        var trackingDetails = TrackingEventDetails.Builder().SetValue(99.99).Build();
+
+        // Act
+        multiProvider.Track(TestTrackingEventName, this._evaluationContext, trackingDetails);
+
+        // Assert
+        var provider1Invocations = this._testProvider1.GetTrackingInvocations();
+        var provider2Invocations = this._testProvider2.GetTrackingInvocations();
+        var provider3Invocations = this._testProvider3.GetTrackingInvocations();
+
+        Assert.Single(provider1Invocations);
+        Assert.Single(provider2Invocations);
+        Assert.Single(provider3Invocations);
+
+        Assert.Equal(TestTrackingEventName, provider1Invocations[0].EventName);
+        Assert.Equal(TestTrackingEventName, provider2Invocations[0].EventName);
+        Assert.Equal(TestTrackingEventName, provider3Invocations[0].EventName);
+
+        Assert.Equal(trackingDetails.Value, provider1Invocations[0].TrackingEventDetails?.Value);
+        Assert.Equal(trackingDetails.Value, provider2Invocations[0].TrackingEventDetails?.Value);
+        Assert.Equal(trackingDetails.Value, provider3Invocations[0].TrackingEventDetails?.Value);
+    }
+
+    [Fact]
+    public async Task Track_WithNullEvaluationContext_CallsTrackWithNullContext()
+    {
+        // Arrange
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._testProvider1, Provider1Name),
+            new(this._testProvider2, Provider2Name)
+        };
+
+        var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
+        await multiProvider.InitializeAsync(this._evaluationContext);
+
+        // Act
+        multiProvider.Track(TestTrackingEventName);
+
+        // Assert
+        var provider1Invocations = this._testProvider1.GetTrackingInvocations();
+        var provider2Invocations = this._testProvider2.GetTrackingInvocations();
+
+        Assert.Single(provider1Invocations);
+        Assert.Single(provider2Invocations);
+
+        Assert.Equal(TestTrackingEventName, provider1Invocations[0].EventName);
+        Assert.Equal(TestTrackingEventName, provider2Invocations[0].EventName);
+    }
+
+    [Fact]
+    public async Task Track_WithNullTrackingDetails_CallsTrackWithNullDetails()
+    {
+        // Arrange
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._testProvider1, Provider1Name),
+            new(this._testProvider2, Provider2Name)
+        };
+
+        var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
+        await multiProvider.InitializeAsync(this._evaluationContext);
+
+        // Act
+        multiProvider.Track(TestTrackingEventName, this._evaluationContext);
+
+        // Assert
+        var provider1Invocations = this._testProvider1.GetTrackingInvocations();
+        var provider2Invocations = this._testProvider2.GetTrackingInvocations();
+
+        Assert.Single(provider1Invocations);
+        Assert.Single(provider2Invocations);
+
+        Assert.Equal(TestTrackingEventName, provider1Invocations[0].EventName);
+        Assert.Null(provider1Invocations[0].TrackingEventDetails);
+
+        Assert.Equal(TestTrackingEventName, provider2Invocations[0].EventName);
+        Assert.Null(provider2Invocations[0].TrackingEventDetails);
+    }
+
+    [Fact]
+    public async Task Track_WhenProviderThrowsException_ContinuesWithOtherProviders()
+    {
+        // Arrange
+        var throwingProvider = Substitute.For<FeatureProvider>();
+        throwingProvider.GetMetadata().Returns(new Metadata(Provider2Name));
+        throwingProvider.When(x => x.Track(Arg.Any<string>(), Arg.Any<EvaluationContext>(), Arg.Any<TrackingEventDetails>()))
+            .Do(_ => throw new InvalidOperationException("Test exception"));
+
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._testProvider1, Provider1Name),
+            new(throwingProvider, Provider2Name),
+            new(this._testProvider3, Provider3Name)
+        };
+
+        var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
+        await multiProvider.InitializeAsync(this._evaluationContext);
+
+        // Manually set all providers to Ready status
+        throwingProvider.Status.Returns(ProviderStatus.Ready);
+
+        var trackingDetails = TrackingEventDetails.Builder().SetValue(99.99).Build();
+
+        // Act
+        multiProvider.Track(TestTrackingEventName, this._evaluationContext, trackingDetails);
+
+        // Assert - should not throw and should continue with other providers
+        var provider1Invocations = this._testProvider1.GetTrackingInvocations();
+        var provider3Invocations = this._testProvider3.GetTrackingInvocations();
+
+        Assert.Single(provider1Invocations);
+        Assert.Single(provider3Invocations);
+
+        throwingProvider.Received(1).Track(TestTrackingEventName, Arg.Any<EvaluationContext>(), trackingDetails);
+    }
+
+    [Fact]
+    public async Task Track_WhenDisposed_ThrowsObjectDisposedException()
+    {
+        // Arrange
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._testProvider1, Provider1Name)
+        };
+
+        var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
+        await multiProvider.InitializeAsync(this._evaluationContext);
+        await multiProvider.DisposeAsync();
+
+        // Act & Assert
+        Assert.Throws<ObjectDisposedException>(() => multiProvider.Track(TestTrackingEventName, this._evaluationContext));
+    }
+
+    [Fact]
+    public async Task Track_WithCustomStrategy_RespectsStrategyDecision()
+    {
+        // Arrange
+        var customStrategy = Substitute.For<BaseEvaluationStrategy>();
+        customStrategy.RunMode.Returns(RunMode.Sequential);
+
+        // Only allow tracking with the first provider
+        customStrategy.ShouldTrackWithThisProvider(
+            Arg.Is<StrategyPerProviderContext<object>>(ctx => ctx.ProviderName == Provider1Name),
+            Arg.Any<EvaluationContext>(),
+            Arg.Any<string>(),
+            Arg.Any<TrackingEventDetails>()
+        ).Returns(true);
+
+        customStrategy.ShouldTrackWithThisProvider(
+            Arg.Is<StrategyPerProviderContext<object>>(ctx => ctx.ProviderName != Provider1Name),
+            Arg.Any<EvaluationContext>(),
+            Arg.Any<string>(),
+            Arg.Any<TrackingEventDetails>()
+        ).Returns(false);
+
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._testProvider1, Provider1Name),
+            new(this._testProvider2, Provider2Name),
+            new(this._testProvider3, Provider3Name)
+        };
+
+        var multiProvider = new MultiProvider(providerEntries, customStrategy);
+        await multiProvider.InitializeAsync(this._evaluationContext);
+
+        var trackingDetails = TrackingEventDetails.Builder().SetValue(99.99).Build();
+
+        // Act
+        multiProvider.Track(TestTrackingEventName, this._evaluationContext, trackingDetails);
+
+        // Assert - only provider1 should receive the tracking call
+        var provider1Invocations = this._testProvider1.GetTrackingInvocations();
+        var provider2Invocations = this._testProvider2.GetTrackingInvocations();
+        var provider3Invocations = this._testProvider3.GetTrackingInvocations();
+
+        Assert.Single(provider1Invocations);
+        Assert.Empty(provider2Invocations);
+        Assert.Empty(provider3Invocations);
+
+        customStrategy.Received(3).ShouldTrackWithThisProvider(
+            Arg.Any<StrategyPerProviderContext<object>>(),
+            Arg.Any<EvaluationContext>(),
+            TestTrackingEventName,
+            trackingDetails
+        );
+    }
+
+    [Fact]
+    public async Task Track_WithComplexTrackingDetails_PropagatesAllDetails()
+    {
+        // Arrange
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._testProvider1, Provider1Name),
+            new(this._testProvider2, Provider2Name)
+        };
+
+        var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
+        await multiProvider.InitializeAsync(this._evaluationContext);
+
+        var trackingDetails = TrackingEventDetails.Builder()
+            .SetValue(199.99)
+            .Set("currency", new Value("USD"))
+            .Set("productId", new Value("prod-123"))
+            .Set("quantity", new Value(5))
+            .Build();
+
+        // Act
+        multiProvider.Track(TestTrackingEventName, this._evaluationContext, trackingDetails);
+
+        // Assert
+        var provider1Invocations = this._testProvider1.GetTrackingInvocations();
+        var provider2Invocations = this._testProvider2.GetTrackingInvocations();
+
+        Assert.Single(provider1Invocations);
+        Assert.Single(provider2Invocations);
+
+        var details1 = provider1Invocations[0].TrackingEventDetails;
+        var details2 = provider2Invocations[0].TrackingEventDetails;
+
+        Assert.NotNull(details1);
+        Assert.NotNull(details2);
+
+        Assert.Equal(199.99, details1.Value);
+        Assert.Equal(199.99, details2.Value);
+
+        Assert.Equal("USD", details1.GetValue("currency").AsString);
+        Assert.Equal("USD", details2.GetValue("currency").AsString);
+
+        Assert.Equal("prod-123", details1.GetValue("productId").AsString);
+        Assert.Equal("prod-123", details2.GetValue("productId").AsString);
+
+        Assert.Equal(5, details1.GetValue("quantity").AsInteger);
+        Assert.Equal(5, details2.GetValue("quantity").AsInteger);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task Track_WhenEmptyTrackingDetails_DoesNotThrow(string? trackingEventName)
+    {
+        // Arrange
+        var providerEntries = new List<ProviderEntry>
+        {
+            new(this._testProvider1, Provider1Name),
+            new(this._testProvider2, Provider2Name)
+        };
+
+        var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
+        await multiProvider.InitializeAsync(this._evaluationContext);
+
+        // Act & Assert
+        multiProvider.Track(trackingEventName!, this._evaluationContext, TrackingEventDetails.Empty);
+
+        var provider1Invocations = this._testProvider1.GetTrackingInvocations();
+        var provider2Invocations = this._testProvider2.GetTrackingInvocations();
+
+        Assert.Empty(provider1Invocations);
+        Assert.Empty(provider2Invocations);
+    }
+}

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTrackingTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTrackingTests.cs
@@ -275,7 +275,7 @@ public class MultiProviderTrackingTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public async Task Track_WhenEmptyTrackingDetails_DoesNotThrow(string? trackingEventName)
+    public async Task Track_WhenInvalidTrackingEventName_DoesNotCallProviders(string? trackingEventName)
     {
         // Arrange
         var providerEntries = new List<ProviderEntry>

--- a/test/OpenFeature.Providers.MultiProvider.Tests/Utils/TestProvider.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/Utils/TestProvider.cs
@@ -6,7 +6,19 @@ namespace OpenFeature.Providers.MultiProvider.Tests.Utils;
 /// <summary>
 /// Represents a tracking invocation for testing purposes.
 /// </summary>
-public record TrackingInvocation(string EventName, EvaluationContext? EvaluationContext, TrackingEventDetails? TrackingEventDetails);
+public class TrackingInvocation
+{
+    public string EventName { get; }
+    public EvaluationContext? EvaluationContext { get; }
+    public TrackingEventDetails? TrackingEventDetails { get; }
+
+    public TrackingInvocation(string eventName, EvaluationContext? evaluationContext, TrackingEventDetails? trackingEventDetails)
+    {
+        this.EventName = eventName;
+        this.EvaluationContext = evaluationContext;
+        this.TrackingEventDetails = trackingEventDetails;
+    }
+}
 
 /// <summary>
 /// A test implementation of FeatureProvider for MultiProvider testing.


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request adds support for tracking events in the `MultiProvider` feature flag provider, allowing tracking events to be propagated to underlying providers according to a customizable strategy. It introduces a new `Track` method, provides robust error handling and logging, and adds comprehensive unit tests to verify tracking behavior under various scenarios.

### Tracking event support

* Added a `Track` method to `MultiProvider` that propagates tracking events to all eligible underlying providers, with error handling and logging for invalid event names and provider exceptions.
* Implemented the `ShouldTrackWithThisProvider` method in `BaseEvaluationStrategy` to allow strategies to control which providers receive tracking events (defaulting to providers with `Ready` status).

### Logging improvements

* Added new logger message methods to `MultiProvider` for tracking event errors and empty event names.

### Testing and utilities

* Added a new test suite `MultiProviderTrackingTests` covering scenarios such as multiple providers, exception handling, invalid event names, custom strategies, and propagation of complex tracking details.
* Enhanced the `TestProvider` utility to record tracking invocations for assertions in tests. [[1]](diffhunk://#diff-99193ae7d4cb066df86688c4ee15520b117d8f90cc00288fcfe07fd01835df92R1-R10) [[2]](diffhunk://#diff-99193ae7d4cb066df86688c4ee15520b117d8f90cc00288fcfe07fd01835df92R19) [[3]](diffhunk://#diff-99193ae7d4cb066df86688c4ee15520b117d8f90cc00288fcfe07fd01835df92R28-R31) [[4]](diffhunk://#diff-99193ae7d4cb066df86688c4ee15520b117d8f90cc00288fcfe07fd01835df92R73-R91)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #550