### PR TITLE
feat: Add SourceLink configuration for .NET to enhance debugging experience

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -33,4 +33,16 @@
     <None Include="$(MSBuildThisFileDirectory)openfeature-icon.png" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
+  <!-- SourceLink configuration for .NET SDK 8+ -->
+  <!-- https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/source-link -->
+  <PropertyGroup Label="SourceLink">
+    <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- Include symbols in a separate .snupkg file -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request adds SourceLink configuration to the `build/Common.prod.props` file to improve debugging and source code traceability for .NET SDK 8 and above. The most important change is the inclusion of properties that enable publishing repository URLs, embedding untracked sources, and generating symbol packages.

SourceLink configuration:

* Added a new `PropertyGroup` labeled `SourceLink` that enables publishing the repository URL, embedding untracked sources in PDBs, and generating separate symbol packages (`.snupkg`).

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #535