### PR TITLE
ci: Fix build for the dotnet SDK and macOS runner image

### DIFF
--- a/.github/workflows/aot-compatibility.yml
+++ b/.github/workflows/aot-compatibility.yml
@@ -34,7 +34,7 @@ jobs:
             arch: arm64
             runtime: win-arm64
           # macOS x64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x64
             runtime: osx-x64
           # macOS ARM64 (Apple Silicon)

--- a/build/Common.props
+++ b/build/Common.props
@@ -28,4 +28,11 @@
   <ItemGroup Condition="'$(OS)' == 'Unix'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="all" />
   </ItemGroup>
+
+  <!-- This is a workaround for targeting .NET Framework 4.6.2 (it fails to build with certain
+  warnings) -->
+  <PropertyGroup
+    Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net462'))">
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "rollForward": "latestFeature",
-    "version": "9.0.300",
+    "rollForward": "disable",
+    "version": "9.0.306",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request contains several updates aimed at improving build reliability and compatibility across different environments. The most important changes include updating the .NET SDK version, adjusting the build configuration for .NET Framework 4.6.2, and updating the macOS runner for CI workflows.

**Build and SDK configuration improvements:**

* Updated the .NET SDK version in `global.json` from `9.0.300` to `9.0.306` and set `rollForward` to `"disable"` to ensure the build uses the specified SDK version exactly, improving build reproducibility.
* Added a property group in `build/Common.props` to suppress target framework support warnings when building for .NET Framework 4.6.2, working around build failures due to certain warnings.

**CI workflow updates:**

* Updated the macOS x64 runner in `.github/workflows/aot-compatibility.yml` from `macos-13` to `macos-15-intel` to ensure compatibility with current GitHub-hosted runners.

### Notes
<!-- any additional notes for this PR -->

We were getting errors in the latest 9.0.x.
9.0.112 -> https://github.com/open-feature/dotnet-sdk/actions/runs/19275629307
10.0.100 -> https://github.com/open-feature/dotnet-sdk/actions/runs/19275919896
9.0.111 -> https://github.com/open-feature/dotnet-sdk/actions/runs/19276071981

This attempts to lock it to the version 9.0.111 until we fully migrate to the SDK 10.0