### PR TITLE
ci: Simplify test coverage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -42,10 +42,39 @@ jobs:
       - name: Run Test
         run: dotnet test --verbosity normal --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
 
-      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      # Keep globbing on non-Windows runners (works today)
+      - name: Upload coverage to Codecov (non-Windows)
+        if: runner.os != 'Windows'
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           name: Code Coverage for ${{ matrix.os }}
           files: "**/TestResults/**/coverage.opencover.xml"
+          disable_search: true
+          fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
+
+      # On Windows, avoid passing a glob that expands into multiple args
+      - name: Find coverage reports (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $files = Get-ChildItem -Path "$PWD" -Recurse -Filter "coverage.opencover.xml" | ForEach-Object { $_.FullName }
+          if (-not $files -or $files.Count -eq 0) {
+            throw "No coverage.opencover.xml files were found under the repository."
+          }
+
+          # Codecov accepts comma-separated file paths
+          $csv = ($files -join ",")
+          "CODECOV_FILES=$csv" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Upload coverage to Codecov (Windows)
+        if: runner.os == 'Windows'
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          name: Code Coverage for ${{ matrix.os }}
+          files: ${{ env.CODECOV_FILES }}
+          disable_search: true
           fail_ci_if_error: true
           verbose: true
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -40,11 +40,12 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Run Test
-        run: dotnet test --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+        run: dotnet test --verbosity normal --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
 
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           name: Code Coverage for ${{ matrix.os }}
+          files: "**/TestResults/**/coverage.opencover.xml"
           fail_ci_if_error: true
           verbose: true
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,12 @@ To run unit tests execute:
 dotnet test test/OpenFeature.Tests/
 ```
 
+To run unit tests with code coverage execute:
+
+```bash
+dotnet test test/OpenFeature.Tests/ --collect:"XPlat Code Coverage"
+```
+
 #### E2E tests
 
 To be able to run the e2e tests, first we need to initialize the submodule.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,8 @@
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
     <MicrosoftExtensionsVersion>9.0.0</MicrosoftExtensionsVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net10.0'))">
+  <PropertyGroup
+    Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net10.0'))">
     <MicrosoftExtensionsVersion>10.0.0</MicrosoftExtensionsVersion>
   </PropertyGroup>
 
@@ -35,7 +36,6 @@
     <PackageVersion Include="AutoFixture" Version="5.0.0-preview0012" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />

--- a/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
+++ b/test/OpenFeature.E2ETests/OpenFeature.E2ETests.csproj
@@ -10,10 +10,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Reqnroll.xUnit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/test/OpenFeature.Hosting.Tests/OpenFeature.Hosting.Tests.csproj
+++ b/test/OpenFeature.Hosting.Tests/OpenFeature.Hosting.Tests.csproj
@@ -10,10 +10,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
+++ b/test/OpenFeature.IntegrationTests/OpenFeature.IntegrationTests.csproj
@@ -9,10 +9,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />

--- a/test/OpenFeature.Providers.MultiProvider.Tests/OpenFeature.Providers.MultiProvider.Tests.csproj
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/OpenFeature.Providers.MultiProvider.Tests.csproj
@@ -10,10 +10,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/test/OpenFeature.Tests/OpenFeature.Tests.csproj
+++ b/test/OpenFeature.Tests/OpenFeature.Tests.csproj
@@ -10,10 +10,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates our code coverage tooling by switching from the `coverlet.msbuild` package to the built-in .NET `XPlat Code Coverage` data collector. This simplifies our dependencies and updates our documentation and CI workflow to match the new approach.

**Code coverage tooling update:**

* Removed all references to the `coverlet.msbuild` package from test project files and the central `Directory.Packages.props` to reduce dependency complexity. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L38) [[2]](diffhunk://#diff-0be27d52eedaa38daa5f722e08c534bd3ae672aaf8e92c48c481e0f5308d006fL13-L16) [[3]](diffhunk://#diff-07af0ee09870050ac5c9b8a958f68806ffc85b2f7e5a58c949f67549a52ede17L13-L16) [[4]](diffhunk://#diff-056c737ea9a6dc141f40eb12b62f535acbdaccdc64fba44d85dc6ac94e8f1c03L12-L15) [[5]](diffhunk://#diff-97d4a2550f0fd445571df1b3cb4712b57dce7ef63fc442f67a5dcb643f162993L13-L16) [[6]](diffhunk://#diff-ab2ad60395e1cc72b327459243ed8c5711efbd88531a3b3b813fb6c4c6019886L13-L16)
* Updated the GitHub Actions workflow in `.github/workflows/code-coverage.yml` to use `dotnet test` with the `--collect:"XPlat Code Coverage"` option and set the output format to `opencover`. Also specified the correct coverage file path for the Codecov upload step.

**Documentation improvements:**

* Added instructions to `CONTRIBUTING.md` for running unit tests with code coverage using the new `XPlat Code Coverage` collector.

### Notes
<!-- any additional notes for this PR -->

- We were installing two collectors and using only the old MSBuild version. This PR aims to migrate to use only the `collector` one making it simpler.