### PR TITLE
ci: Update macOS version in AOT compatibility workflow

### DIFF
--- a/.github/workflows/aot-compatibility.yml
+++ b/.github/workflows/aot-compatibility.yml
@@ -34,7 +34,7 @@ jobs:
             arch: arm64
             runtime: win-arm64
           # macOS x64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x64
             runtime: osx-x64
           # macOS ARM64 (Apple Silicon)


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the AOT compatibility GitHub Actions workflow to use a newer macOS runner for x64 builds.

Workflow runner update:

* Changed the x64 macOS build runner from `macos-13` to `macos-15-intel` in the `.github/workflows/aot-compatibility.yml` workflow to ensure compatibility with the latest GitHub-hosted runners.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes
<!-- any additional notes for this PR -->
See https://github.com/actions/runner-images/issues/13046