### PR TITLE
docs: Update deprecation notice in README.md

### DIFF
--- a/src/OpenFeature.DependencyInjection/README.md
+++ b/src/OpenFeature.DependencyInjection/README.md
@@ -1,6 +1,6 @@
 # OpenFeature.DependencyInjection
 
-> **⚠️ DEPRECATED**: This library is now deprecated. The OpenTelemetry Dependency Injection library has been moved to the OpenFeature Hosting integration in version 2.9.0.
+> **⚠️ DEPRECATED**: This library is now deprecated. The OpenFeature Dependency Injection library has been moved to the OpenFeature Hosting integration in version 2.9.0.
 
 OpenFeature is an open standard for feature flag management, created to support a robust feature flag ecosystem using cloud native technologies. OpenFeature will provide a unified API and SDK, and a developer-first, cloud-native implementation, with extensibility for open source and commercial offerings.
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request makes a minor correction to the deprecation notice in the `README.md` file for the `OpenFeature.DependencyInjection` package. The change clarifies that the "OpenFeature Dependency Injection" library (not "OpenTelemetry Dependency Injection") has been moved to the OpenFeature Hosting integration in version 2.9.0.
