### PR TITLE
feat: Upgrade to dotnet version 10

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/dotnet:latest": {
       "version": "10.0",
-      "additionalVersions": "9.0;8.0"
+      "dotnetRuntimeVersions": "9.0, 8.0"
     },
     "ghcr.io/devcontainers/features/github-cli:latest": {},
     "ghcr.io/devcontainers/features/docker-in-docker": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 {
   "name": "OpenFeature .NET SDK",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:9.0-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
   "features": {
     "ghcr.io/devcontainers/features/dotnet:latest": {
-      "version": "9.0",
-      "additionalVersions": "8.0"
+      "version": "10.0",
+      "additionalVersions": "9.0;8.0"
     },
     "ghcr.io/devcontainers/features/github-cli:latest": {},
     "ghcr.io/devcontainers/features/docker-in-docker": {}

--- a/.github/workflows/aot-compatibility.yml
+++ b/.github/workflows/aot-compatibility.yml
@@ -81,6 +81,7 @@ jobs:
         shell: pwsh
         run: |
           dotnet publish test/OpenFeature.AotCompatibility/OpenFeature.AotCompatibility.csproj `
+            -f net10.0 `
             -r ${{ matrix.runtime }} `
             -o ./aot-output
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
@@ -49,11 +49,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.21" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.22" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.11" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,9 @@
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
     <MicrosoftExtensionsVersion>9.0.0</MicrosoftExtensionsVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net10.0'))">
+    <MicrosoftExtensionsVersion>10.0.0</MicrosoftExtensionsVersion>
+  </PropertyGroup>
 
   <ItemGroup Label="src">
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftExtensionsVersion)" />
@@ -51,6 +54,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.10" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Unix'">

--- a/build/Common.samples.props
+++ b/build/Common.samples.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/docs/AOT_COMPATIBILITY.md
+++ b/docs/AOT_COMPATIBILITY.md
@@ -26,7 +26,7 @@ To enable NativeAOT in your project, add these properties to your `.csproj` file
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework> <!-- or net9.0 -->
+    <TargetFramework>net8.0</TargetFramework> <!-- or net9.0, net10.0 -->
     <OutputType>Exe</OutputType>
 
     <!-- Enable NativeAOT -->

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "9.0.300",
+    "version": "10.0.100",
     "allowPrerelease": false
   }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import
     Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenFeature.slnx'))\build\Common.prod.props" />
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <!-- Enable native AOT related analyzers
     https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers -->
     <IsAotCompatible>$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))</IsAotCompatible>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,3 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenFeature.slnx'))\build\Common.tests.props" />
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+  </PropertyGroup>
 </Project>

--- a/test/OpenFeature.AotCompatibility/OpenFeature.AotCompatibility.csproj
+++ b/test/OpenFeature.AotCompatibility/OpenFeature.AotCompatibility.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj
+++ b/test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <RootNamespace>OpenFeature.Benchmark</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
+++ b/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <RootNamespace>OpenFeature.E2ETests</RootNamespace>
   </PropertyGroup>
 

--- a/test/OpenFeature.Hosting.Tests/OpenFeature.Hosting.Tests.csproj
+++ b/test/OpenFeature.Hosting.Tests/OpenFeature.Hosting.Tests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <RootNamespace>OpenFeature.Hosting.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
+++ b/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenFeature.Providers.MultiProvider.Tests/OpenFeature.Providers.MultiProvider.Tests.csproj
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/OpenFeature.Providers.MultiProvider.Tests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <RootNamespace>OpenFeature.Providers.MultiProvider.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/test/OpenFeature.Tests/OpenFeature.Tests.csproj
+++ b/test/OpenFeature.Tests/OpenFeature.Tests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <RootNamespace>OpenFeature.Tests</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request adds support for .NET 10.0 across the codebase, updating project files, dependencies, and build/test configurations to ensure compatibility. It also updates the devcontainer and global SDK version to .NET 10.0, and makes minor dependency version bumps for related packages.

**.NET 10.0 Support and Configuration Updates:**

* Added `net10.0` to `TargetFrameworks` in main, test, and sample project files, ensuring all relevant projects can build and run against .NET 10.0. (`src/Directory.Build.props`, `test/Directory.Build.props`, `test/OpenFeature.AotCompatibility/OpenFeature.AotCompatibility.csproj`, `test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj`, `test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj`, [[1]](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907L5-R5) [[2]](diffhunk://#diff-4ff9836a33237453c681d5c88a55ada0028bbd34db2f5c8d2fff968b039e1c3dL4-R4) [[3]](diffhunk://#diff-056c737ea9a6dc141f40eb12b62f535acbdaccdc64fba44d85dc6ac94e8f1c03L4-R4) [[4]](diffhunk://#diff-df96b8ed5b2829c26d252dc79f17c211bb0018d1c5169d9e5a65ae8c2a8a43c5L3-R3) [[5]](diffhunk://#diff-af5b00be86cfd4b9af22d05535dc0c179aaa41549a0e6a978db498a55ca28075R3-R6)
* Updated the devcontainer image and feature configuration to use .NET 10.0 as the primary version, with 9.0 and 8.0 as additional runtimes. (`.devcontainer/devcontainer.json`, [.devcontainer/devcontainer.jsonL3-R7](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L3-R7))
* Updated `global.json` to require .NET SDK version 10.0.100. (`global.json`, [global.jsonL4-R4](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL4-R4))
* Updated AOT compatibility documentation to mention `net10.0` as a valid target. (`docs/AOT_COMPATIBILITY.md`, [docs/AOT_COMPATIBILITY.mdL29-R29](diffhunk://#diff-de0b366780b83306d8455908d400312cd9084cf6cdf2bc2ce434df636337df12L29-R29))
* Updated AOT workflow to include `-f net10.0` in the publish step. (`.github/workflows/aot-compatibility.yml`, [.github/workflows/aot-compatibility.ymlR84](diffhunk://#diff-c11673295c4098470ecfcbf8a7e02f7f4afc044a185cc82bf609a852f02e06ceR84))

**Dependency and Package Version Updates:**

* Added conditional property groups and package references for `net10.0` in `Directory.Packages.props`, including `Microsoft.Extensions.Diagnostics.Testing` and `Microsoft.AspNetCore.TestHost` at version 10.0.0. (`Directory.Packages.props`, [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R10-R12) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L37-R40) [[3]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L49-R60)

**Test Project Adjustments:**

* Cleaned up and unified `TargetFrameworks` handling in test project files to align with new .NET 10.0 support. (`test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj`, `test/OpenFeature.Hosting.Tests/OpenFeature.Hosting.Tests.csproj`, `test/OpenFeature.Providers.MultiProvider.Tests/OpenFeature.Providers.MultiProvider.Tests.csproj`, `test/OpenFeature.Tests/OpenFeature.Tests.csproj`, [[1]](diffhunk://#diff-ab2ad60395e1cc72b327459243ed8c5711efbd88531a3b3b813fb6c4c6019886L4-L5) [[2]](diffhunk://#diff-97d4a2550f0fd445571df1b3cb4712b57dce7ef63fc442f67a5dcb643f162993L4-L5) [[3]](diffhunk://#diff-07af0ee09870050ac5c9b8a958f68806ffc85b2f7e5a58c949f67549a52ede17L4-L5) [[4]](diffhunk://#diff-0be27d52eedaa38daa5f722e08c534bd3ae672aaf8e92c48c481e0f5308d006fL4-L5)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #647 