### PR TITLE
ci: Update SDK version and rollForward policy

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "rollForward": "disable",
-    "version": "9.0.306",
+    "rollForward": "latestFeature",
+    "version": "9.0.300",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request makes a minor update to the `.NET` SDK configuration in `global.json`, changing the SDK version and roll-forward policy. The new settings allow the use of the latest feature version within the same major version, and set the SDK version to `9.0.300` instead of `9.0.306`.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Related to https://github.com/dotnet/msbuild/issues/12751