### PR TITLE
test: Upgrade to xUnit v3 and mtp v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: dotnet build -c Release --no-restore
 
       - name: Test
-        run: dotnet test -c Release --no-build --logger GitHubActions
+        run: dotnet test -c Release --no-build --report-github --ignore-exit-code 8
 
       - name: aot-publish test
         run: |

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Run Test
-        run: dotnet test --verbosity normal --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+        run: dotnet test --coverlet --coverlet-output-format opencover --coverlet-exclude "[GitHubActionsTestLogger*]*" --ignore-exit-code 8
 
       # Keep globbing on non-Windows runners (works today)
       - name: Upload coverage to Codecov (non-Windows)
@@ -48,7 +48,7 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           name: Code Coverage for ${{ matrix.os }}
-          files: "**/TestResults/**/coverage.opencover.xml"
+          files: "**/TestResults/**/coverage.opencover.*.xml"
           disable_search: true
           fail_ci_if_error: true
           verbose: true
@@ -59,9 +59,9 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $files = Get-ChildItem -Path "$PWD" -Recurse -Filter "coverage.opencover.xml" | ForEach-Object { $_.FullName }
+          $files = Get-ChildItem -Path "$PWD" -Recurse -Filter "coverage.opencover.*.xml" | ForEach-Object { $_.FullName }
           if (-not $files -or $files.Count -eq 0) {
-            throw "No coverage.opencover.xml files were found under the repository."
+            throw "No coverage.opencover.*.xml files were found under the repository."
           }
 
           # Codecov accepts comma-separated file paths

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,4 +40,4 @@ jobs:
           cp spec/specification/assets/gherkin/*.feature test/OpenFeature.E2ETests/Features/
 
       - name: Run Tests
-        run: dotnet test test/OpenFeature.E2ETests/ --configuration Release --logger GitHubActions
+        run: dotnet test test/OpenFeature.E2ETests/ --configuration Release --report-github

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ dotnet test test/OpenFeature.Tests/
 To run unit tests with code coverage execute:
 
 ```bash
-dotnet test test/OpenFeature.Tests/ --collect:"XPlat Code Coverage"
+dotnet test test/OpenFeature.Tests/ --coverlet --coverlet-output-format opencover
 ```
 
 #### E2E tests

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,7 @@
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
     <MicrosoftExtensionsVersion>9.0.0</MicrosoftExtensionsVersion>
   </PropertyGroup>
-  <PropertyGroup
-    Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net10.0'))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net10.0'))">
     <MicrosoftExtensionsVersion>10.0.0</MicrosoftExtensionsVersion>
   </PropertyGroup>
 
@@ -35,7 +34,7 @@
   <ItemGroup Label="test">
     <PackageVersion Include="AutoFixture" Version="5.0.0-preview0012" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="coverlet.MTP" Version="10.0.1" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
@@ -43,9 +42,9 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
-    <PackageVersion Include="Reqnroll.xUnit" Version="3.3.4" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="Reqnroll.xunit.v3" Version="3.3.4" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "rollForward": "latestFeature",
     "version": "10.0.100",
     "allowPrerelease": false
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenFeature.slnx'))\build\Common.tests.props" />
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
+++ b/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
@@ -2,24 +2,20 @@
 
   <PropertyGroup>
     <RootNamespace>OpenFeature.E2ETests</RootNamespace>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" />
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Reqnroll.xUnit" />
+    <PackageReference Include="coverlet.MTP" />
+    <PackageReference Include="Reqnroll.xUnit.v3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <!-- Reqnroll 3.2.0 requires System.Threading.Channels >= 9.0.6 -->
-    <PackageVersion Update="System.Threading.Channels" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenFeature.E2ETests/Steps/ExcludedTagsStep.cs
+++ b/test/OpenFeature.E2ETests/Steps/ExcludedTagsStep.cs
@@ -11,6 +11,6 @@ public class ExcludedTagsStep
     [BeforeScenario]
     public static void BeforeScenario()
     {
-        Skip.If(true, "Tag is not supported");
+        Assert.SkipWhen(true, "Tag is not supported");
     }
 }

--- a/test/OpenFeature.Hosting.Tests/Internal/FeatureLifecycleManagerTests.cs
+++ b/test/OpenFeature.Hosting.Tests/Internal/FeatureLifecycleManagerTests.cs
@@ -26,7 +26,7 @@ public class FeatureLifecycleManagerTests : IAsyncLifetime
         // Act
         using var serviceProvider = services.BuildServiceProvider();
         var lifecycleManager = new FeatureLifecycleManager(api, serviceProvider, NullLogger<FeatureLifecycleManager>.Instance);
-        await lifecycleManager.EnsureInitializedAsync();
+        await lifecycleManager.EnsureInitializedAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var actualProvider = api.GetProvider();
@@ -53,7 +53,7 @@ public class FeatureLifecycleManagerTests : IAsyncLifetime
         // Act
         using var serviceProvider = services.BuildServiceProvider();
         var lifecycleManager = new FeatureLifecycleManager(api, serviceProvider, NullLogger<FeatureLifecycleManager>.Instance);
-        await lifecycleManager.EnsureInitializedAsync();
+        await lifecycleManager.EnsureInitializedAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(provider1, api.GetProvider("provider1"));
@@ -80,7 +80,7 @@ public class FeatureLifecycleManagerTests : IAsyncLifetime
         // Act
         using var serviceProvider = services.BuildServiceProvider();
         var lifecycleManager = new FeatureLifecycleManager(api, serviceProvider, NullLogger<FeatureLifecycleManager>.Instance);
-        await lifecycleManager.EnsureInitializedAsync();
+        await lifecycleManager.EnsureInitializedAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var actualHooks = api.GetHooks();
@@ -108,7 +108,7 @@ public class FeatureLifecycleManagerTests : IAsyncLifetime
         // Act
         using var serviceProvider = services.BuildServiceProvider();
         var lifecycleManager = new FeatureLifecycleManager(api, serviceProvider, NullLogger<FeatureLifecycleManager>.Instance);
-        await lifecycleManager.EnsureInitializedAsync();
+        await lifecycleManager.EnsureInitializedAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(hookExecuted);
@@ -122,13 +122,13 @@ public class FeatureLifecycleManagerTests : IAsyncLifetime
         var provider = new NoOpFeatureProvider();
 
         var api = Api.Instance;
-        await api.SetProviderAsync(provider);
+        await api.SetProviderAsync(provider, TestContext.Current.CancellationToken);
         api.AddHooks(new NoOpHook());
 
         // Act
         using var serviceProvider = services.BuildServiceProvider();
         var lifecycleManager = new FeatureLifecycleManager(api, serviceProvider, NullLogger<FeatureLifecycleManager>.Instance);
-        await lifecycleManager.ShutdownAsync();
+        await lifecycleManager.ShutdownAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var actualProvider = api.GetProvider();
@@ -154,7 +154,7 @@ public class FeatureLifecycleManagerTests : IAsyncLifetime
         // Act
         using var serviceProvider = services.BuildServiceProvider();
         var lifecycleManager = new FeatureLifecycleManager(api, serviceProvider, logger);
-        await lifecycleManager.EnsureInitializedAsync();
+        await lifecycleManager.EnsureInitializedAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var log = logger.LatestRecord;
@@ -181,7 +181,7 @@ public class FeatureLifecycleManagerTests : IAsyncLifetime
         // Act
         using var serviceProvider = services.BuildServiceProvider();
         var lifecycleManager = new FeatureLifecycleManager(api, serviceProvider, logger);
-        await lifecycleManager.ShutdownAsync();
+        await lifecycleManager.ShutdownAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var log = logger.LatestRecord;
@@ -190,13 +190,13 @@ public class FeatureLifecycleManagerTests : IAsyncLifetime
         Assert.Equal(LogLevel.Information, log.Level);
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await Api.Instance.ShutdownAsync();
     }
 
     // Make sure the singleton is cleared between tests
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await Api.Instance.ShutdownAsync().ConfigureAwait(false);
     }

--- a/test/OpenFeature.Hosting.Tests/OpenFeature.Hosting.Tests.csproj
+++ b/test/OpenFeature.Hosting.Tests/OpenFeature.Hosting.Tests.csproj
@@ -2,18 +2,16 @@
 
   <PropertyGroup>
     <RootNamespace>OpenFeature.Hosting.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" />
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/test/OpenFeature.Hosting.Tests/Providers/Memory/FeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.Hosting.Tests/Providers/Memory/FeatureBuilderExtensionsTests.cs
@@ -48,7 +48,7 @@ public class FeatureBuilderExtensionsTests
         Assert.NotNull(featureProvider);
         Assert.IsType<InMemoryProvider>(featureProvider);
 
-        var result = await featureProvider.ResolveBooleanValueAsync("feature1", false);
+        var result = await featureProvider.ResolveBooleanValueAsync("feature1", false, cancellationToken: TestContext.Current.CancellationToken);
         Assert.True(result.Value);
     }
 
@@ -130,7 +130,7 @@ public class FeatureBuilderExtensionsTests
         Assert.IsType<InMemoryProvider>(featureProvider);
 
         var context = EvaluationContext.Builder().Set("group", "alpha").Build();
-        var result = await featureProvider.ResolveBooleanValueAsync("feature2", false, context);
+        var result = await featureProvider.ResolveBooleanValueAsync("feature2", false, context, TestContext.Current.CancellationToken);
         Assert.True(result.Value);
     }
 
@@ -178,7 +178,7 @@ public class FeatureBuilderExtensionsTests
         Assert.NotNull(featureProvider);
         Assert.IsType<InMemoryProvider>(featureProvider);
 
-        var result = await featureProvider.ResolveBooleanValueAsync("new-feature", true);
+        var result = await featureProvider.ResolveBooleanValueAsync("new-feature", true, cancellationToken: TestContext.Current.CancellationToken);
         Assert.False(result.Value);
     }
 
@@ -208,7 +208,7 @@ public class FeatureBuilderExtensionsTests
         Assert.NotNull(featureProvider);
         Assert.IsType<InMemoryProvider>(featureProvider);
 
-        var result = await featureProvider.ResolveBooleanValueAsync("new-feature", true);
+        var result = await featureProvider.ResolveBooleanValueAsync("new-feature", true, cancellationToken: TestContext.Current.CancellationToken);
         Assert.False(result.Value);
     }
 

--- a/test/OpenFeature.IntegrationTests/FeatureFlagIntegrationTest.cs
+++ b/test/OpenFeature.IntegrationTests/FeatureFlagIntegrationTest.cs
@@ -54,8 +54,8 @@ public class FeatureFlagIntegrationTest
         var requestUri = $"/features/{userId}/flags/{FeatureA}";
 
         // Act
-        var response = await client.GetAsync(requestUri).ConfigureAwait(true);
-        var responseContent = await response.Content.ReadFromJsonAsync<FeatureFlagResponse<bool>>().ConfigureAwait(true);
+        var response = await client.GetAsync(requestUri, TestContext.Current.CancellationToken).ConfigureAwait(true);
+        var responseContent = await response.Content.ReadFromJsonAsync<FeatureFlagResponse<bool>>(cancellationToken: TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         // Assert
         Assert.True(response.IsSuccessStatusCode, "Expected HTTP status code 200 OK.");
@@ -85,7 +85,7 @@ public class FeatureFlagIntegrationTest
         var requestUri = $"/features/{TestUserId}/flags/{FeatureA}";
 
         // Act
-        var response = await client.GetAsync(requestUri).ConfigureAwait(true);
+        var response = await client.GetAsync(requestUri, TestContext.Current.CancellationToken).ConfigureAwait(true);
         var logs = logger.Collector.GetSnapshot();
 
         // Assert
@@ -120,7 +120,7 @@ public class FeatureFlagIntegrationTest
         var requestUri = $"/features/{TestUserId}/flags/{FeatureA}";
 
         // Act
-        var response = await client.GetAsync(requestUri).ConfigureAwait(true);
+        var response = await client.GetAsync(requestUri, TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         // Assert
         Assert.True(response.IsSuccessStatusCode, "Expected HTTP status code 200 OK.");
@@ -152,7 +152,7 @@ public class FeatureFlagIntegrationTest
         var requestUri = $"/features/{TestUserId}/flags/{FeatureA}";
 
         // Act
-        var response = await client.GetAsync(requestUri).ConfigureAwait(true);
+        var response = await client.GetAsync(requestUri, TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         // Assert
         Assert.True(response.IsSuccessStatusCode, "Expected HTTP status code 200 OK.");
@@ -191,7 +191,7 @@ public class FeatureFlagIntegrationTest
         var requestUri = $"/features/{TestUserId}/flags/{FeatureA}";
 
         // Act
-        var response = await client.GetAsync(requestUri).ConfigureAwait(true);
+        var response = await client.GetAsync(requestUri, TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         // Assert
         Assert.True(response.IsSuccessStatusCode, "Expected HTTP status code 200 OK.");

--- a/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
+++ b/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
@@ -2,17 +2,15 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTests.cs
@@ -119,7 +119,7 @@ public class MultiProviderClassTests
             .Returns(finalResult);
 
         // Act
-        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, this._evaluationContext);
+        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(expectedDetails, result);
@@ -142,7 +142,7 @@ public class MultiProviderClassTests
             .Returns(finalResult);
 
         // Act
-        var result = await multiProvider.ResolveStringValueAsync(TestFlagKey, defaultValue, this._evaluationContext);
+        var result = await multiProvider.ResolveStringValueAsync(TestFlagKey, defaultValue, this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(expectedDetails, result);
@@ -163,7 +163,7 @@ public class MultiProviderClassTests
         this._mockProvider2.InitializeAsync(this._evaluationContext, Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
         // Act
-        await multiProvider.InitializeAsync(this._evaluationContext);
+        await multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert
         await this._mockProvider1.Received(1).InitializeAsync(this._evaluationContext, Arg.Any<CancellationToken>());
@@ -186,7 +186,7 @@ public class MultiProviderClassTests
         this._mockProvider2.InitializeAsync(this._evaluationContext, Arg.Any<CancellationToken>()).ThrowsAsync(expectedException);
 
         // Act & Assert
-        var exception = await Assert.ThrowsAsync<AggregateException>(() => multiProvider.InitializeAsync(this._evaluationContext));
+        var exception = await Assert.ThrowsAsync<AggregateException>(() => multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken));
         Assert.Contains("Failed to initialize providers", exception.Message);
         Assert.Contains(Provider2Name, exception.Message);
         Assert.Contains(expectedException, exception.InnerExceptions);
@@ -208,7 +208,7 @@ public class MultiProviderClassTests
         this._mockProvider2.ShutdownAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
         // Act
-        await multiProvider.ShutdownAsync();
+        await multiProvider.ShutdownAsync(TestContext.Current.CancellationToken);
 
         // Assert
         await this._mockProvider1.Received(1).ShutdownAsync(Arg.Any<CancellationToken>());
@@ -231,7 +231,7 @@ public class MultiProviderClassTests
         this._mockProvider2.ShutdownAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
         // Act
-        await multiProvider.ShutdownAsync();
+        await multiProvider.ShutdownAsync(TestContext.Current.CancellationToken);
 
         // Assert
         await this._mockProvider1.Received(1).ShutdownAsync(Arg.Any<CancellationToken>());
@@ -255,7 +255,7 @@ public class MultiProviderClassTests
         this._mockProvider2.ShutdownAsync(Arg.Any<CancellationToken>()).ThrowsAsync(expectedException);
 
         // Act & Assert
-        var exception = await Assert.ThrowsAsync<AggregateException>(() => multiProvider.ShutdownAsync());
+        var exception = await Assert.ThrowsAsync<AggregateException>(() => multiProvider.ShutdownAsync(TestContext.Current.CancellationToken));
         Assert.Contains("Failed to shutdown providers", exception.Message);
         Assert.Contains(Provider2Name, exception.Message);
         Assert.Contains(expectedException, exception.InnerExceptions);
@@ -292,7 +292,7 @@ public class MultiProviderClassTests
             .Returns(finalResult);
 
         // Act
-        var result = await multiProvider.ResolveDoubleValueAsync(TestFlagKey, defaultValue, this._evaluationContext);
+        var result = await multiProvider.ResolveDoubleValueAsync(TestFlagKey, defaultValue, this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(expectedDetails, result);
@@ -315,7 +315,7 @@ public class MultiProviderClassTests
             .Returns(finalResult);
 
         // Act
-        var result = await multiProvider.ResolveIntegerValueAsync(TestFlagKey, defaultValue, this._evaluationContext);
+        var result = await multiProvider.ResolveIntegerValueAsync(TestFlagKey, defaultValue, this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(expectedDetails, result);
@@ -337,7 +337,7 @@ public class MultiProviderClassTests
             .Returns(finalResult);
 
         // Act
-        var result = await multiProvider.ResolveStructureValueAsync(TestFlagKey, defaultValue, this._evaluationContext);
+        var result = await multiProvider.ResolveStructureValueAsync(TestFlagKey, defaultValue, this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(expectedDetails, result);
@@ -369,7 +369,7 @@ public class MultiProviderClassTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, this._evaluationContext);
+        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(expectedDetails, result);
@@ -404,7 +404,7 @@ public class MultiProviderClassTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, this._evaluationContext);
+        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(expectedDetails, result);
@@ -423,7 +423,7 @@ public class MultiProviderClassTests
         this._mockStrategy.RunMode.Returns((RunMode)999); // Invalid enum value
 
         // Act & Assert
-        var details = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, this._evaluationContext);
+        var details = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, this._evaluationContext, TestContext.Current.CancellationToken);
         Assert.Equal(ErrorType.ProviderFatal, details.ErrorType);
         Assert.Equal(Reason.Error, details.Reason);
         Assert.Contains("Unsupported run mode", details.ErrorMessage);
@@ -459,7 +459,7 @@ public class MultiProviderClassTests
             .Returns(expectedDetails);
 
         // Act
-        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, this._evaluationContext);
+        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(expectedDetails, result);
@@ -613,7 +613,7 @@ public class MultiProviderClassTests
         this._mockProvider3.InitializeAsync(this._evaluationContext, Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
         // Act & Assert
-        await multiProvider.InitializeAsync(this._evaluationContext);
+        await multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Verify all providers were called
         await this._mockProvider1.Received(1).InitializeAsync(this._evaluationContext, Arg.Any<CancellationToken>());
@@ -639,7 +639,7 @@ public class MultiProviderClassTests
         this._mockProvider3.ShutdownAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
         // Act & Assert
-        await multiProvider.ShutdownAsync();
+        await multiProvider.ShutdownAsync(TestContext.Current.CancellationToken);
 
         // Verify all providers were called
         await this._mockProvider1.Received(1).ShutdownAsync(Arg.Any<CancellationToken>());
@@ -757,7 +757,7 @@ public class MultiProviderClassTests
 
         // Assert
         var exception = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            multiProvider.InitializeAsync(this._evaluationContext));
+            multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken));
         Assert.Equal(nameof(MultiProvider), exception.ObjectName);
     }
 
@@ -773,7 +773,7 @@ public class MultiProviderClassTests
 
         // Assert
         var exception = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            multiProvider.ShutdownAsync());
+            multiProvider.ShutdownAsync(TestContext.Current.CancellationToken));
         Assert.Equal(nameof(MultiProvider), exception.ObjectName);
     }
 
@@ -789,7 +789,7 @@ public class MultiProviderClassTests
 
         // Act & Assert
         await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            multiProvider.InitializeAsync(this._evaluationContext));
+            multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken));
 
         // Verify that the underlying provider was never called since the object was disposed
         await this._mockProvider1.DidNotReceive().InitializeAsync(Arg.Any<EvaluationContext>(), Arg.Any<CancellationToken>());
@@ -807,7 +807,7 @@ public class MultiProviderClassTests
 
         // Act & Assert
         await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            multiProvider.ShutdownAsync());
+            multiProvider.ShutdownAsync(TestContext.Current.CancellationToken));
 
         // Verify that the underlying provider was never called since the object was disposed
         await this._mockProvider1.DidNotReceive().ShutdownAsync(Arg.Any<CancellationToken>());
@@ -825,23 +825,23 @@ public class MultiProviderClassTests
 
         // Assert - All evaluate methods should throw ObjectDisposedException
         var boolException = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            multiProvider.ResolveBooleanValueAsync(TestFlagKey, false));
+            multiProvider.ResolveBooleanValueAsync(TestFlagKey, false, cancellationToken: TestContext.Current.CancellationToken));
         Assert.Equal(nameof(MultiProvider), boolException.ObjectName);
 
         var stringException = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            multiProvider.ResolveStringValueAsync(TestFlagKey, "default"));
+            multiProvider.ResolveStringValueAsync(TestFlagKey, "default", cancellationToken: TestContext.Current.CancellationToken));
         Assert.Equal(nameof(MultiProvider), stringException.ObjectName);
 
         var intException = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            multiProvider.ResolveIntegerValueAsync(TestFlagKey, 0));
+            multiProvider.ResolveIntegerValueAsync(TestFlagKey, 0, cancellationToken: TestContext.Current.CancellationToken));
         Assert.Equal(nameof(MultiProvider), intException.ObjectName);
 
         var doubleException = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            multiProvider.ResolveDoubleValueAsync(TestFlagKey, 0.0));
+            multiProvider.ResolveDoubleValueAsync(TestFlagKey, 0.0, cancellationToken: TestContext.Current.CancellationToken));
         Assert.Equal(nameof(MultiProvider), doubleException.ObjectName);
 
         var structureException = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            multiProvider.ResolveStructureValueAsync(TestFlagKey, new Value()));
+            multiProvider.ResolveStructureValueAsync(TestFlagKey, new Value(), cancellationToken: TestContext.Current.CancellationToken));
         Assert.Equal(nameof(MultiProvider), structureException.ObjectName);
     }
 
@@ -952,7 +952,7 @@ public class MultiProviderClassTests
         var multiProvider = new MultiProvider(providerEntries, this._mockStrategy);
 
         // Act
-        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, false, this._evaluationContext);
+        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, false, this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(expectedValue, result.Value);
@@ -1022,7 +1022,7 @@ public class MultiProviderClassTests
         var multiProvider = new MultiProvider(providerEntries, this._mockStrategy);
 
         // Act
-        await multiProvider.ResolveBooleanValueAsync(TestFlagKey, false, this._evaluationContext);
+        await multiProvider.ResolveBooleanValueAsync(TestFlagKey, false, this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert - Verify context isolation
         Assert.NotNull(capturedContext1);
@@ -1079,7 +1079,7 @@ public class MultiProviderClassTests
         var multiProvider = new MultiProvider(providerEntries, this._mockStrategy);
 
         // Act
-        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, false, this._evaluationContext);
+        var result = await multiProvider.ResolveBooleanValueAsync(TestFlagKey, false, this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(expectedValue, result.Value);

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTrackingTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderTrackingTests.cs
@@ -32,7 +32,7 @@ public class MultiProviderTrackingTests
         };
 
         var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
-        await multiProvider.InitializeAsync(this._evaluationContext);
+        await multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken);
 
         var trackingDetails = TrackingEventDetails.Builder().SetValue(99.99).Build();
 
@@ -68,7 +68,7 @@ public class MultiProviderTrackingTests
         };
 
         var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
-        await multiProvider.InitializeAsync(this._evaluationContext);
+        await multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Act
         multiProvider.Track(TestTrackingEventName);
@@ -95,7 +95,7 @@ public class MultiProviderTrackingTests
         };
 
         var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
-        await multiProvider.InitializeAsync(this._evaluationContext);
+        await multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Act
         multiProvider.Track(TestTrackingEventName, this._evaluationContext);
@@ -131,7 +131,7 @@ public class MultiProviderTrackingTests
         };
 
         var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
-        await multiProvider.InitializeAsync(this._evaluationContext);
+        await multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Manually set all providers to Ready status
         throwingProvider.Status.Returns(ProviderStatus.Ready);
@@ -161,7 +161,7 @@ public class MultiProviderTrackingTests
         };
 
         var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
-        await multiProvider.InitializeAsync(this._evaluationContext);
+        await multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken);
         await multiProvider.DisposeAsync();
 
         // Act & Assert
@@ -198,7 +198,7 @@ public class MultiProviderTrackingTests
         };
 
         var multiProvider = new MultiProvider(providerEntries, customStrategy);
-        await multiProvider.InitializeAsync(this._evaluationContext);
+        await multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken);
 
         var trackingDetails = TrackingEventDetails.Builder().SetValue(99.99).Build();
 
@@ -233,7 +233,7 @@ public class MultiProviderTrackingTests
         };
 
         var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
-        await multiProvider.InitializeAsync(this._evaluationContext);
+        await multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken);
 
         var trackingDetails = TrackingEventDetails.Builder()
             .SetValue(199.99)
@@ -285,7 +285,7 @@ public class MultiProviderTrackingTests
         };
 
         var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
-        await multiProvider.InitializeAsync(this._evaluationContext);
+        await multiProvider.InitializeAsync(this._evaluationContext, TestContext.Current.CancellationToken);
 
         // Act & Assert
         multiProvider.Track(trackingEventName!, this._evaluationContext, TrackingEventDetails.Empty);

--- a/test/OpenFeature.Providers.MultiProvider.Tests/OpenFeature.Providers.MultiProvider.Tests.csproj
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/OpenFeature.Providers.MultiProvider.Tests.csproj
@@ -2,20 +2,18 @@
 
   <PropertyGroup>
     <RootNamespace>OpenFeature.Providers.MultiProvider.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" />
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
+++ b/test/OpenFeature.Tests/ClearOpenFeatureInstanceFixture.cs
@@ -2,15 +2,15 @@ namespace OpenFeature.Tests;
 
 public class ClearOpenFeatureInstanceFixture : IAsyncLifetime
 {
-    public Task InitializeAsync()
+    public ValueTask InitializeAsync()
     {
         Api.ResetApi();
 
-        return Task.CompletedTask;
+        return default;
     }
 
     // Make sure the singleton is cleared between tests
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await Api.Instance.ShutdownAsync().ConfigureAwait(false);
     }

--- a/test/OpenFeature.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderTests.cs
@@ -39,23 +39,23 @@ public class FeatureProviderTests : ClearOpenFeatureInstanceFixture
 
         var boolResolutionDetails = new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.None,
             NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-        Assert.Equivalent(boolResolutionDetails, await provider.ResolveBooleanValueAsync(flagName, defaultBoolValue));
+        Assert.Equivalent(boolResolutionDetails, await provider.ResolveBooleanValueAsync(flagName, defaultBoolValue, cancellationToken: TestContext.Current.CancellationToken));
 
         var integerResolutionDetails = new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.None,
             NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-        Assert.Equivalent(integerResolutionDetails, await provider.ResolveIntegerValueAsync(flagName, defaultIntegerValue));
+        Assert.Equivalent(integerResolutionDetails, await provider.ResolveIntegerValueAsync(flagName, defaultIntegerValue, cancellationToken: TestContext.Current.CancellationToken));
 
         var doubleResolutionDetails = new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.None,
             NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-        Assert.Equivalent(doubleResolutionDetails, await provider.ResolveDoubleValueAsync(flagName, defaultDoubleValue));
+        Assert.Equivalent(doubleResolutionDetails, await provider.ResolveDoubleValueAsync(flagName, defaultDoubleValue, cancellationToken: TestContext.Current.CancellationToken));
 
         var stringResolutionDetails = new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.None,
             NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-        Assert.Equivalent(stringResolutionDetails, await provider.ResolveStringValueAsync(flagName, defaultStringValue));
+        Assert.Equivalent(stringResolutionDetails, await provider.ResolveStringValueAsync(flagName, defaultStringValue, cancellationToken: TestContext.Current.CancellationToken));
 
         var structureResolutionDetails = new ResolutionDetails<Value>(flagName, defaultStructureValue,
             ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-        Assert.Equivalent(structureResolutionDetails, await provider.ResolveStructureValueAsync(flagName, defaultStructureValue));
+        Assert.Equivalent(structureResolutionDetails, await provider.ResolveStructureValueAsync(flagName, defaultStructureValue, cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -74,59 +74,52 @@ public class FeatureProviderTests : ClearOpenFeatureInstanceFixture
         var providerMock = Substitute.For<FeatureProvider>();
         const string testMessage = "An error message";
 
-        providerMock.ResolveBooleanValueAsync(flagName, defaultBoolValue, Arg.Any<EvaluationContext>())
-            .Returns(new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.General,
+        providerMock.ResolveBooleanValueAsync(flagName, defaultBoolValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<bool>(flagName, defaultBoolValue, ErrorType.General,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-        providerMock.ResolveIntegerValueAsync(flagName, defaultIntegerValue, Arg.Any<EvaluationContext>())
-            .Returns(new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.ParseError,
+        providerMock.ResolveIntegerValueAsync(flagName, defaultIntegerValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<int>(flagName, defaultIntegerValue, ErrorType.ParseError,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-        providerMock.ResolveDoubleValueAsync(flagName, defaultDoubleValue, Arg.Any<EvaluationContext>())
-            .Returns(new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.InvalidContext,
+        providerMock.ResolveDoubleValueAsync(flagName, defaultDoubleValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<double>(flagName, defaultDoubleValue, ErrorType.InvalidContext,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-        providerMock.ResolveStringValueAsync(flagName, defaultStringValue, Arg.Any<EvaluationContext>())
-            .Returns(new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.TypeMismatch,
+        providerMock.ResolveStringValueAsync(flagName, defaultStringValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<string>(flagName, defaultStringValue, ErrorType.TypeMismatch,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-        providerMock.ResolveStructureValueAsync(flagName, defaultStructureValue, Arg.Any<EvaluationContext>())
-            .Returns(new ResolutionDetails<Value>(flagName, defaultStructureValue, ErrorType.FlagNotFound,
+        providerMock.ResolveStructureValueAsync(flagName, defaultStructureValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<Value>(flagName, defaultStructureValue, ErrorType.FlagNotFound,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-        providerMock.ResolveStructureValueAsync(flagName2, defaultStructureValue, Arg.Any<EvaluationContext>())
-            .Returns(new ResolutionDetails<Value>(flagName2, defaultStructureValue, ErrorType.ProviderNotReady,
+        providerMock.ResolveStructureValueAsync(flagName2, defaultStructureValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<Value>(flagName2, defaultStructureValue, ErrorType.ProviderNotReady,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant, testMessage));
 
-        providerMock.ResolveBooleanValueAsync(flagName2, defaultBoolValue, Arg.Any<EvaluationContext>())
-            .Returns(new ResolutionDetails<bool>(flagName2, defaultBoolValue, ErrorType.TargetingKeyMissing,
+        providerMock.ResolveBooleanValueAsync(flagName2, defaultBoolValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<bool>(flagName2, defaultBoolValue, ErrorType.TargetingKeyMissing,
                 NoOpProvider.ReasonNoOp, NoOpProvider.Variant));
 
-        var boolRes = await providerMock.ResolveBooleanValueAsync(flagName, defaultBoolValue);
+        var boolRes = await providerMock.ResolveBooleanValueAsync(flagName, defaultBoolValue, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ErrorType.General, boolRes.ErrorType);
         Assert.Equal(testMessage, boolRes.ErrorMessage);
 
-        var intRes = await providerMock.ResolveIntegerValueAsync(flagName, defaultIntegerValue);
+        var intRes = await providerMock.ResolveIntegerValueAsync(flagName, defaultIntegerValue, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ErrorType.ParseError, intRes.ErrorType);
         Assert.Equal(testMessage, intRes.ErrorMessage);
 
-        var doubleRes = await providerMock.ResolveDoubleValueAsync(flagName, defaultDoubleValue);
+        var doubleRes = await providerMock.ResolveDoubleValueAsync(flagName, defaultDoubleValue, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ErrorType.InvalidContext, doubleRes.ErrorType);
         Assert.Equal(testMessage, doubleRes.ErrorMessage);
 
-        var stringRes = await providerMock.ResolveStringValueAsync(flagName, defaultStringValue);
+        var stringRes = await providerMock.ResolveStringValueAsync(flagName, defaultStringValue, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ErrorType.TypeMismatch, stringRes.ErrorType);
         Assert.Equal(testMessage, stringRes.ErrorMessage);
 
-        var structRes1 = await providerMock.ResolveStructureValueAsync(flagName, defaultStructureValue);
+        var structRes1 = await providerMock.ResolveStructureValueAsync(flagName, defaultStructureValue, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ErrorType.FlagNotFound, structRes1.ErrorType);
         Assert.Equal(testMessage, structRes1.ErrorMessage);
 
-        var structRes2 = await providerMock.ResolveStructureValueAsync(flagName2, defaultStructureValue);
+        var structRes2 = await providerMock.ResolveStructureValueAsync(flagName2, defaultStructureValue, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ErrorType.ProviderNotReady, structRes2.ErrorType);
         Assert.Equal(testMessage, structRes2.ErrorMessage);
 
-        var boolRes2 = await providerMock.ResolveBooleanValueAsync(flagName2, defaultBoolValue);
+        var boolRes2 = await providerMock.ResolveBooleanValueAsync(flagName2, defaultBoolValue, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ErrorType.TargetingKeyMissing, boolRes2.ErrorType);
         Assert.Null(boolRes2.ErrorMessage);
     }

--- a/test/OpenFeature.Tests/Hooks/LoggingHookTests.cs
+++ b/test/OpenFeature.Tests/Hooks/LoggingHookTests.cs
@@ -22,7 +22,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: false);
 
         // Act
-        await hook.BeforeAsync(context);
+        await hook.BeforeAsync(context, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, logger.Collector.Count);
@@ -57,7 +57,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: false);
 
         // Act
-        await hook.BeforeAsync(context);
+        await hook.BeforeAsync(context, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         var record = logger.LatestRecord;
@@ -98,7 +98,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: true);
 
         // Act
-        await hook.BeforeAsync(context);
+        await hook.BeforeAsync(context, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, logger.Collector.Count);
@@ -130,7 +130,7 @@ public class LoggingHookTests
         // Act
         var hook = new LoggingHook(logger, includeContext: true);
 
-        await hook.BeforeAsync(context);
+        await hook.BeforeAsync(context, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, logger.Collector.Count);
@@ -168,7 +168,7 @@ public class LoggingHookTests
         var exception = new Exception("Error within hook!");
 
         // Act
-        await hook.ErrorAsync(context, exception);
+        await hook.ErrorAsync(context, exception, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, logger.Collector.Count);
@@ -194,7 +194,7 @@ public class LoggingHookTests
         var exception = new Exception("Error within hook!");
 
         // Act
-        await hook.ErrorAsync(context, exception);
+        await hook.ErrorAsync(context, exception, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         var record = logger.LatestRecord;
@@ -238,7 +238,7 @@ public class LoggingHookTests
         var exception = new Exception("Error within hook!");
 
         // Act
-        await hook.ErrorAsync(context, exception);
+        await hook.ErrorAsync(context, exception, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, logger.Collector.Count);
@@ -271,7 +271,7 @@ public class LoggingHookTests
         var exception = new Exception("Error within hook!");
 
         // Act
-        await hook.ErrorAsync(context, exception);
+        await hook.ErrorAsync(context, exception, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, logger.Collector.Count);
@@ -309,7 +309,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: false);
 
         // Act
-        await hook.AfterAsync(context, details);
+        await hook.AfterAsync(context, details, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, logger.Collector.Count);
@@ -334,7 +334,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: false);
 
         // Act
-        await hook.AfterAsync(context, details);
+        await hook.AfterAsync(context, details, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         var record = logger.LatestRecord;
@@ -376,7 +376,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: true);
 
         // Act
-        await hook.AfterAsync(context, details);
+        await hook.AfterAsync(context, details, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, logger.Collector.Count);
@@ -386,7 +386,7 @@ public class LoggingHookTests
 
         // .NET Framework uses G15 formatter on double.ToString
         // .NET uses G17 formatter on double.ToString
-#if NET462
+#if NETFRAMEWORK
         var expectedMaxDoubleString = "-1.79769313486232E+308";
 #else
         var expectedMaxDoubleString = "-1.7976931348623157E+308";
@@ -416,7 +416,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: true);
 
         // Act
-        await hook.AfterAsync(context, details);
+        await hook.AfterAsync(context, details, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, logger.Collector.Count);
@@ -464,7 +464,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: true);
 
         // Act
-        await hook.AfterAsync(context, details);
+        await hook.AfterAsync(context, details, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         var record = logger.LatestRecord;
@@ -507,7 +507,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: true);
 
         // Act
-        await hook.AfterAsync(context, details);
+        await hook.AfterAsync(context, details, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         var record = logger.LatestRecord;
@@ -548,7 +548,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: true);
 
         // Act
-        await hook.AfterAsync(context, details);
+        await hook.AfterAsync(context, details, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         var record = logger.LatestRecord;
@@ -589,7 +589,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: true);
 
         // Act
-        await hook.AfterAsync(context, details);
+        await hook.AfterAsync(context, details, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         var record = logger.LatestRecord;
@@ -630,7 +630,7 @@ public class LoggingHookTests
         var hook = new LoggingHook(logger, includeContext: true);
 
         // Act
-        await hook.AfterAsync(context, details);
+        await hook.AfterAsync(context, details, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         var record = logger.LatestRecord;

--- a/test/OpenFeature.Tests/Hooks/MetricsHookTests.cs
+++ b/test/OpenFeature.Tests/Hooks/MetricsHookTests.cs
@@ -20,9 +20,7 @@ public class MetricsHookTest
             new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
 
         // Act
-        await metricsHook.AfterAsync(ctx,
-            new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"),
-            new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.AfterAsync(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"), new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.LastMeasurement;
 
@@ -50,7 +48,7 @@ public class MetricsHookTest
         // Act
         await metricsHook.AfterAsync(ctx,
             new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", variant: null),
-            new Dictionary<string, object>()).ConfigureAwait(true);
+            new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.LastMeasurement;
 
@@ -76,9 +74,7 @@ public class MetricsHookTest
             new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
 
         // Act
-        await metricsHook.AfterAsync(ctx,
-            new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, reason: null, "default"),
-            new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.AfterAsync(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, reason: null, "default"), new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.LastMeasurement;
 
@@ -107,9 +103,7 @@ public class MetricsHookTest
             new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
 
         // Act
-        await metricsHook.AfterAsync(ctx,
-            new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"),
-            new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.AfterAsync(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"), new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.LastMeasurement;
 
@@ -145,9 +139,7 @@ public class MetricsHookTest
         });
 
         // Act
-        await metricsHook.AfterAsync(ctx,
-            new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default", errorMessage: null, flagMetadata),
-            new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.AfterAsync(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default", errorMessage: null, flagMetadata), new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.LastMeasurement;
 
@@ -175,7 +167,7 @@ public class MetricsHookTest
         var errorMessage = "An error occurred during evaluation";
 
         // Act
-        await metricsHook.ErrorAsync(ctx, new Exception(errorMessage), new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.ErrorAsync(ctx, new Exception(errorMessage), new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.LastMeasurement;
 
@@ -206,7 +198,7 @@ public class MetricsHookTest
         var errorMessage = "An error occurred during evaluation";
 
         // Act
-        await metricsHook.ErrorAsync(ctx, new Exception(errorMessage), new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.ErrorAsync(ctx, new Exception(errorMessage), new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.LastMeasurement;
 
@@ -233,7 +225,7 @@ public class MetricsHookTest
         var evaluationDetails = new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default");
 
         // Act
-        await metricsHook.FinallyAsync(ctx, evaluationDetails, new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.FinallyAsync(ctx, evaluationDetails, new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.LastMeasurement;
 
@@ -263,7 +255,7 @@ public class MetricsHookTest
         var evaluationDetails = new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default");
 
         // Act
-        await metricsHook.FinallyAsync(ctx, evaluationDetails, new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.FinallyAsync(ctx, evaluationDetails, new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.LastMeasurement;
 
@@ -299,7 +291,7 @@ public class MetricsHookTest
         var evaluationDetails = new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default", flagMetadata: flagMetadata);
 
         // Act
-        await metricsHook.FinallyAsync(ctx, evaluationDetails, new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.FinallyAsync(ctx, evaluationDetails, new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.LastMeasurement;
 
@@ -326,7 +318,7 @@ public class MetricsHookTest
             new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
 
         // Act
-        await metricsHook.BeforeAsync(ctx, new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.BeforeAsync(ctx, new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector1.LastMeasurement;
 
@@ -356,7 +348,7 @@ public class MetricsHookTest
             new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
 
         // Act
-        await metricsHook.BeforeAsync(ctx, new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.BeforeAsync(ctx, new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector1.LastMeasurement;
 
@@ -390,8 +382,8 @@ public class MetricsHookTest
         var evaluationDetails = new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default", flagMetadata: flagMetadata);
 
         // Act
-        await metricsHook.BeforeAsync(ctx, new Dictionary<string, object>()).ConfigureAwait(true);
-        await metricsHook.FinallyAsync(ctx, evaluationDetails, new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.BeforeAsync(ctx, new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
+        await metricsHook.FinallyAsync(ctx, evaluationDetails, new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.GetMeasurementSnapshot();
 
@@ -423,7 +415,7 @@ public class MetricsHookTest
             new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
 
         // Act - call BeforeAsync (no flag metadata available yet)
-        await metricsHook.BeforeAsync(ctx, new Dictionary<string, object>()).ConfigureAwait(true);
+        await metricsHook.BeforeAsync(ctx, new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         var measurements = collector.LastMeasurement;
 

--- a/test/OpenFeature.Tests/Hooks/TraceEnricherHookTests.cs
+++ b/test/OpenFeature.Tests/Hooks/TraceEnricherHookTests.cs
@@ -47,9 +47,7 @@ public class TraceEnricherHookTests : IDisposable
 
         // Act
         var span = this._tracer.StartActiveSpan("my-span");
-        await traceEnricherHook.FinallyAsync(ctx,
-            new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"),
-            new Dictionary<string, object>()).ConfigureAwait(true);
+        await traceEnricherHook.FinallyAsync(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"), new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
         span.End();
 
         this._tracerProvider.ForceFlush();
@@ -83,9 +81,7 @@ public class TraceEnricherHookTests : IDisposable
 
         // Act
         var span = this._tracer.StartActiveSpan("my-span");
-        await traceEnricherHook.FinallyAsync(ctx,
-            new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"),
-            new Dictionary<string, object>()).ConfigureAwait(true);
+        await traceEnricherHook.FinallyAsync(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"), new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
         span.End();
 
         this._tracerProvider.ForceFlush();
@@ -126,9 +122,7 @@ public class TraceEnricherHookTests : IDisposable
 
         // Act
         var span = this._tracer.StartActiveSpan("my-span");
-        await traceEnricherHook.FinallyAsync(ctx,
-            new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default", flagMetadata: flagMetadata),
-            new Dictionary<string, object>()).ConfigureAwait(true);
+        await traceEnricherHook.FinallyAsync(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default", flagMetadata: flagMetadata), new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
         span.End();
 
         this._tracerProvider.ForceFlush();
@@ -157,9 +151,7 @@ public class TraceEnricherHookTests : IDisposable
             new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
 
         // Act
-        await traceEnricherHook.FinallyAsync(ctx,
-            new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"),
-            new Dictionary<string, object>()).ConfigureAwait(true);
+        await traceEnricherHook.FinallyAsync(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"), new Dictionary<string, object>(), TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         this._tracerProvider.ForceFlush();
 

--- a/test/OpenFeature.Tests/Isolated/IsolatedApiTests.cs
+++ b/test/OpenFeature.Tests/Isolated/IsolatedApiTests.cs
@@ -45,7 +45,7 @@ public class IsolatedApiTests
         {
             // Provider management
             var provider = new TestProvider();
-            await isolated.SetProviderAsync(provider);
+            await isolated.SetProviderAsync(provider, TestContext.Current.CancellationToken);
             Assert.Equal(provider, isolated.GetProvider());
             Assert.Equal(provider.GetMetadata()?.Name, isolated.GetProviderMetadata()?.Name);
 
@@ -86,7 +86,7 @@ public class IsolatedApiTests
         try
         {
             var provider = new TestProvider("isolated-provider");
-            await isolated.SetProviderAsync(provider);
+            await isolated.SetProviderAsync(provider, TestContext.Current.CancellationToken);
 
             // The singleton should still have the default NoOp provider
             Assert.Equal(NoOpProvider.NoOpProviderName, Api.Instance.GetProviderMetadata()?.Name);
@@ -108,8 +108,8 @@ public class IsolatedApiTests
         {
             var provider1 = new TestProvider("provider-1");
             var provider2 = new TestProvider("provider-2");
-            await isolated1.SetProviderAsync(provider1);
-            await isolated2.SetProviderAsync(provider2);
+            await isolated1.SetProviderAsync(provider1, TestContext.Current.CancellationToken);
+            await isolated2.SetProviderAsync(provider2, TestContext.Current.CancellationToken);
 
             Assert.Equal("provider-1", isolated1.GetProviderMetadata()?.Name);
             Assert.Equal("provider-2", isolated2.GetProviderMetadata()?.Name);
@@ -167,10 +167,10 @@ public class IsolatedApiTests
         try
         {
             var provider = new TestProvider("shared-provider");
-            await isolated1.SetProviderAsync(provider);
+            await isolated1.SetProviderAsync(provider, TestContext.Current.CancellationToken);
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => isolated2.SetProviderAsync(provider));
+                () => isolated2.SetProviderAsync(provider, TestContext.Current.CancellationToken));
 
             Assert.Equal("This provider instance is already bound to a different API instance. " +
                 "A provider should not be registered with more than one API instance simultaneously.", exception.Message);
@@ -191,10 +191,10 @@ public class IsolatedApiTests
         try
         {
             var provider = new TestProvider("shared-provider");
-            await isolated1.SetProviderAsync("domain-1", provider);
+            await isolated1.SetProviderAsync("domain-1", provider, TestContext.Current.CancellationToken);
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => isolated2.SetProviderAsync("domain-2", provider));
+                () => isolated2.SetProviderAsync("domain-2", provider, TestContext.Current.CancellationToken));
 
             Assert.Equal("This provider instance is already bound to a different API instance. " +
                 "A provider should not be registered with more than one API instance simultaneously.", exception.Message);
@@ -246,13 +246,13 @@ public class IsolatedApiTests
         try
         {
             var provider = new TestProvider("rebindable-provider");
-            await isolated1.SetProviderAsync(provider);
+            await isolated1.SetProviderAsync(provider, TestContext.Current.CancellationToken);
 
             // Shut down first instance — this frees the provider
             await isolated1.ShutdownAsync();
 
             // Now the provider should be bindable to another instance
-            await isolated2.SetProviderAsync(provider);
+            await isolated2.SetProviderAsync(provider, TestContext.Current.CancellationToken);
             Assert.Equal("rebindable-provider", isolated2.GetProviderMetadata()?.Name);
         }
         finally
@@ -269,8 +269,8 @@ public class IsolatedApiTests
         try
         {
             var provider = new TestProvider("multi-domain-provider");
-            await isolated.SetProviderAsync("domain-a", provider);
-            await isolated.SetProviderAsync("domain-b", provider);
+            await isolated.SetProviderAsync("domain-a", provider, TestContext.Current.CancellationToken);
+            await isolated.SetProviderAsync("domain-b", provider, TestContext.Current.CancellationToken);
 
             Assert.Equal(provider, isolated.GetProvider("domain-a"));
             Assert.Equal(provider, isolated.GetProvider("domain-b"));
@@ -286,11 +286,11 @@ public class IsolatedApiTests
     {
         Api.ResetApi();
         var singletonProvider = new TestProvider("singleton-provider");
-        await Api.Instance.SetProviderAsync(singletonProvider);
+        await Api.Instance.SetProviderAsync(singletonProvider, TestContext.Current.CancellationToken);
 
         var isolated = OpenFeatureFactory.CreateIsolated();
         var isolatedProvider = new TestProvider("isolated-provider");
-        await isolated.SetProviderAsync(isolatedProvider);
+        await isolated.SetProviderAsync(isolatedProvider, TestContext.Current.CancellationToken);
 
         // Shutting down isolated instance
         await isolated.ShutdownAsync();
@@ -311,8 +311,8 @@ public class IsolatedApiTests
         {
             var provider1 = new TestProvider("provider-1");
             var provider2 = new TestProvider("provider-2");
-            await isolated1.SetProviderAsync(provider1);
-            await isolated2.SetProviderAsync(provider2);
+            await isolated1.SetProviderAsync(provider1, TestContext.Current.CancellationToken);
+            await isolated2.SetProviderAsync(provider2, TestContext.Current.CancellationToken);
 
             await isolated1.ShutdownAsync();
 
@@ -335,16 +335,16 @@ public class IsolatedApiTests
             var providerA = new TestProvider("provider-a");
             var providerB = new TestProvider("provider-b");
 
-            await isolated1.SetProviderAsync(providerA);
+            await isolated1.SetProviderAsync(providerA, TestContext.Current.CancellationToken);
 
             // Replace providerA with providerB in isolated1 — providerA should be unbound
-            await isolated1.SetProviderAsync(providerB);
+            await isolated1.SetProviderAsync(providerB, TestContext.Current.CancellationToken);
 
             // Allow some time for the async shutdown to complete
-            await Task.Delay(100);
+            await Task.Delay(100, TestContext.Current.CancellationToken);
 
             // providerA should now be free to bind to isolated2
-            await isolated2.SetProviderAsync(providerA);
+            await isolated2.SetProviderAsync(providerA, TestContext.Current.CancellationToken);
             Assert.Equal("provider-a", isolated2.GetProviderMetadata()?.Name);
         }
         finally
@@ -362,12 +362,12 @@ public class IsolatedApiTests
         try
         {
             var provider = new TestProvider("eval-provider");
-            await isolated.SetProviderAsync(provider);
+            await isolated.SetProviderAsync(provider, TestContext.Current.CancellationToken);
 
             var client = isolated.GetClient();
 
             // TestProvider inverts boolean defaults
-            var result = await client.GetBooleanValueAsync("test-flag", false);
+            var result = await client.GetBooleanValueAsync("test-flag", false, cancellationToken: TestContext.Current.CancellationToken);
             Assert.True(result);
         }
         finally

--- a/test/OpenFeature.Tests/OpenFeature.Tests.csproj
+++ b/test/OpenFeature.Tests/OpenFeature.Tests.csproj
@@ -2,20 +2,18 @@
 
   <PropertyGroup>
     <RootNamespace>OpenFeature.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" />
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -70,28 +70,28 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var defaultStructureValue = fixture.Create<Value>();
         var emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
-        await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
+        await Api.Instance.SetProviderAsync(new NoOpFeatureProvider(), TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
 
-        Assert.Equal(defaultBoolValue, await client.GetBooleanValueAsync(flagName, defaultBoolValue));
-        Assert.Equal(defaultBoolValue, await client.GetBooleanValueAsync(flagName, defaultBoolValue, EvaluationContext.Empty));
-        Assert.Equal(defaultBoolValue, await client.GetBooleanValueAsync(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions));
+        Assert.Equal(defaultBoolValue, await client.GetBooleanValueAsync(flagName, defaultBoolValue, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal(defaultBoolValue, await client.GetBooleanValueAsync(flagName, defaultBoolValue, EvaluationContext.Empty, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal(defaultBoolValue, await client.GetBooleanValueAsync(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions, TestContext.Current.CancellationToken));
 
-        Assert.Equal(defaultIntegerValue, await client.GetIntegerValueAsync(flagName, defaultIntegerValue));
-        Assert.Equal(defaultIntegerValue, await client.GetIntegerValueAsync(flagName, defaultIntegerValue, EvaluationContext.Empty));
-        Assert.Equal(defaultIntegerValue, await client.GetIntegerValueAsync(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions));
+        Assert.Equal(defaultIntegerValue, await client.GetIntegerValueAsync(flagName, defaultIntegerValue, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal(defaultIntegerValue, await client.GetIntegerValueAsync(flagName, defaultIntegerValue, EvaluationContext.Empty, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal(defaultIntegerValue, await client.GetIntegerValueAsync(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions, TestContext.Current.CancellationToken));
 
-        Assert.Equal(defaultDoubleValue, await client.GetDoubleValueAsync(flagName, defaultDoubleValue));
-        Assert.Equal(defaultDoubleValue, await client.GetDoubleValueAsync(flagName, defaultDoubleValue, EvaluationContext.Empty));
-        Assert.Equal(defaultDoubleValue, await client.GetDoubleValueAsync(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions));
+        Assert.Equal(defaultDoubleValue, await client.GetDoubleValueAsync(flagName, defaultDoubleValue, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal(defaultDoubleValue, await client.GetDoubleValueAsync(flagName, defaultDoubleValue, EvaluationContext.Empty, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal(defaultDoubleValue, await client.GetDoubleValueAsync(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions, TestContext.Current.CancellationToken));
 
-        Assert.Equal(defaultStringValue, await client.GetStringValueAsync(flagName, defaultStringValue));
-        Assert.Equal(defaultStringValue, await client.GetStringValueAsync(flagName, defaultStringValue, EvaluationContext.Empty));
-        Assert.Equal(defaultStringValue, await client.GetStringValueAsync(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions));
+        Assert.Equal(defaultStringValue, await client.GetStringValueAsync(flagName, defaultStringValue, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal(defaultStringValue, await client.GetStringValueAsync(flagName, defaultStringValue, EvaluationContext.Empty, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal(defaultStringValue, await client.GetStringValueAsync(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions, TestContext.Current.CancellationToken));
 
-        Assert.Equivalent(defaultStructureValue, await client.GetObjectValueAsync(flagName, defaultStructureValue));
-        Assert.Equivalent(defaultStructureValue, await client.GetObjectValueAsync(flagName, defaultStructureValue, EvaluationContext.Empty));
-        Assert.Equivalent(defaultStructureValue, await client.GetObjectValueAsync(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions));
+        Assert.Equivalent(defaultStructureValue, await client.GetObjectValueAsync(flagName, defaultStructureValue, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(defaultStructureValue, await client.GetObjectValueAsync(flagName, defaultStructureValue, EvaluationContext.Empty, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(defaultStructureValue, await client.GetObjectValueAsync(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -116,33 +116,33 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var defaultStructureValue = fixture.Create<Value>();
         var emptyFlagOptions = new FlagEvaluationOptions(ImmutableList<Hook>.Empty, ImmutableDictionary<string, object>.Empty);
 
-        await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
+        await Api.Instance.SetProviderAsync(new NoOpFeatureProvider(), TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
 
         var boolFlagEvaluationDetails = new FlagEvaluationDetails<bool>(flagName, defaultBoolValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-        Assert.Equivalent(boolFlagEvaluationDetails, await client.GetBooleanDetailsAsync(flagName, defaultBoolValue));
-        Assert.Equivalent(boolFlagEvaluationDetails, await client.GetBooleanDetailsAsync(flagName, defaultBoolValue, EvaluationContext.Empty));
-        Assert.Equivalent(boolFlagEvaluationDetails, await client.GetBooleanDetailsAsync(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions));
+        Assert.Equivalent(boolFlagEvaluationDetails, await client.GetBooleanDetailsAsync(flagName, defaultBoolValue, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(boolFlagEvaluationDetails, await client.GetBooleanDetailsAsync(flagName, defaultBoolValue, EvaluationContext.Empty, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(boolFlagEvaluationDetails, await client.GetBooleanDetailsAsync(flagName, defaultBoolValue, EvaluationContext.Empty, emptyFlagOptions, TestContext.Current.CancellationToken));
 
         var integerFlagEvaluationDetails = new FlagEvaluationDetails<int>(flagName, defaultIntegerValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-        Assert.Equivalent(integerFlagEvaluationDetails, await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue));
-        Assert.Equivalent(integerFlagEvaluationDetails, await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue, EvaluationContext.Empty));
-        Assert.Equivalent(integerFlagEvaluationDetails, await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions));
+        Assert.Equivalent(integerFlagEvaluationDetails, await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(integerFlagEvaluationDetails, await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue, EvaluationContext.Empty, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(integerFlagEvaluationDetails, await client.GetIntegerDetailsAsync(flagName, defaultIntegerValue, EvaluationContext.Empty, emptyFlagOptions, TestContext.Current.CancellationToken));
 
         var doubleFlagEvaluationDetails = new FlagEvaluationDetails<double>(flagName, defaultDoubleValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-        Assert.Equivalent(doubleFlagEvaluationDetails, await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue));
-        Assert.Equivalent(doubleFlagEvaluationDetails, await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue, EvaluationContext.Empty));
-        Assert.Equivalent(doubleFlagEvaluationDetails, await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions));
+        Assert.Equivalent(doubleFlagEvaluationDetails, await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(doubleFlagEvaluationDetails, await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue, EvaluationContext.Empty, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(doubleFlagEvaluationDetails, await client.GetDoubleDetailsAsync(flagName, defaultDoubleValue, EvaluationContext.Empty, emptyFlagOptions, TestContext.Current.CancellationToken));
 
         var stringFlagEvaluationDetails = new FlagEvaluationDetails<string>(flagName, defaultStringValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-        Assert.Equivalent(stringFlagEvaluationDetails, await client.GetStringDetailsAsync(flagName, defaultStringValue));
-        Assert.Equivalent(stringFlagEvaluationDetails, await client.GetStringDetailsAsync(flagName, defaultStringValue, EvaluationContext.Empty));
-        Assert.Equivalent(stringFlagEvaluationDetails, await client.GetStringDetailsAsync(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions));
+        Assert.Equivalent(stringFlagEvaluationDetails, await client.GetStringDetailsAsync(flagName, defaultStringValue, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(stringFlagEvaluationDetails, await client.GetStringDetailsAsync(flagName, defaultStringValue, EvaluationContext.Empty, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(stringFlagEvaluationDetails, await client.GetStringDetailsAsync(flagName, defaultStringValue, EvaluationContext.Empty, emptyFlagOptions, TestContext.Current.CancellationToken));
 
         var structureFlagEvaluationDetails = new FlagEvaluationDetails<Value>(flagName, defaultStructureValue, ErrorType.None, NoOpProvider.ReasonNoOp, NoOpProvider.Variant);
-        Assert.Equivalent(structureFlagEvaluationDetails, await client.GetObjectDetailsAsync(flagName, defaultStructureValue));
-        Assert.Equivalent(structureFlagEvaluationDetails, await client.GetObjectDetailsAsync(flagName, defaultStructureValue, EvaluationContext.Empty));
-        Assert.Equivalent(structureFlagEvaluationDetails, await client.GetObjectDetailsAsync(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions));
+        Assert.Equivalent(structureFlagEvaluationDetails, await client.GetObjectDetailsAsync(flagName, defaultStructureValue, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(structureFlagEvaluationDetails, await client.GetObjectDetailsAsync(flagName, defaultStructureValue, EvaluationContext.Empty, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equivalent(structureFlagEvaluationDetails, await client.GetObjectDetailsAsync(flagName, defaultStructureValue, EvaluationContext.Empty, emptyFlagOptions, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -163,18 +163,18 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var mockedLogger = Substitute.For<ILogger<Api>>();
 
         // This will fail to case a String to TestStructure
-        mockedFeatureProvider.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Throws<InvalidCastException>();
+        mockedFeatureProvider.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Throws<InvalidCastException>();
         mockedFeatureProvider.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
         mockedFeatureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-        await Api.Instance.SetProviderAsync(mockedFeatureProvider);
+        await Api.Instance.SetProviderAsync(mockedFeatureProvider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion, mockedLogger);
 
-        var evaluationDetails = await client.GetObjectDetailsAsync(flagName, defaultValue);
+        var evaluationDetails = await client.GetObjectDetailsAsync(flagName, defaultValue, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ErrorType.TypeMismatch, evaluationDetails.ErrorType);
         Assert.Equal(new InvalidCastException().Message, evaluationDetails.ErrorMessage);
 
-        _ = mockedFeatureProvider.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
+        _ = mockedFeatureProvider.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
 
         mockedLogger.Received(0).IsEnabled(LogLevel.Error);
     }
@@ -189,7 +189,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var provider = new TestProvider();
         FeatureClient client = Api.Instance.GetClient(name);
         Assert.Equal(ProviderStatus.NotReady, provider.Status);
-        await Api.Instance.SetProviderAsync(name, provider);
+        await Api.Instance.SetProviderAsync(name, provider, TestContext.Current.CancellationToken);
 
         // after init fails fatally, status should be READY
         Assert.Equal(ProviderStatus.Ready, client.ProviderStatus);
@@ -205,7 +205,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var provider = new TestProvider("some-name", new GeneralException("fake"));
         FeatureClient client = Api.Instance.GetClient(name);
         Assert.Equal(ProviderStatus.NotReady, provider.Status);
-        await Api.Instance.SetProviderAsync(name, provider);
+        await Api.Instance.SetProviderAsync(name, provider, TestContext.Current.CancellationToken);
 
         // after init fails fatally, status should be ERROR
         Assert.Equal(ProviderStatus.Error, client.ProviderStatus);
@@ -221,7 +221,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var provider = new TestProvider(name, new ProviderFatalException("fatal"));
         FeatureClient client = Api.Instance.GetClient(name);
         Assert.Equal(ProviderStatus.NotReady, provider.Status);
-        await Api.Instance.SetProviderAsync(name, provider);
+        await Api.Instance.SetProviderAsync(name, provider, TestContext.Current.CancellationToken);
 
         // after init fails fatally, status should be FATAL
         Assert.Equal(ProviderStatus.Fatal, client.ProviderStatus);
@@ -238,9 +238,9 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var provider = new TestProvider(name, null, int.MaxValue);
         FeatureClient client = Api.Instance.GetClient(name);
         Assert.Equal(ProviderStatus.NotReady, provider.Status);
-        _ = Api.Instance.SetProviderAsync(name, provider);
+        _ = Api.Instance.SetProviderAsync(name, provider, TestContext.Current.CancellationToken);
 
-        var details = await client.GetStringDetailsAsync("some-flag", defaultStr);
+        var details = await client.GetStringDetailsAsync("some-flag", defaultStr, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(defaultStr, details.Value);
         Assert.Equal(ErrorType.ProviderNotReady, details.ErrorType);
         Assert.Equal(Reason.Error, details.Reason);
@@ -257,9 +257,9 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var provider = new TestProvider(name, new ProviderFatalException("fake"));
         FeatureClient client = Api.Instance.GetClient(name);
         Assert.Equal(ProviderStatus.NotReady, provider.Status);
-        _ = Api.Instance.SetProviderAsync(name, provider);
+        _ = Api.Instance.SetProviderAsync(name, provider, TestContext.Current.CancellationToken);
 
-        var details = await client.GetStringDetailsAsync("some-flag", defaultStr);
+        var details = await client.GetStringDetailsAsync("some-flag", defaultStr, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(defaultStr, details.Value);
         Assert.Equal(ErrorType.ProviderFatal, details.ErrorType);
         Assert.Equal(Reason.Error, details.Reason);
@@ -275,16 +275,16 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var defaultValue = fixture.Create<bool>();
 
         var featureProviderMock = Substitute.For<FeatureProvider>();
-        featureProviderMock.ResolveBooleanValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>(flagName, defaultValue));
+        featureProviderMock.ResolveBooleanValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<bool>(flagName, defaultValue));
         featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
         featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-        await Api.Instance.SetProviderAsync(featureProviderMock);
+        await Api.Instance.SetProviderAsync(featureProviderMock, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
 
-        Assert.Equal(defaultValue, await client.GetBooleanValueAsync(flagName, defaultValue));
+        Assert.Equal(defaultValue, await client.GetBooleanValueAsync(flagName, defaultValue, cancellationToken: TestContext.Current.CancellationToken));
 
-        _ = featureProviderMock.Received(1).ResolveBooleanValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
+        _ = featureProviderMock.Received(1).ResolveBooleanValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -297,16 +297,16 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var defaultValue = fixture.Create<string>();
 
         var featureProviderMock = Substitute.For<FeatureProvider>();
-        featureProviderMock.ResolveStringValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<string>(flagName, defaultValue));
+        featureProviderMock.ResolveStringValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<string>(flagName, defaultValue));
         featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
         featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-        await Api.Instance.SetProviderAsync(featureProviderMock);
+        await Api.Instance.SetProviderAsync(featureProviderMock, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
 
-        Assert.Equal(defaultValue, await client.GetStringValueAsync(flagName, defaultValue));
+        Assert.Equal(defaultValue, await client.GetStringValueAsync(flagName, defaultValue, cancellationToken: TestContext.Current.CancellationToken));
 
-        _ = featureProviderMock.Received(1).ResolveStringValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
+        _ = featureProviderMock.Received(1).ResolveStringValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -319,16 +319,16 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var defaultValue = fixture.Create<int>();
 
         var featureProviderMock = Substitute.For<FeatureProvider>();
-        featureProviderMock.ResolveIntegerValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<int>(flagName, defaultValue));
+        featureProviderMock.ResolveIntegerValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<int>(flagName, defaultValue));
         featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
         featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-        await Api.Instance.SetProviderAsync(featureProviderMock);
+        await Api.Instance.SetProviderAsync(featureProviderMock, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
 
-        Assert.Equal(defaultValue, await client.GetIntegerValueAsync(flagName, defaultValue));
+        Assert.Equal(defaultValue, await client.GetIntegerValueAsync(flagName, defaultValue, cancellationToken: TestContext.Current.CancellationToken));
 
-        _ = featureProviderMock.Received(1).ResolveIntegerValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
+        _ = featureProviderMock.Received(1).ResolveIntegerValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -341,16 +341,16 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var defaultValue = fixture.Create<double>();
 
         var featureProviderMock = Substitute.For<FeatureProvider>();
-        featureProviderMock.ResolveDoubleValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<double>(flagName, defaultValue));
+        featureProviderMock.ResolveDoubleValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<double>(flagName, defaultValue));
         featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
         featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-        await Api.Instance.SetProviderAsync(featureProviderMock);
+        await Api.Instance.SetProviderAsync(featureProviderMock, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
 
-        Assert.Equal(defaultValue, await client.GetDoubleValueAsync(flagName, defaultValue));
+        Assert.Equal(defaultValue, await client.GetDoubleValueAsync(flagName, defaultValue, cancellationToken: TestContext.Current.CancellationToken));
 
-        _ = featureProviderMock.Received(1).ResolveDoubleValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
+        _ = featureProviderMock.Received(1).ResolveDoubleValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -363,16 +363,16 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var defaultValue = fixture.Create<Value>();
 
         var featureProviderMock = Substitute.For<FeatureProvider>();
-        featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<Value>(flagName, defaultValue));
+        featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<Value>(flagName, defaultValue));
         featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
         featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-        await Api.Instance.SetProviderAsync(featureProviderMock);
+        await Api.Instance.SetProviderAsync(featureProviderMock, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
 
-        Assert.Equal(defaultValue, await client.GetObjectValueAsync(flagName, defaultValue));
+        Assert.Equal(defaultValue, await client.GetObjectValueAsync(flagName, defaultValue, cancellationToken: TestContext.Current.CancellationToken));
 
-        _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
+        _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -386,18 +386,18 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         const string testMessage = "Couldn't parse flag data.";
 
         var featureProviderMock = Substitute.For<FeatureProvider>();
-        featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Returns(Task.FromResult(new ResolutionDetails<Value>(flagName, defaultValue, ErrorType.ParseError, "ERROR", null, testMessage)));
+        featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(Task.FromResult(new ResolutionDetails<Value>(flagName, defaultValue, ErrorType.ParseError, "ERROR", null, testMessage)));
         featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
         featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-        await Api.Instance.SetProviderAsync(featureProviderMock);
+        await Api.Instance.SetProviderAsync(featureProviderMock, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
-        var response = await client.GetObjectDetailsAsync(flagName, defaultValue);
+        var response = await client.GetObjectDetailsAsync(flagName, defaultValue, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ErrorType.ParseError, response.ErrorType);
         Assert.Equal(Reason.Error, response.Reason);
         Assert.Equal(testMessage, response.ErrorMessage);
-        _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
+        _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -411,18 +411,18 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         const string testMessage = "Couldn't parse flag data.";
 
         var featureProviderMock = Substitute.For<FeatureProvider>();
-        featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>()).Throws(new FeatureProviderException(ErrorType.ParseError, testMessage));
+        featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Throws(new FeatureProviderException(ErrorType.ParseError, testMessage));
         featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
         featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-        await Api.Instance.SetProviderAsync(featureProviderMock);
+        await Api.Instance.SetProviderAsync(featureProviderMock, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
-        var response = await client.GetObjectDetailsAsync(flagName, defaultValue);
+        var response = await client.GetObjectDetailsAsync(flagName, defaultValue, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ErrorType.ParseError, response.ErrorType);
         Assert.Equal(Reason.Error, response.Reason);
         Assert.Equal(testMessage, response.ErrorMessage);
-        _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
+        _ = featureProviderMock.Received(1).ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -436,23 +436,22 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         const string testMessage = "Couldn't parse flag data.";
 
         var featureProviderMock = Substitute.For<FeatureProvider>();
-        featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>())
-            .Returns(Task.FromResult(new ResolutionDetails<Value>(flagName, defaultValue, ErrorType.ParseError,
+        featureProviderMock.ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(Task.FromResult(new ResolutionDetails<Value>(flagName, defaultValue, ErrorType.ParseError,
                 "ERROR", null, testMessage)));
         featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
         featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-        await Api.Instance.SetProviderAsync(featureProviderMock);
+        await Api.Instance.SetProviderAsync(featureProviderMock, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
         var testHook = new TestHook();
         client.AddHooks(testHook);
-        var response = await client.GetObjectDetailsAsync(flagName, defaultValue);
+        var response = await client.GetObjectDetailsAsync(flagName, defaultValue, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ErrorType.ParseError, response.ErrorType);
         Assert.Equal(Reason.Error, response.Reason);
         Assert.Equal(testMessage, response.ErrorMessage);
         _ = featureProviderMock.Received(1)
-            .ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>());
+            .ResolveStructureValueAsync(flagName, defaultValue, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
 
         Assert.Equal(1, testHook.BeforeCallCount);
         Assert.Equal(0, testHook.AfterCallCount);
@@ -479,7 +478,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
             var token = args.ArgAt<CancellationToken>(3);
             while (!token.IsCancellationRequested)
             {
-                await Task.Delay(10); // artificially delay until cancelled
+                await Task.Delay(10, TestContext.Current.CancellationToken); // artificially delay until cancelled
             }
 
             return new ResolutionDetails<string>(flagName, defaultString, ErrorType.None, cancelledReason);
@@ -487,7 +486,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         featureProviderMock.GetMetadata().Returns(new Metadata(fixture.Create<string>()));
         featureProviderMock.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-        await Api.Instance.SetProviderAsync(domain, featureProviderMock);
+        await Api.Instance.SetProviderAsync(domain, featureProviderMock, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
         var task = client.GetStringDetailsAsync(flagName, defaultString, EvaluationContext.Empty, null, cts.Token);
         cts.Cancel(); // cancel before awaiting
@@ -540,7 +539,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
     public async Task TheClient_ImplementsATrackingFunction()
     {
         var provider = new TestProvider();
-        await Api.Instance.SetProviderAsync(provider);
+        await Api.Instance.SetProviderAsync(provider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
 
         const string trackingEventName = "trackingEventName";
@@ -581,7 +580,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
     public async Task PassingAnEmptyStringAsTrackingEventName_ThrowsArgumentException()
     {
         var provider = new TestProvider();
-        await Api.Instance.SetProviderAsync(provider);
+        await Api.Instance.SetProviderAsync(provider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
 
         Assert.Throws<ArgumentException>(() => client.Track(""));
@@ -591,7 +590,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
     public async Task PassingABlankStringAsTrackingEventName_ThrowsArgumentException()
     {
         var provider = new TestProvider();
-        await Api.Instance.SetProviderAsync(provider);
+        await Api.Instance.SetProviderAsync(provider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
 
         Assert.Throws<ArgumentException>(() => client.Track(" \n "));
@@ -604,7 +603,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
     public async Task PassingBlankClientName_DoesNotThrowArgumentNullException(string? clientName)
     {
         var provider = new TestProvider();
-        await Api.Instance.SetProviderAsync(provider);
+        await Api.Instance.SetProviderAsync(provider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(clientName);
 
         var ex = Record.Exception(() => client.AddHandler(ProviderEventTypes.ProviderReady, (args) => { }));
@@ -648,7 +647,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
     public async Task TheClient_MergesTheEvaluationContextInTheCorrectOrder(string key, EvaluationContext? globalEvaluationContext, EvaluationContext? clientEvaluationContext, EvaluationContext? invocationEvaluationContext, string expectedResult)
     {
         var provider = new TestProvider();
-        await Api.Instance.SetProviderAsync(provider);
+        await Api.Instance.SetProviderAsync(provider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
 
         const string trackingEventName = "trackingEventName";
@@ -672,15 +671,15 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var provider = new TestProvider();
         var providerHook = Substitute.For<Hook>();
         provider.AddHook(providerHook);
-        await Api.Instance.SetProviderAsync(provider);
+        await Api.Instance.SetProviderAsync(provider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
 
         const string flagName = "flagName";
 
         // Act
-        var evaluationDetails = await client.GetBooleanDetailsAsync(flagName, true);
+        var evaluationDetails = await client.GetBooleanDetailsAsync(flagName, true, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
-        await providerHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), evaluationDetails);
+        await providerHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), evaluationDetails, cancellationToken: TestContext.Current.CancellationToken);
     }
 }

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -69,11 +69,11 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         Api.Instance.AddHandler(ProviderEventTypes.ProviderStale, eventHandler);
 
         var testProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(testProvider);
+        await Api.Instance.SetProviderAsync(testProvider, TestContext.Current.CancellationToken);
 
-        await testProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
-        await testProvider.SendEventAsync(ProviderEventTypes.ProviderError);
-        await testProvider.SendEventAsync(ProviderEventTypes.ProviderStale);
+        await testProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged, TestContext.Current.CancellationToken);
+        await testProvider.SendEventAsync(ProviderEventTypes.ProviderError, TestContext.Current.CancellationToken);
+        await testProvider.SendEventAsync(ProviderEventTypes.ProviderStale, TestContext.Current.CancellationToken);
 
         await Utils.AssertUntilAsync(_ => eventHandler
             .Received()
@@ -116,7 +116,7 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         var eventHandler = Substitute.For<EventHandlerDelegate>();
 
         var testProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(testProvider);
+        await Api.Instance.SetProviderAsync(testProvider, TestContext.Current.CancellationToken);
 
         Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
@@ -140,7 +140,7 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         var eventHandler = Substitute.For<EventHandlerDelegate>();
 
         var testProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(testProvider);
+        await Api.Instance.SetProviderAsync(testProvider, TestContext.Current.CancellationToken);
 
         Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
@@ -164,7 +164,7 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         var eventHandler = Substitute.For<EventHandlerDelegate>();
 
         var testProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(testProvider);
+        await Api.Instance.SetProviderAsync(testProvider, TestContext.Current.CancellationToken);
 
         testProvider.Status = ProviderStatus.Error;
 
@@ -189,7 +189,7 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         var eventHandler = Substitute.For<EventHandlerDelegate>();
 
         var testProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(testProvider);
+        await Api.Instance.SetProviderAsync(testProvider, TestContext.Current.CancellationToken);
 
         testProvider.Status = ProviderStatus.Stale;
 
@@ -217,14 +217,14 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         Api.Instance.AddHandler(ProviderEventTypes.ProviderConfigurationChanged, eventHandler);
 
         var testProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(testProvider);
+        await Api.Instance.SetProviderAsync(testProvider, TestContext.Current.CancellationToken);
 
-        await testProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
+        await testProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged, TestContext.Current.CancellationToken);
 
         var newTestProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(newTestProvider);
+        await Api.Instance.SetProviderAsync(newTestProvider, TestContext.Current.CancellationToken);
 
-        await newTestProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
+        await newTestProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged, TestContext.Current.CancellationToken);
 
         await Utils.AssertUntilAsync(
             _ => eventHandler.Received(2).Invoke(Arg.Is<ProviderEventPayload>(payload => payload.ProviderName == testProvider.GetMetadata().Name && payload.Type == ProviderEventTypes.ProviderReady))
@@ -246,13 +246,13 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
         var testProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(testProvider);
+        await Api.Instance.SetProviderAsync(testProvider, TestContext.Current.CancellationToken);
 
         Thread.Sleep(1000);
         Api.Instance.RemoveHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
         var newTestProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(newTestProvider);
+        await Api.Instance.SetProviderAsync(newTestProvider, TestContext.Current.CancellationToken);
 
         eventHandler.Received(1).Invoke(Arg.Is<ProviderEventPayload>(payload => payload.ProviderName == testProvider.GetMetadata().Name));
     }
@@ -277,7 +277,7 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
         var testProvider = new TestProvider(fixture.Create<string>());
-        await Api.Instance.SetProviderAsync(testProvider);
+        await Api.Instance.SetProviderAsync(testProvider, TestContext.Current.CancellationToken);
 
         await Utils.AssertUntilAsync(
             _ => failingEventHandler.Received().Invoke(Arg.Is<ProviderEventPayload>(payload => payload.ProviderName == testProvider.GetMetadata().Name))
@@ -302,7 +302,7 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         var myClient = Api.Instance.GetClient(domain, clientVersion);
 
         var testProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name!, testProvider);
+        await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name!, testProvider, TestContext.Current.CancellationToken);
 
         myClient.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
@@ -333,7 +333,7 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         myClient.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
         var testProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name!, testProvider);
+        await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name!, testProvider, TestContext.Current.CancellationToken);
 
         await Utils.AssertUntilAsync(
             _ => failingEventHandler.Received().Invoke(Arg.Is<ProviderEventPayload>(payload => payload.ProviderName == testProvider.GetMetadata().Name))
@@ -362,9 +362,9 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         var clientProvider = new TestProvider(fixture.Create<string>());
 
         // set the default provider on API level, but not specifically to the client
-        await Api.Instance.SetProviderAsync(apiProvider);
+        await Api.Instance.SetProviderAsync(apiProvider, TestContext.Current.CancellationToken);
         // set the other provider specifically for the client
-        await Api.Instance.SetProviderAsync(myClientWithBoundProvider.GetMetadata().Name!, clientProvider);
+        await Api.Instance.SetProviderAsync(myClientWithBoundProvider.GetMetadata().Name!, clientProvider, TestContext.Current.CancellationToken);
 
         myClientWithNoBoundProvider.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
         myClientWithBoundProvider.AddHandler(ProviderEventTypes.ProviderReady, clientEventHandler);
@@ -394,11 +394,11 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         var clientProvider = new TestProvider(fixture.Create<string>());
 
         // set the default provider
-        await Api.Instance.SetProviderAsync(defaultProvider);
+        await Api.Instance.SetProviderAsync(defaultProvider, TestContext.Current.CancellationToken);
 
         client.AddHandler(ProviderEventTypes.ProviderConfigurationChanged, clientEventHandler);
 
-        await defaultProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
+        await defaultProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged, TestContext.Current.CancellationToken);
 
         // verify that the client received the event from the default provider as there is no named provider registered yet
         await Utils.AssertUntilAsync(
@@ -407,11 +407,11 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         );
 
         // set the other provider specifically for the client
-        await Api.Instance.SetProviderAsync(client.GetMetadata().Name!, clientProvider);
+        await Api.Instance.SetProviderAsync(client.GetMetadata().Name!, clientProvider, TestContext.Current.CancellationToken);
 
         // now, send another event for the default handler
-        await defaultProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
-        await clientProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged);
+        await defaultProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged, TestContext.Current.CancellationToken);
+        await clientProvider.SendEventAsync(ProviderEventTypes.ProviderConfigurationChanged, TestContext.Current.CancellationToken);
 
         // now the client should have received only the event from the named provider
         await Utils.AssertUntilAsync(
@@ -439,7 +439,7 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         var myClient = Api.Instance.GetClient(fixture.Create<string>(), fixture.Create<string>());
 
         var testProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name!, testProvider);
+        await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name!, testProvider, TestContext.Current.CancellationToken);
 
         // add the event handler after the provider has already transitioned into the ready state
         myClient.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
@@ -464,7 +464,7 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         myClient.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
         var testProvider = new TestProvider();
-        await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name!, testProvider);
+        await Api.Instance.SetProviderAsync(myClient.GetMetadata().Name!, testProvider, TestContext.Current.CancellationToken);
 
         // wait for the first event to be received
         await Utils.AssertUntilAsync(
@@ -474,7 +474,7 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         myClient.RemoveHandler(ProviderEventTypes.ProviderReady, eventHandler);
 
         // send another event from the provider - this one should not be received
-        await testProvider.SendEventAsync(ProviderEventTypes.ProviderReady);
+        await testProvider.SendEventAsync(ProviderEventTypes.ProviderReady, TestContext.Current.CancellationToken);
 
         // wait a bit and make sure we only have received the first event, but nothing after removing the event handler
         await Utils.AssertUntilAsync(
@@ -505,8 +505,8 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
     public async Task Provider_Events_Should_Update_ProviderStatus(ProviderEventTypes type, ProviderStatus status)
     {
         var provider = new TestProvider();
-        await Api.Instance.SetProviderAsync("5.3.5", provider);
-        _ = provider.SendEventAsync(type);
+        await Api.Instance.SetProviderAsync("5.3.5", provider, TestContext.Current.CancellationToken);
+        _ = provider.SendEventAsync(type, TestContext.Current.CancellationToken);
         await Utils.AssertUntilAsync(_ => Assert.True(provider.Status == status));
     }
 }

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -28,57 +28,56 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         var providerHook = Substitute.For<Hook>();
 
         // Sequence
-        apiHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-        clientHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-        invocationHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-        providerHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(EvaluationContext.Empty);
-        providerHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
-        invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
-        clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
-        apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
-        providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
-        invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
-        clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
-        apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>()).Returns(new ValueTask());
+        apiHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
+        clientHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
+        invocationHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
+        providerHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
+        providerHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
+        invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
+        clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
+        apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
+        providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
+        invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
+        clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
+        apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
 
         var testProvider = new TestProvider();
         testProvider.AddHook(providerHook);
         Api.Instance.AddHooks(apiHook);
-        await Api.Instance.SetProviderAsync(testProvider);
+        await Api.Instance.SetProviderAsync(testProvider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient(domain, clientVersion);
         client.AddHooks(clientHook);
 
-        await client.GetBooleanValueAsync(flagName, defaultValue, EvaluationContext.Empty,
-            new FlagEvaluationOptions(invocationHook, ImmutableDictionary<string, object>.Empty));
+        await client.GetBooleanValueAsync(flagName, defaultValue, EvaluationContext.Empty, new FlagEvaluationOptions(invocationHook, ImmutableDictionary<string, object>.Empty), TestContext.Current.CancellationToken);
 
         Received.InOrder(() =>
         {
-            apiHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            clientHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            invocationHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            providerHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            providerHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-            apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+            apiHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            clientHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            invocationHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            providerHook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            providerHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            invocationHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            clientHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            apiHook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            providerHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            invocationHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            clientHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            apiHook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
         });
 
-        _ = apiHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-        _ = clientHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-        _ = invocationHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-        _ = providerHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-        _ = providerHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-        _ = invocationHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-        _ = clientHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-        _ = apiHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-        _ = providerHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-        _ = invocationHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-        _ = clientHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
-        _ = apiHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>());
+        _ = apiHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = clientHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = invocationHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = providerHook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = providerHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = invocationHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = clientHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = apiHook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = providerHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = invocationHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = clientHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = apiHook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<IReadOnlyDictionary<string, object>>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -145,15 +144,14 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
             FlagValueType.Boolean, new ClientMetadata("test", "1.0.0"), new Metadata(NoOpProvider.NoOpProviderName),
             evaluationContext);
 
-        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>()).Returns(evaluationContext);
-        hook2.BeforeAsync(hookContext, Arg.Any<ImmutableDictionary<string, object>>()).Returns(evaluationContext);
+        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(evaluationContext);
+        hook2.BeforeAsync(hookContext, Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(evaluationContext);
 
         var client = Api.Instance.GetClient("test", "1.0.0");
-        await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty,
-            new FlagEvaluationOptions(ImmutableList.Create(hook1, hook2), ImmutableDictionary<string, object>.Empty));
+        await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty, new FlagEvaluationOptions(ImmutableList.Create(hook1, hook2), ImmutableDictionary<string, object>.Empty), TestContext.Current.CancellationToken);
 
-        _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-        _ = hook2.Received(1).BeforeAsync(Arg.Is<HookContext<bool>>(a => a.EvaluationContext.GetValue("test").AsString == "test"), Arg.Any<ImmutableDictionary<string, object>>());
+        _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = hook2.Received(1).BeforeAsync(Arg.Is<HookContext<bool>>(a => a.EvaluationContext.GetValue("test").AsString == "test"), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -162,29 +160,26 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
     {
         var hook = Substitute.For<Hook>();
 
-        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(EvaluationContext.Empty).AndDoes(info =>
+        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty).AndDoes(info =>
             {
                 info.Arg<HookContext<bool>>().Data.Set("test-a", true);
             });
-        hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(),
-            Arg.Any<ImmutableDictionary<string, object>>()).Returns(new ValueTask()).AndDoes(info =>
+        hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask()).AndDoes(info =>
         {
             info.Arg<HookContext<bool>>().Data.Set("test-b", "test-value");
         });
 
-        await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
+        await Api.Instance.SetProviderAsync(new NoOpFeatureProvider(), TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient("test", "1.0.0");
 
-        await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty,
-            new FlagEvaluationOptions(ImmutableList.Create(hook), ImmutableDictionary<string, object>.Empty));
+        await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty, new FlagEvaluationOptions(ImmutableList.Create(hook), ImmutableDictionary<string, object>.Empty), TestContext.Current.CancellationToken);
 
         _ = hook.Received(1).AfterAsync(Arg.Is<HookContext<bool>>(hookContext =>
             (bool)hookContext.Data.Get("test-a") == true
-        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
         _ = hook.Received(1).FinallyAsync(Arg.Is<HookContext<bool>>(hookContext =>
             (bool)hookContext.Data.Get("test-a") == true && (string)hookContext.Data.Get("test-b") == "test-value"
-        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -195,54 +190,49 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         var hook1 = Substitute.For<Hook>();
         var hook2 = Substitute.For<Hook>();
 
-        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(EvaluationContext.Empty).AndDoes(info =>
+        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty).AndDoes(info =>
             {
                 info.Arg<HookContext<bool>>().Data.Set("hook-1-value-a", true);
                 info.Arg<HookContext<bool>>().Data.Set("same", true);
             });
-        hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(),
-            Arg.Any<ImmutableDictionary<string, object>>()).Returns(new ValueTask()).AndDoes(info =>
+        hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask()).AndDoes(info =>
         {
             info.Arg<HookContext<bool>>().Data.Set("hook-1-value-b", "test-value-hook-1");
         });
 
-        hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(EvaluationContext.Empty).AndDoes(info =>
+        hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty).AndDoes(info =>
             {
                 info.Arg<HookContext<bool>>().Data.Set("hook-2-value-a", false);
                 info.Arg<HookContext<bool>>().Data.Set("same", false);
             });
-        hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(),
-            Arg.Any<ImmutableDictionary<string, object>>()).Returns(new ValueTask()).AndDoes(info =>
+        hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask()).AndDoes(info =>
         {
             info.Arg<HookContext<bool>>().Data.Set("hook-2-value-b", "test-value-hook-2");
         });
 
-        await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
+        await Api.Instance.SetProviderAsync(new NoOpFeatureProvider(), TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient("test", "1.0.0");
 
-        await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty,
-            new FlagEvaluationOptions(ImmutableList.Create(hook1, hook2),
-                ImmutableDictionary<string, object>.Empty));
+        await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty, new FlagEvaluationOptions(ImmutableList.Create(hook1, hook2),
+                ImmutableDictionary<string, object>.Empty), TestContext.Current.CancellationToken);
 
         _ = hook1.Received(1).AfterAsync(Arg.Is<HookContext<bool>>(hookContext =>
             (bool)hookContext.Data.Get("hook-1-value-a") == true && (bool)hookContext.Data.Get("same") == true
-        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
         _ = hook1.Received(1).FinallyAsync(Arg.Is<HookContext<bool>>(hookContext =>
             (bool)hookContext.Data.Get("hook-1-value-a") == true &&
             (bool)hookContext.Data.Get("same") == true &&
             (string)hookContext.Data.Get("hook-1-value-b") == "test-value-hook-1" && hookContext.Data.Count == 3
-        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
 
         _ = hook2.Received(1).AfterAsync(Arg.Is<HookContext<bool>>(hookContext =>
             (bool)hookContext.Data.Get("hook-2-value-a") == false && (bool)hookContext.Data.Get("same") == false
-        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
         _ = hook2.Received(1).FinallyAsync(Arg.Is<HookContext<bool>>(hookContext =>
             (bool)hookContext.Data.Get("hook-2-value-a") == false &&
             (bool)hookContext.Data.Get("same") == false &&
             (string)hookContext.Data.Get("hook-2-value-b") == "test-value-hook-2" && hookContext.Data.Count == 3
-        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+        ), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -305,16 +295,16 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
 
         provider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
-        provider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", true));
+        provider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<bool>("test", true));
 
-        await Api.Instance.SetProviderAsync(provider);
+        await Api.Instance.SetProviderAsync(provider, TestContext.Current.CancellationToken);
 
         var hook = Substitute.For<Hook>();
-        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>()).Returns(hookContext);
+        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(hookContext);
 
 
         var client = Api.Instance.GetClient("test", "1.0.0", null, clientContext);
-        await client.GetBooleanValueAsync("test", false, invocationContext, new FlagEvaluationOptions(ImmutableList.Create(hook), ImmutableDictionary<string, object>.Empty));
+        await client.GetBooleanValueAsync("test", false, invocationContext, new FlagEvaluationOptions(ImmutableList.Create(hook), ImmutableDictionary<string, object>.Empty), TestContext.Current.CancellationToken);
 
         // after proper merging, all properties should equal true
         _ = provider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Is<EvaluationContext>(y =>
@@ -327,7 +317,7 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
             && (y.GetValue(propClientToOverwrite).AsBoolean ?? false)
             && (y.GetValue(propHook).AsBoolean ?? false)
             && (y.GetValue(propInvocationToOverwrite).AsBoolean ?? false)
-        ));
+        ), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -352,10 +342,10 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         var evaluationDetails =
             new FlagEvaluationDetails<bool>("test", false, ErrorType.None, "testing", "testing");
 
-        await hook.BeforeAsync(hookContext, hookHints);
-        await hook.AfterAsync(hookContext, evaluationDetails, hookHints);
-        await hook.FinallyAsync(hookContext, evaluationDetails, hookHints);
-        await hook.ErrorAsync(hookContext, new Exception(), hookHints);
+        await hook.BeforeAsync(hookContext, hookHints, TestContext.Current.CancellationToken);
+        await hook.AfterAsync(hookContext, evaluationDetails, hookHints, TestContext.Current.CancellationToken);
+        await hook.FinallyAsync(hookContext, evaluationDetails, hookHints, TestContext.Current.CancellationToken);
+        await hook.ErrorAsync(hookContext, new Exception(), hookHints, TestContext.Current.CancellationToken);
 
         Assert.Null(hookContext.ClientMetadata.Name);
         Assert.Null(hookContext.ClientMetadata.Version);
@@ -378,29 +368,29 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         featureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
         // Sequence
-        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Returns(EvaluationContext.Empty);
-        featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
-        _ = hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-        _ = hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
+        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
+        featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<bool>("test", false));
+        _ = hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
 
-        await Api.Instance.SetProviderAsync(featureProvider);
+        await Api.Instance.SetProviderAsync(featureProvider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
         client.AddHooks(hook);
 
-        await client.GetBooleanValueAsync("test", false);
+        await client.GetBooleanValueAsync("test", false, cancellationToken: TestContext.Current.CancellationToken);
 
         Received.InOrder(() =>
         {
-            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-            featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-            hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
+            featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
+            hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
         });
 
-        _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-        _ = hook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-        _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>());
-        _ = featureProvider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
+        _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = hook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = featureProvider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -415,11 +405,10 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         var testProvider = new TestProvider();
         testProvider.AddHook(hook4);
         Api.Instance.AddHooks(hook1);
-        await Api.Instance.SetProviderAsync(testProvider);
+        await Api.Instance.SetProviderAsync(testProvider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
         client.AddHooks(hook2);
-        await client.GetBooleanValueAsync("test", false, null,
-            new FlagEvaluationOptions(hook3, ImmutableDictionary<string, object>.Empty));
+        await client.GetBooleanValueAsync("test", false, null, new FlagEvaluationOptions(hook3, ImmutableDictionary<string, object>.Empty), TestContext.Current.CancellationToken);
 
         Assert.Single(Api.Instance.GetHooks());
         Assert.Single(client.GetHooks());
@@ -438,39 +427,39 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         featureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
         // Sequence
-        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-        hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-        featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Returns(new ResolutionDetails<bool>("test", false));
-        hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
-        hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
-        hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
-        hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Throws(new Exception());
+        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
+        hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
+        featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<bool>("test", false));
+        hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken).Returns(new ValueTask());
+        hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken).Returns(new ValueTask());
+        hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken).Returns(new ValueTask());
+        hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken).Throws(new Exception());
 
-        await Api.Instance.SetProviderAsync(featureProvider);
+        await Api.Instance.SetProviderAsync(featureProvider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
         client.AddHooks(new[] { hook1, hook2 });
         Assert.Equal(2, client.GetHooks().Count());
 
-        await client.GetBooleanValueAsync("test", false);
+        await client.GetBooleanValueAsync("test", false, cancellationToken: TestContext.Current.CancellationToken);
 
         Received.InOrder(() =>
         {
-            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
-            hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
-            featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-            hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-            hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-            hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-            hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken);
+            hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken);
+            featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
+            hook2.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken);
+            hook1.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken);
+            hook2.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken);
+            hook1.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken);
         });
 
-        _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
-        _ = hook2.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
-        _ = featureProvider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-        _ = hook2.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-        _ = hook1.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-        _ = hook2.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
-        _ = hook1.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+        _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken);
+        _ = hook2.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken);
+        _ = featureProvider.Received(1).ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
+        _ = hook2.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken);
+        _ = hook1.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken);
+        _ = hook2.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken);
+        _ = hook1.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -485,31 +474,31 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         featureProvider1.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
         // Sequence
-        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-        hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null).Returns(EvaluationContext.Empty);
-        featureProvider1.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>()).Throws(new Exception());
-        hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Throws(new Exception());
-        hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(new ValueTask());
+        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
+        hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
+        featureProvider1.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Throws(new Exception());
+        hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken).Throws(new Exception());
+        hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken).Returns(new ValueTask());
 
-        await Api.Instance.SetProviderAsync(featureProvider1);
+        await Api.Instance.SetProviderAsync(featureProvider1, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
         client.AddHooks(new[] { hook1, hook2 });
 
-        await client.GetBooleanValueAsync("test", false);
+        await client.GetBooleanValueAsync("test", false, cancellationToken: TestContext.Current.CancellationToken);
 
         Received.InOrder(() =>
         {
-            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
-            hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null);
-            featureProvider1.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>());
-            hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-            hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken);
+            hook2.BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken);
+            featureProvider1.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
+            hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken);
+            hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken);
         });
 
-        _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
-        _ = hook2.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
-        _ = hook1.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-        _ = hook2.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+        _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken);
+        _ = hook2.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken);
+        _ = hook1.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken);
+        _ = hook2.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -524,27 +513,27 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         featureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
 
         // Sequence
-        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Throws(new Exception());
-        _ = hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-        _ = hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+        hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken).Throws(new Exception());
+        _ = hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken);
+        _ = hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken);
 
-        await Api.Instance.SetProviderAsync(featureProvider);
+        await Api.Instance.SetProviderAsync(featureProvider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
         client.AddHooks(new[] { hook1, hook2 });
 
-        await client.GetBooleanValueAsync("test", false);
+        await client.GetBooleanValueAsync("test", false, cancellationToken: TestContext.Current.CancellationToken);
 
         Received.InOrder(() =>
         {
-            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-            hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-            hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+            hook1.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
+            hook2.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken);
+            hook1.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken);
         });
 
-        _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-        _ = hook2.DidNotReceive().BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-        _ = hook1.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-        _ = hook2.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
+        _ = hook1.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = hook2.DidNotReceive().BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
+        _ = hook1.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken);
+        _ = hook2.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -561,29 +550,25 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         featureProvider.GetProviderHooks()
             .Returns(ImmutableList<Hook>.Empty);
 
-        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(EvaluationContext.Empty);
+        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
 
-        featureProvider.ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>())
-            .Returns(new ResolutionDetails<bool>("test", false));
+        featureProvider.ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<bool>("test", false));
 
-        hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(new ValueTask());
+        hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
 
-        hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(new ValueTask());
+        hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
 
-        await Api.Instance.SetProviderAsync(featureProvider);
+        await Api.Instance.SetProviderAsync(featureProvider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
 
-        await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty, flagOptions);
+        await client.GetBooleanValueAsync("test", false, EvaluationContext.Empty, flagOptions, TestContext.Current.CancellationToken);
 
         Received.InOrder(() =>
         {
-            hook.Received().BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-            featureProvider.Received().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>());
-            hook.Received().AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-            hook.Received().FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+            hook.Received().BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            featureProvider.Received().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
+            hook.Received().AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            hook.Received().FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
         });
     }
 
@@ -599,26 +584,26 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         featureProvider.GetMetadata().Returns(new Metadata(null));
 
         // Sequence
-        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>()).Throws(exceptionToThrow);
-        hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null).Returns(new ValueTask());
-        hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null).Returns(new ValueTask());
+        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken).Throws(exceptionToThrow);
+        hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken).Returns(new ValueTask());
+        hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken).Returns(new ValueTask());
 
         var client = Api.Instance.GetClient();
         client.AddHooks(hook);
 
-        var resolvedFlag = await client.GetBooleanValueAsync("test", true);
+        var resolvedFlag = await client.GetBooleanValueAsync("test", true, cancellationToken: TestContext.Current.CancellationToken);
 
         Received.InOrder(() =>
         {
-            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>());
-            hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null);
-            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+            hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Dictionary<string, object>>(), TestContext.Current.CancellationToken);
+            hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), null, TestContext.Current.CancellationToken);
+            hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken);
         });
 
         Assert.True(resolvedFlag);
-        _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null);
-        _ = hook.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), exceptionToThrow, null);
-        _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null);
+        _ = hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), null, TestContext.Current.CancellationToken);
+        _ = hook.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), exceptionToThrow, null, TestContext.Current.CancellationToken);
+        _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), null, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -636,36 +621,31 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         featureProvider.GetProviderHooks()
             .Returns(ImmutableList<Hook>.Empty);
 
-        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(EvaluationContext.Empty);
+        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
 
-        featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>())
-            .Returns(new ResolutionDetails<bool>("test", false));
+        featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Returns(new ResolutionDetails<bool>("test", false));
 
-        hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Throws(exceptionToThrow);
+        hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Throws(exceptionToThrow);
 
-        hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(new ValueTask());
+        hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
 
-        hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(new ValueTask());
+        hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
 
-        await Api.Instance.SetProviderAsync(featureProvider);
+        await Api.Instance.SetProviderAsync(featureProvider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
 
-        var resolvedFlag = await client.GetBooleanValueAsync("test", true, config: flagOptions);
+        var resolvedFlag = await client.GetBooleanValueAsync("test", true, config: flagOptions, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(resolvedFlag);
 
         Received.InOrder(() =>
         {
-            hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-            hook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
-            hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>());
+            hook.Received(1).BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            hook.Received(1).AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
+            hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken);
         });
 
-        await featureProvider.DidNotReceive().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>());
+        await featureProvider.DidNotReceive().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -683,7 +663,7 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         _ = hook.AfterAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), cts.Token);
         _ = hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<Dictionary<string, object>>(), cts.Token);
 
-        await Api.Instance.SetProviderAsync(featureProvider);
+        await Api.Instance.SetProviderAsync(featureProvider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
         client.AddHooks(hook);
 
@@ -709,19 +689,15 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         featureProvider.GetProviderHooks()
             .Returns(ImmutableList<Hook>.Empty);
 
-        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(EvaluationContext.Empty);
+        hook.BeforeAsync(Arg.Any<HookContext<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(EvaluationContext.Empty);
 
-        featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>())
-            .Throws(exceptionToThrow);
+        featureProvider.ResolveBooleanValueAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken).Throws(exceptionToThrow);
 
-        hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(new ValueTask());
+        hook.ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
 
-        hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>())
-            .Returns(new ValueTask());
+        hook.FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), TestContext.Current.CancellationToken).Returns(new ValueTask());
 
-        await Api.Instance.SetProviderAsync(featureProvider);
+        await Api.Instance.SetProviderAsync(featureProvider, TestContext.Current.CancellationToken);
         var client = Api.Instance.GetClient();
 
         await client.GetBooleanValueAsync("test", true, EvaluationContext.Empty, flagOptions, cts.Token);
@@ -730,7 +706,7 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         _ = hook.Received(1).ErrorAsync(Arg.Any<HookContext<bool>>(), Arg.Any<Exception>(), Arg.Any<ImmutableDictionary<string, object>>(), cts.Token);
         _ = hook.Received(1).FinallyAsync(Arg.Any<HookContext<bool>>(), Arg.Any<FlagEvaluationDetails<bool>>(), Arg.Any<ImmutableDictionary<string, object>>(), cts.Token);
 
-        await featureProvider.DidNotReceive().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>());
+        await featureProvider.DidNotReceive().ResolveBooleanValueAsync("test", false, Arg.Any<EvaluationContext>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/test/OpenFeature.Tests/OpenFeatureTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureTests.cs
@@ -24,14 +24,14 @@ public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
         var providerMockDefault = Substitute.For<FeatureProvider>();
         providerMockDefault.Status.Returns(ProviderStatus.NotReady);
 
-        await Api.Instance.SetProviderAsync(providerMockDefault);
-        await providerMockDefault.Received(1).InitializeAsync(Api.Instance.GetContext());
+        await Api.Instance.SetProviderAsync(providerMockDefault, TestContext.Current.CancellationToken);
+        await providerMockDefault.Received(1).InitializeAsync(Api.Instance.GetContext(), TestContext.Current.CancellationToken);
 
         var providerMockNamed = Substitute.For<FeatureProvider>();
         providerMockNamed.Status.Returns(ProviderStatus.NotReady);
 
-        await Api.Instance.SetProviderAsync("the-name", providerMockNamed);
-        await providerMockNamed.Received(1).InitializeAsync(Api.Instance.GetContext());
+        await Api.Instance.SetProviderAsync("the-name", providerMockNamed, TestContext.Current.CancellationToken);
+        await providerMockNamed.Received(1).InitializeAsync(Api.Instance.GetContext(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -79,28 +79,28 @@ public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
         var providerA = Substitute.For<FeatureProvider>();
         providerA.Status.Returns(ProviderStatus.NotReady);
 
-        await Api.Instance.SetProviderAsync(providerA);
-        await providerA.Received(1).InitializeAsync(Api.Instance.GetContext());
+        await Api.Instance.SetProviderAsync(providerA, TestContext.Current.CancellationToken);
+        await providerA.Received(1).InitializeAsync(Api.Instance.GetContext(), TestContext.Current.CancellationToken);
 
         var providerB = Substitute.For<FeatureProvider>();
         providerB.Status.Returns(ProviderStatus.NotReady);
 
-        await Api.Instance.SetProviderAsync(providerB);
-        await providerB.Received(1).InitializeAsync(Api.Instance.GetContext());
-        await providerA.Received(1).ShutdownAsync();
+        await Api.Instance.SetProviderAsync(providerB, TestContext.Current.CancellationToken);
+        await providerB.Received(1).InitializeAsync(Api.Instance.GetContext(), TestContext.Current.CancellationToken);
+        await providerA.Received(1).ShutdownAsync(TestContext.Current.CancellationToken);
 
         var providerC = Substitute.For<FeatureProvider>();
         providerC.Status.Returns(ProviderStatus.NotReady);
 
-        await Api.Instance.SetProviderAsync("named", providerC);
-        await providerC.Received(1).InitializeAsync(Api.Instance.GetContext());
+        await Api.Instance.SetProviderAsync("named", providerC, TestContext.Current.CancellationToken);
+        await providerC.Received(1).InitializeAsync(Api.Instance.GetContext(), TestContext.Current.CancellationToken);
 
         var providerD = Substitute.For<FeatureProvider>();
         providerD.Status.Returns(ProviderStatus.NotReady);
 
-        await Api.Instance.SetProviderAsync("named", providerD);
-        await providerD.Received(1).InitializeAsync(Api.Instance.GetContext());
-        await providerC.Received(1).ShutdownAsync();
+        await Api.Instance.SetProviderAsync("named", providerD, TestContext.Current.CancellationToken);
+        await providerD.Received(1).InitializeAsync(Api.Instance.GetContext(), TestContext.Current.CancellationToken);
+        await providerC.Received(1).ShutdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -113,13 +113,15 @@ public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
         var providerB = Substitute.For<FeatureProvider>();
         providerB.Status.Returns(ProviderStatus.NotReady);
 
-        await Api.Instance.SetProviderAsync(providerA);
-        await Api.Instance.SetProviderAsync("named", providerB);
+        await Api.Instance.SetProviderAsync(providerA, TestContext.Current.CancellationToken);
+        await Api.Instance.SetProviderAsync("named", providerB, TestContext.Current.CancellationToken);
 
         await Api.Instance.ShutdownAsync();
 
+#pragma warning disable xUnit1051
         await providerA.Received(1).ShutdownAsync();
         await providerB.Received(1).ShutdownAsync();
+#pragma warning restore xUnit1051
     }
 
     [Fact]
@@ -128,8 +130,8 @@ public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
     {
         var openFeature = Api.Instance;
 
-        await openFeature.SetProviderAsync(new NoOpFeatureProvider());
-        await openFeature.SetProviderAsync(TestProvider.DefaultName, new TestProvider());
+        await openFeature.SetProviderAsync(new NoOpFeatureProvider(), TestContext.Current.CancellationToken);
+        await openFeature.SetProviderAsync(TestProvider.DefaultName, new TestProvider(), TestContext.Current.CancellationToken);
 
         var defaultClient = openFeature.GetProviderMetadata();
         var domainScopedClient = openFeature.GetProviderMetadata(TestProvider.DefaultName);
@@ -144,7 +146,7 @@ public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
     {
         var openFeature = Api.Instance;
 
-        await openFeature.SetProviderAsync(new TestProvider());
+        await openFeature.SetProviderAsync(new TestProvider(), TestContext.Current.CancellationToken);
 
         var defaultClient = openFeature.GetProviderMetadata();
 
@@ -158,8 +160,8 @@ public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
         const string name = "new-client";
         var openFeature = Api.Instance;
 
-        await openFeature.SetProviderAsync(name, new TestProvider());
-        await openFeature.SetProviderAsync(name, new NoOpFeatureProvider());
+        await openFeature.SetProviderAsync(name, new TestProvider(), TestContext.Current.CancellationToken);
+        await openFeature.SetProviderAsync(name, new NoOpFeatureProvider(), TestContext.Current.CancellationToken);
 
         Assert.Equal(NoOpProvider.NoOpProviderName, openFeature.GetProviderMetadata(name)?.Name);
     }
@@ -171,8 +173,8 @@ public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
         var openFeature = Api.Instance;
         var provider = new TestProvider();
 
-        await openFeature.SetProviderAsync("a", provider);
-        await openFeature.SetProviderAsync("b", provider);
+        await openFeature.SetProviderAsync("a", provider, TestContext.Current.CancellationToken);
+        await openFeature.SetProviderAsync("b", provider, TestContext.Current.CancellationToken);
 
         var clientA = openFeature.GetProvider("a");
         var clientB = openFeature.GetProvider("b");
@@ -213,7 +215,7 @@ public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
     [Specification("1.1.5", "The API MUST provide a function for retrieving the metadata field of the configured `provider`.")]
     public async Task OpenFeature_Should_Get_Metadata()
     {
-        await Api.Instance.SetProviderAsync(new NoOpFeatureProvider());
+        await Api.Instance.SetProviderAsync(new NoOpFeatureProvider(), TestContext.Current.CancellationToken);
         var openFeature = Api.Instance;
         var metadata = openFeature.GetProviderMetadata();
 
@@ -263,8 +265,8 @@ public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
     {
         var openFeature = Api.Instance;
 
-        await openFeature.SetProviderAsync("client1", new TestProvider());
-        await openFeature.SetProviderAsync("client2", new NoOpFeatureProvider());
+        await openFeature.SetProviderAsync("client1", new TestProvider(), TestContext.Current.CancellationToken);
+        await openFeature.SetProviderAsync("client2", new NoOpFeatureProvider(), TestContext.Current.CancellationToken);
 
         var client1 = openFeature.GetClient("client1");
         var client2 = openFeature.GetClient("client2");
@@ -272,8 +274,8 @@ public class OpenFeatureTests : ClearOpenFeatureInstanceFixture
         Assert.Equal("client1", client1.GetMetadata().Name);
         Assert.Equal("client2", client2.GetMetadata().Name);
 
-        Assert.True(await client1.GetBooleanValueAsync("test", false));
-        Assert.False(await client2.GetBooleanValueAsync("test", false));
+        Assert.True(await client1.GetBooleanValueAsync("test", false, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.False(await client2.GetBooleanValueAsync("test", false, cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]

--- a/test/OpenFeature.Tests/ProviderRepositoryTests.cs
+++ b/test/OpenFeature.Tests/ProviderRepositoryTests.cs
@@ -15,7 +15,7 @@ public class ProviderRepositoryTests
         var repository = new ProviderRepository();
         var provider = new NoOpFeatureProvider();
         var context = new EvaluationContextBuilder().Build();
-        await repository.SetProviderAsync(provider, context);
+        await repository.SetProviderAsync(provider, context, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(provider, repository.GetProvider());
     }
 
@@ -26,9 +26,9 @@ public class ProviderRepositoryTests
         var providerMock = Substitute.For<FeatureProvider>();
         providerMock.Status.Returns(ProviderStatus.NotReady);
         var context = new EvaluationContextBuilder().Build();
-        await repository.SetProviderAsync(providerMock, context);
-        providerMock.Received(1).InitializeAsync(context);
-        providerMock.DidNotReceive().ShutdownAsync();
+        await repository.SetProviderAsync(providerMock, context, cancellationToken: TestContext.Current.CancellationToken);
+        providerMock.Received(1).InitializeAsync(context, TestContext.Current.CancellationToken);
+        providerMock.DidNotReceive().ShutdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class ProviderRepositoryTests
             Assert.Equal(providerMock, theProvider);
             callCount++;
             return Task.CompletedTask;
-        });
+        }, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(1, callCount);
     }
 
@@ -89,7 +89,7 @@ public class ProviderRepositoryTests
             callCount++;
             receivedError = error;
             return Task.CompletedTask;
-        });
+        }, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("BAD THINGS", receivedError?.Message);
         Assert.Equal(1, callCount);
     }
@@ -130,8 +130,8 @@ public class ProviderRepositoryTests
         var providerMock = Substitute.For<FeatureProvider>();
         providerMock.Status.Returns(status);
         var context = new EvaluationContextBuilder().Build();
-        await repository.SetProviderAsync(providerMock, context);
-        providerMock.DidNotReceive().InitializeAsync(context);
+        await repository.SetProviderAsync(providerMock, context, cancellationToken: TestContext.Current.CancellationToken);
+        providerMock.DidNotReceive().InitializeAsync(context, TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -149,7 +149,7 @@ public class ProviderRepositoryTests
         {
             callCount++;
             return Task.CompletedTask;
-        });
+        }, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(0, callCount);
     }
 
@@ -164,10 +164,10 @@ public class ProviderRepositoryTests
         provider2.Status.Returns(ProviderStatus.NotReady);
 
         var context = new EvaluationContextBuilder().Build();
-        await repository.SetProviderAsync(provider1, context);
-        await repository.SetProviderAsync(provider2, context);
-        provider1.Received(1).ShutdownAsync();
-        provider2.DidNotReceive().ShutdownAsync();
+        await repository.SetProviderAsync(provider1, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync(provider2, context, cancellationToken: TestContext.Current.CancellationToken);
+        provider1.Received(1).ShutdownAsync(TestContext.Current.CancellationToken);
+        provider2.DidNotReceive().ShutdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -177,7 +177,7 @@ public class ProviderRepositoryTests
         var provider = new NoOpFeatureProvider();
         var context = new EvaluationContextBuilder().Build();
 
-        await repository.SetProviderAsync("the-name", provider, context);
+        await repository.SetProviderAsync("the-name", provider, context, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(provider, repository.GetProvider("the-name"));
     }
 
@@ -188,9 +188,9 @@ public class ProviderRepositoryTests
         var providerMock = Substitute.For<FeatureProvider>();
         providerMock.Status.Returns(ProviderStatus.NotReady);
         var context = new EvaluationContextBuilder().Build();
-        await repository.SetProviderAsync("the-name", providerMock, context);
-        providerMock.Received(1).InitializeAsync(context);
-        providerMock.DidNotReceive().ShutdownAsync();
+        await repository.SetProviderAsync("the-name", providerMock, context, cancellationToken: TestContext.Current.CancellationToken);
+        providerMock.Received(1).InitializeAsync(context, TestContext.Current.CancellationToken);
+        providerMock.DidNotReceive().ShutdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -206,7 +206,7 @@ public class ProviderRepositoryTests
             Assert.Equal(providerMock, theProvider);
             callCount++;
             return Task.CompletedTask;
-        });
+        }, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(1, callCount);
     }
 
@@ -250,7 +250,7 @@ public class ProviderRepositoryTests
             callCount++;
             receivedError = error;
             return Task.CompletedTask;
-        });
+        }, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("BAD THINGS", receivedError?.Message);
         Assert.Equal(1, callCount);
     }
@@ -291,8 +291,8 @@ public class ProviderRepositoryTests
         var providerMock = Substitute.For<FeatureProvider>();
         providerMock.Status.Returns(status);
         var context = new EvaluationContextBuilder().Build();
-        await repository.SetProviderAsync("the-name", providerMock, context);
-        providerMock.DidNotReceive().InitializeAsync(context);
+        await repository.SetProviderAsync("the-name", providerMock, context, cancellationToken: TestContext.Current.CancellationToken);
+        providerMock.DidNotReceive().InitializeAsync(context, TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -306,12 +306,11 @@ public class ProviderRepositoryTests
         providerMock.Status.Returns(status);
         var context = new EvaluationContextBuilder().Build();
         var callCount = 0;
-        await repository.SetProviderAsync("the-name", providerMock, context,
-            afterInitSuccess: (provider, ct) =>
+        await repository.SetProviderAsync("the-name", providerMock, context, afterInitSuccess: (provider, ct) =>
             {
                 callCount++;
                 return Task.CompletedTask;
-            });
+            }, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(0, callCount);
     }
 
@@ -326,10 +325,10 @@ public class ProviderRepositoryTests
         provider2.Status.Returns(ProviderStatus.NotReady);
 
         var context = new EvaluationContextBuilder().Build();
-        await repository.SetProviderAsync("the-name", provider1, context);
-        await repository.SetProviderAsync("the-name", provider2, context);
-        provider1.Received(1).ShutdownAsync();
-        provider2.DidNotReceive().ShutdownAsync();
+        await repository.SetProviderAsync("the-name", provider1, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("the-name", provider2, context, cancellationToken: TestContext.Current.CancellationToken);
+        provider1.Received(1).ShutdownAsync(TestContext.Current.CancellationToken);
+        provider2.DidNotReceive().ShutdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -344,12 +343,12 @@ public class ProviderRepositoryTests
 
         var context = new EvaluationContextBuilder().Build();
 
-        await repository.SetProviderAsync(provider1, context);
-        await repository.SetProviderAsync("A", provider1, context);
+        await repository.SetProviderAsync(provider1, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("A", provider1, context, cancellationToken: TestContext.Current.CancellationToken);
         // Provider one is replaced for "A", but not default.
-        await repository.SetProviderAsync("A", provider2, context);
+        await repository.SetProviderAsync("A", provider2, context, cancellationToken: TestContext.Current.CancellationToken);
 
-        provider1.DidNotReceive().ShutdownAsync();
+        provider1.DidNotReceive().ShutdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -364,12 +363,12 @@ public class ProviderRepositoryTests
 
         var context = new EvaluationContextBuilder().Build();
 
-        await repository.SetProviderAsync("B", provider1, context);
-        await repository.SetProviderAsync("A", provider1, context);
+        await repository.SetProviderAsync("B", provider1, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("A", provider1, context, cancellationToken: TestContext.Current.CancellationToken);
         // Provider one is replaced for "A", but not "B".
-        await repository.SetProviderAsync("A", provider2, context);
+        await repository.SetProviderAsync("A", provider2, context, cancellationToken: TestContext.Current.CancellationToken);
 
-        provider1.DidNotReceive().ShutdownAsync();
+        provider1.DidNotReceive().ShutdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -384,13 +383,13 @@ public class ProviderRepositoryTests
 
         var context = new EvaluationContextBuilder().Build();
 
-        await repository.SetProviderAsync("B", provider1, context);
-        await repository.SetProviderAsync("A", provider1, context);
+        await repository.SetProviderAsync("B", provider1, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("A", provider1, context, cancellationToken: TestContext.Current.CancellationToken);
 
-        await repository.SetProviderAsync("A", provider2, context);
-        await repository.SetProviderAsync("B", provider2, context);
+        await repository.SetProviderAsync("A", provider2, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("B", provider2, context, cancellationToken: TestContext.Current.CancellationToken);
 
-        provider1.Received(1).ShutdownAsync();
+        provider1.Received(1).ShutdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -405,8 +404,8 @@ public class ProviderRepositoryTests
 
         var context = new EvaluationContextBuilder().Build();
 
-        await repository.SetProviderAsync("A", provider1, context);
-        await repository.SetProviderAsync("B", provider2, context);
+        await repository.SetProviderAsync("A", provider1, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("B", provider2, context, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(provider1, repository.GetProvider("A"));
         Assert.Equal(provider2, repository.GetProvider("B"));
@@ -424,8 +423,8 @@ public class ProviderRepositoryTests
 
         var context = new EvaluationContextBuilder().Build();
 
-        await repository.SetProviderAsync("A", provider1, context);
-        await repository.SetProviderAsync("A", provider2, context);
+        await repository.SetProviderAsync("A", provider1, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("A", provider2, context, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(provider2, repository.GetProvider("A"));
     }
@@ -445,17 +444,17 @@ public class ProviderRepositoryTests
 
         var context = new EvaluationContextBuilder().Build();
 
-        await repository.SetProviderAsync(provider1, context);
-        await repository.SetProviderAsync("provider1", provider1, context);
-        await repository.SetProviderAsync("provider2", provider2, context);
-        await repository.SetProviderAsync("provider2a", provider2, context);
-        await repository.SetProviderAsync("provider3", provider3, context);
+        await repository.SetProviderAsync(provider1, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("provider1", provider1, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("provider2", provider2, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("provider2a", provider2, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("provider3", provider3, context, cancellationToken: TestContext.Current.CancellationToken);
 
-        await repository.ShutdownAsync();
+        await repository.ShutdownAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        provider1.Received(1).ShutdownAsync();
-        provider2.Received(1).ShutdownAsync();
-        provider3.Received(1).ShutdownAsync();
+        provider1.Received(1).ShutdownAsync(TestContext.Current.CancellationToken);
+        provider2.Received(1).ShutdownAsync(TestContext.Current.CancellationToken);
+        provider3.Received(1).ShutdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -465,12 +464,12 @@ public class ProviderRepositoryTests
         var provider = Substitute.For<FeatureProvider>();
         provider.Status.Returns(ProviderStatus.NotReady);
         var context = new EvaluationContextBuilder().Build();
-        await repository.SetProviderAsync(provider, context);
-        await repository.SetProviderAsync(provider, context);
+        await repository.SetProviderAsync(provider, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync(provider, context, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(provider, repository.GetProvider());
-        provider.Received(1).InitializeAsync(context);
-        provider.DidNotReceive().ShutdownAsync();
+        provider.Received(1).InitializeAsync(context, TestContext.Current.CancellationToken);
+        provider.DidNotReceive().ShutdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -480,12 +479,12 @@ public class ProviderRepositoryTests
         var provider = Substitute.For<FeatureProvider>();
         provider.Status.Returns(ProviderStatus.NotReady);
         var context = new EvaluationContextBuilder().Build();
-        await repository.SetProviderAsync(provider, context);
-        await repository.SetProviderAsync(null, context);
+        await repository.SetProviderAsync(provider, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync(null, context, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(provider, repository.GetProvider());
-        provider.Received(1).InitializeAsync(context);
-        provider.DidNotReceive().ShutdownAsync();
+        provider.Received(1).InitializeAsync(context, TestContext.Current.CancellationToken);
+        provider.DidNotReceive().ShutdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -500,10 +499,10 @@ public class ProviderRepositoryTests
         defaultProvider.Status.Returns(ProviderStatus.NotReady);
 
         var context = new EvaluationContextBuilder().Build();
-        await repository.SetProviderAsync(defaultProvider, context);
+        await repository.SetProviderAsync(defaultProvider, context, cancellationToken: TestContext.Current.CancellationToken);
 
-        await repository.SetProviderAsync("named-provider", namedProvider, context);
-        await repository.SetProviderAsync("named-provider", null, context);
+        await repository.SetProviderAsync("named-provider", namedProvider, context, cancellationToken: TestContext.Current.CancellationToken);
+        await repository.SetProviderAsync("named-provider", null, context, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(defaultProvider, repository.GetProvider("named-provider"));
     }

--- a/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
+++ b/test/OpenFeature.Tests/Providers/Memory/InMemoryProviderTests.cs
@@ -174,7 +174,7 @@ public class InMemoryProviderTests
     [Fact]
     public async Task GetBoolean_ShouldEvaluateWithReasonAndVariant()
     {
-        ResolutionDetails<bool> details = await this.commonProvider.ResolveBooleanValueAsync("boolean-flag", false, EvaluationContext.Empty);
+        ResolutionDetails<bool> details = await this.commonProvider.ResolveBooleanValueAsync("boolean-flag", false, EvaluationContext.Empty, TestContext.Current.CancellationToken);
         Assert.True(details.Value);
         Assert.Equal(Reason.Static, details.Reason);
         Assert.Equal("on", details.Variant);
@@ -184,7 +184,7 @@ public class InMemoryProviderTests
     public async Task GetBoolean_WithNoEvaluationContext_ShouldEvaluateWithReasonAndVariant()
     {
         // Act
-        ResolutionDetails<bool> details = await this.commonProvider.ResolveBooleanValueAsync("boolean-flag", false);
+        ResolutionDetails<bool> details = await this.commonProvider.ResolveBooleanValueAsync("boolean-flag", false, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(details.Value);
@@ -196,7 +196,7 @@ public class InMemoryProviderTests
     public async Task GetBoolean_WhenDisabled_ShouldEvaluateWithDefaultReason()
     {
         // Act
-        ResolutionDetails<bool> details = await this.commonProvider.ResolveBooleanValueAsync("boolean-disabled-flag", false, EvaluationContext.Empty);
+        ResolutionDetails<bool> details = await this.commonProvider.ResolveBooleanValueAsync("boolean-disabled-flag", false, EvaluationContext.Empty, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(details.Value);
@@ -207,7 +207,7 @@ public class InMemoryProviderTests
     [Fact]
     public async Task GetString_ShouldEvaluateWithReasonAndVariant()
     {
-        ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("string-flag", "nope", EvaluationContext.Empty);
+        ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("string-flag", "nope", EvaluationContext.Empty, TestContext.Current.CancellationToken);
         Assert.Equal("hi", details.Value);
         Assert.Equal(Reason.Static, details.Reason);
         Assert.Equal("greeting", details.Variant);
@@ -217,7 +217,7 @@ public class InMemoryProviderTests
     public async Task GetString_WithNoEvaluationContext_ShouldEvaluateWithReasonAndVariant()
     {
         // Act
-        ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("string-flag", "nope");
+        ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("string-flag", "nope", cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal("hi", details.Value);
@@ -229,7 +229,7 @@ public class InMemoryProviderTests
     public async Task GetString_WhenDisabled_ShouldEvaluateWithDefaultReason()
     {
         // Act
-        ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("string-disabled-flag", "nope");
+        ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("string-disabled-flag", "nope", cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal("nope", details.Value);
@@ -240,7 +240,7 @@ public class InMemoryProviderTests
     [Fact]
     public async Task GetInt_ShouldEvaluateWithReasonAndVariant()
     {
-        ResolutionDetails<int> details = await this.commonProvider.ResolveIntegerValueAsync("integer-flag", 13, EvaluationContext.Empty);
+        ResolutionDetails<int> details = await this.commonProvider.ResolveIntegerValueAsync("integer-flag", 13, EvaluationContext.Empty, TestContext.Current.CancellationToken);
         Assert.Equal(10, details.Value);
         Assert.Equal(Reason.Static, details.Reason);
         Assert.Equal("ten", details.Variant);
@@ -250,7 +250,7 @@ public class InMemoryProviderTests
     public async Task GetInt_WithNoEvaluationContext_ShouldEvaluateWithReasonAndVariant()
     {
         // Act
-        ResolutionDetails<int> details = await this.commonProvider.ResolveIntegerValueAsync("integer-flag", 13);
+        ResolutionDetails<int> details = await this.commonProvider.ResolveIntegerValueAsync("integer-flag", 13, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(10, details.Value);
@@ -262,7 +262,7 @@ public class InMemoryProviderTests
     public async Task GetInt_WhenDisabled_ShouldEvaluateWithDefaultReason()
     {
         // Act
-        ResolutionDetails<int> details = await this.commonProvider.ResolveIntegerValueAsync("integer-disabled-flag", 13);
+        ResolutionDetails<int> details = await this.commonProvider.ResolveIntegerValueAsync("integer-disabled-flag", 13, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(13, details.Value);
@@ -273,7 +273,7 @@ public class InMemoryProviderTests
     [Fact]
     public async Task GetDouble_ShouldEvaluateWithReasonAndVariant()
     {
-        ResolutionDetails<double> details = await this.commonProvider.ResolveDoubleValueAsync("float-flag", 13, EvaluationContext.Empty);
+        ResolutionDetails<double> details = await this.commonProvider.ResolveDoubleValueAsync("float-flag", 13, EvaluationContext.Empty, TestContext.Current.CancellationToken);
         Assert.Equal(0.5, details.Value);
         Assert.Equal(Reason.Static, details.Reason);
         Assert.Equal("half", details.Variant);
@@ -283,7 +283,7 @@ public class InMemoryProviderTests
     public async Task GetDouble_WithNoEvaluationContext_ShouldEvaluateWithReasonAndVariant()
     {
         // Arrange
-        ResolutionDetails<double> details = await this.commonProvider.ResolveDoubleValueAsync("float-flag", 13);
+        ResolutionDetails<double> details = await this.commonProvider.ResolveDoubleValueAsync("float-flag", 13, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(0.5, details.Value);
@@ -295,7 +295,7 @@ public class InMemoryProviderTests
     public async Task GetDouble_WhenDisabled_ShouldEvaluateWithDefaultReason()
     {
         // Act
-        ResolutionDetails<double> details = await this.commonProvider.ResolveDoubleValueAsync("float-disabled-flag", 1.3);
+        ResolutionDetails<double> details = await this.commonProvider.ResolveDoubleValueAsync("float-disabled-flag", 1.3, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1.3, details.Value);
@@ -306,7 +306,7 @@ public class InMemoryProviderTests
     [Fact]
     public async Task GetStruct_ShouldEvaluateWithReasonAndVariant()
     {
-        ResolutionDetails<Value> details = await this.commonProvider.ResolveStructureValueAsync("object-flag", new Value(), EvaluationContext.Empty);
+        ResolutionDetails<Value> details = await this.commonProvider.ResolveStructureValueAsync("object-flag", new Value(), EvaluationContext.Empty, TestContext.Current.CancellationToken);
         Assert.Equal(true, details.Value.AsStructure?["showImages"].AsBoolean);
         Assert.Equal("Check out these pics!", details.Value.AsStructure?["title"].AsString);
         Assert.Equal(100, details.Value.AsStructure?["imagesPerPage"].AsInteger);
@@ -318,7 +318,7 @@ public class InMemoryProviderTests
     public async Task GetStruct_WithNoEvaluationContext_ShouldEvaluateWithReasonAndVariant()
     {
         // Act
-        ResolutionDetails<Value> details = await this.commonProvider.ResolveStructureValueAsync("object-flag", new Value());
+        ResolutionDetails<Value> details = await this.commonProvider.ResolveStructureValueAsync("object-flag", new Value(), cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(true, details.Value.AsStructure?["showImages"].AsBoolean);
@@ -339,7 +339,7 @@ public class InMemoryProviderTests
         );
 
         // Act
-        ResolutionDetails<Value> details = await this.commonProvider.ResolveStructureValueAsync("object-disabled-flag", defaultValue);
+        ResolutionDetails<Value> details = await this.commonProvider.ResolveStructureValueAsync("object-disabled-flag", defaultValue, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(true, details.Value.AsStructure?["default"].AsBoolean);
@@ -351,7 +351,7 @@ public class InMemoryProviderTests
     public async Task GetString_ContextSensitive_ShouldEvaluateWithReasonAndVariant()
     {
         EvaluationContext context = EvaluationContext.Builder().Set("email", "me@faas.com").Build();
-        ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("context-aware", "nope", context);
+        ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("context-aware", "nope", context, TestContext.Current.CancellationToken);
         Assert.Equal("INTERNAL", details.Value);
         Assert.Equal(Reason.TargetingMatch, details.Reason);
         Assert.Equal("internal", details.Variant);
@@ -361,7 +361,7 @@ public class InMemoryProviderTests
     public async Task GetString_ContextSensitive_WithNoEvaluationContext_ShouldEvaluateWithReasonAndVariant()
     {
         // Act
-        ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("context-aware", "nope");
+        ResolutionDetails<string> details = await this.commonProvider.ResolveStringValueAsync("context-aware", "nope", cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal("EXTERNAL", details.Value);
@@ -381,7 +381,7 @@ public class InMemoryProviderTests
     public async Task MissingFlag_ShouldReturnFlagNotFoundEvaluationFlag()
     {
         // Act
-        var result = await this.commonProvider.ResolveBooleanValueAsync("missing-flag", false, EvaluationContext.Empty);
+        var result = await this.commonProvider.ResolveBooleanValueAsync("missing-flag", false, EvaluationContext.Empty, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(Reason.Error, result.Reason);
@@ -392,7 +392,7 @@ public class InMemoryProviderTests
     public async Task MismatchedFlag_ShouldReturnTypeMismatchError()
     {
         // Act
-        var result = await this.commonProvider.ResolveStringValueAsync("boolean-flag", "nope", EvaluationContext.Empty);
+        var result = await this.commonProvider.ResolveStringValueAsync("boolean-flag", "nope", EvaluationContext.Empty, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(Reason.Error, result.Reason);
@@ -402,14 +402,14 @@ public class InMemoryProviderTests
     [Fact]
     public async Task MissingDefaultVariant_ShouldThrow()
     {
-        await Assert.ThrowsAsync<GeneralException>(() => this.commonProvider.ResolveBooleanValueAsync("invalid-flag", false, EvaluationContext.Empty));
+        await Assert.ThrowsAsync<GeneralException>(() => this.commonProvider.ResolveBooleanValueAsync("invalid-flag", false, EvaluationContext.Empty, TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async Task MissingEvaluatedVariant_ReturnsDefaultVariant()
     {
         // Act
-        var result = await this.commonProvider.ResolveBooleanValueAsync("invalid-evaluator-flag", false, EvaluationContext.Empty);
+        var result = await this.commonProvider.ResolveBooleanValueAsync("invalid-evaluator-flag", false, EvaluationContext.Empty, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Value);
@@ -421,7 +421,7 @@ public class InMemoryProviderTests
     public async Task ContextEvaluatorThrows_ReturnsDefaultVariant()
     {
         // Act
-        var result = await this.commonProvider.ResolveBooleanValueAsync("evaluator-throws-flag", false, EvaluationContext.Empty);
+        var result = await this.commonProvider.ResolveBooleanValueAsync("evaluator-throws-flag", false, EvaluationContext.Empty, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Value);
@@ -443,7 +443,7 @@ public class InMemoryProviderTests
             )
         }});
 
-        ResolutionDetails<bool> details = await provider.ResolveBooleanValueAsync("old-flag", false, EvaluationContext.Empty);
+        ResolutionDetails<bool> details = await provider.ResolveBooleanValueAsync("old-flag", false, EvaluationContext.Empty, TestContext.Current.CancellationToken);
         Assert.True(details.Value);
 
         // update flags
@@ -458,17 +458,17 @@ public class InMemoryProviderTests
             )
         }});
 
-        var res = await provider.GetEventChannel().Reader.ReadAsync() as ProviderEventPayload;
+        var res = await provider.GetEventChannel().Reader.ReadAsync(TestContext.Current.CancellationToken) as ProviderEventPayload;
         Assert.Equal(ProviderEventTypes.ProviderConfigurationChanged, res?.Type);
 
         // old flag should be gone
-        var oldFlag = await provider.ResolveBooleanValueAsync("old-flag", false, EvaluationContext.Empty);
+        var oldFlag = await provider.ResolveBooleanValueAsync("old-flag", false, EvaluationContext.Empty, TestContext.Current.CancellationToken);
 
         Assert.Equal(Reason.Error, oldFlag.Reason);
         Assert.Equal(ErrorType.FlagNotFound, oldFlag.ErrorType);
 
         // new flag should be present, old gone (defaults), handler run.
-        ResolutionDetails<string> detailsAfter = await provider.ResolveStringValueAsync("new-flag", "nope", EvaluationContext.Empty);
+        ResolutionDetails<string> detailsAfter = await provider.ResolveStringValueAsync("new-flag", "nope", EvaluationContext.Empty, TestContext.Current.CancellationToken);
         Assert.True(details.Value);
         Assert.Equal("hi", detailsAfter.Value);
     }


### PR DESCRIPTION
## This PR

This PR upgrades the test infrastructure to use xUnit v3 and Microsoft.Testing.Platform (mtp) v2, modernizing the testing framework across all test projects in the dotnet-sdk.

- Upgrades xUnit to v3
- Upgrades Microsoft.Testing.Platform to v2
- Updates all test projects to use the new testing framework versions
- Refactors test assertions and lifecycle management to be compatible with xUnit v3 APIs
- Updates Directory.Packages.props with new package versions
- Adds global.json configuration

### Related Issues

Fixes #624
Fixes #648

### Notes

This is a significant infrastructure upgrade that affects all test projects:
- `OpenFeature.E2ETests`
- `OpenFeature.Hosting.Tests`
- `OpenFeature.IntegrationTests`
- `OpenFeature.Providers.MultiProvider.Tests`
- `OpenFeature.Tests`

The changes include updates to test lifecycle management and assertion patterns to align with xUnit v3 conventions. Net reduction of ~40 lines of code across the test suite while maintaining all existing test coverage.

### How to test

1. Clone the repository
2. Run `dotnet test` to execute the full test suite
3. Verify all tests pass with the new xUnit v3 and mtp v2 framework
4. Check that test output and reporting work as expected