### PR TITLE
refactor: improve code quality

### DIFF
--- a/src/OpenFeature/EventExecutor.cs
+++ b/src/OpenFeature/EventExecutor.cs
@@ -15,7 +15,7 @@ internal sealed partial class EventExecutor : IAsyncDisposable
     private readonly List<FeatureProvider> _activeSubscriptions = [];
 
     /// placeholder for anonymous clients
-    private static Guid _defaultClientName = Guid.NewGuid();
+    private static readonly Guid _defaultClientName = Guid.NewGuid();
 
     private readonly Dictionary<ProviderEventTypes, List<EventHandlerDelegate>> _apiHandlers = [];
     private readonly Dictionary<string, Dictionary<ProviderEventTypes, List<EventHandlerDelegate>>> _clientHandlers = [];

--- a/src/OpenFeature/EventExecutor.cs
+++ b/src/OpenFeature/EventExecutor.cs
@@ -93,12 +93,10 @@ internal sealed partial class EventExecutor : IAsyncDisposable
 
         lock (this._lockObj)
         {
-            if (this._clientHandlers.TryGetValue(clientName, out var clientEventHandlers))
+            if (this._clientHandlers.TryGetValue(clientName, out var clientEventHandlers)
+                    && clientEventHandlers.TryGetValue(type, out var eventHandlers))
             {
-                if (clientEventHandlers.TryGetValue(type, out var eventHandlers))
-                {
-                    eventHandlers.Remove(handler);
-                }
+                eventHandlers.Remove(handler);
             }
         }
     }

--- a/src/OpenFeature/Hooks/LoggingHook.cs
+++ b/src/OpenFeature/Hooks/LoggingHook.cs
@@ -153,11 +153,11 @@ public sealed partial class LoggingHook : Hook
             if (value.IsBoolean)
                 return value.AsBoolean.ToString();
 
-            if (value.IsNumber)
+            if (value.IsNumber && value.AsDouble != null)
             {
                 // Value.AsDouble will attempt to cast other numbers to double
                 // There is an implicit conversation for int/long to double
-                if (value.AsDouble != null) return value.AsDouble.ToString();
+                return value.AsDouble.ToString();
             }
 
             if (value.IsDateTime)

--- a/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
+++ b/src/OpenFeature/Providers/Memory/InMemoryProvider.cs
@@ -26,14 +26,7 @@ public class InMemoryProvider : FeatureProvider
     /// <param name="flags">dictionary of Flags</param>
     public InMemoryProvider(IDictionary<string, Flag>? flags = null)
     {
-        if (flags == null)
-        {
-            this._flags = new Dictionary<string, Flag>();
-        }
-        else
-        {
-            this._flags = new Dictionary<string, Flag>(flags); // shallow copy
-        }
+        this._flags = flags == null ? [] : new Dictionary<string, Flag>(flags); // shallow copy
     }
 
     /// <summary>
@@ -43,14 +36,8 @@ public class InMemoryProvider : FeatureProvider
     public async Task UpdateFlagsAsync(IDictionary<string, Flag>? flags = null)
     {
         var changed = this._flags.Keys.ToList();
-        if (flags == null)
-        {
-            this._flags = new Dictionary<string, Flag>();
-        }
-        else
-        {
-            this._flags = new Dictionary<string, Flag>(flags); // shallow copy
-        }
+        this._flags = flags == null ? [] : new Dictionary<string, Flag>(flags); // shallow copy
+
         changed.AddRange(this._flags.Keys.ToList());
         var @event = new ProviderEventPayload
         {

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
@@ -319,7 +319,7 @@ public class MultiProviderEventTests
     private static async Task<List<ProviderEventPayload>> ReadEvents(Channel<object> channel, int expectedCount = 1, int timeoutMs = 1000)
     {
         var events = new List<ProviderEventPayload>();
-        var cts = new CancellationTokenSource(timeoutMs);
+        using var cts = new CancellationTokenSource(timeoutMs);
 
         try
         {

--- a/test/OpenFeature.Providers.MultiProvider.Tests/ProviderExtensionsTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/ProviderExtensionsTests.cs
@@ -220,7 +220,8 @@ public class ProviderExtensionsTests
         const string resolvedValue = "resolved";
         var expectedDetails = new ResolutionDetails<string>(TestFlagKey, resolvedValue, ErrorType.None, Reason.Static, TestVariant);
         var providerContext = new StrategyPerProviderContext<string>(this._mockProvider, TestProviderName, ProviderStatus.Ready, TestFlagKey);
-        var customCancellationToken = new CancellationTokenSource().Token;
+        using var cts = new CancellationTokenSource();
+        var customCancellationToken = cts.Token;
 
         this._mockProvider.ResolveStringValueAsync(TestFlagKey, defaultValue, this._evaluationContext, customCancellationToken)
             .Returns(expectedDetails);
@@ -283,7 +284,7 @@ public class ProviderExtensionsTests
     {
         // Arrange
         const bool defaultValue = false;
-        var cancellationTokenSource = new CancellationTokenSource();
+        using var cancellationTokenSource = new CancellationTokenSource();
         var providerContext = new StrategyPerProviderContext<bool>(this._mockProvider, TestProviderName, ProviderStatus.Ready, TestFlagKey);
 
         this._mockProvider.ResolveBooleanValueAsync(TestFlagKey, defaultValue, this._evaluationContext, cancellationTokenSource.Token)

--- a/test/OpenFeature.Tests/OpenFeatureClientTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureClientTests.cs
@@ -470,7 +470,7 @@ public class OpenFeatureClientTests : ClearOpenFeatureInstanceFixture
         var defaultString = fixture.Create<string>();
         var cancelledReason = "cancelled";
 
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
 
 
         var featureProviderMock = Substitute.For<FeatureProvider>();

--- a/test/OpenFeature.Tests/OpenFeatureHookTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureHookTests.cs
@@ -673,7 +673,7 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
     {
         var featureProvider = Substitute.For<FeatureProvider>();
         var hook = Substitute.For<Hook>();
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
 
         featureProvider.GetMetadata().Returns(new Metadata(null));
         featureProvider.GetProviderHooks().Returns(ImmutableList<Hook>.Empty);
@@ -701,7 +701,7 @@ public class OpenFeatureHookTests : ClearOpenFeatureInstanceFixture
         var hook = Substitute.For<Hook>();
         var flagOptions = new FlagEvaluationOptions(hook);
         var exceptionToThrow = new GeneralException("Fake Exception");
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
 
         featureProvider.GetMetadata()
             .Returns(new Metadata(null));


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request makes several improvements to code quality and correctness across the OpenFeature project. The main themes are safer resource management, minor logic corrections, and code simplification. The most notable changes are the consistent use of `using` statements for `CancellationTokenSource` in tests, simplification of dictionary initialization, and minor refactoring for clarity and correctness.

**Resource management improvements in tests:**

* Replaced raw `CancellationTokenSource` instances with `using` statements in multiple test files to ensure proper disposal and prevent resource leaks (`test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs`, `test/OpenFeature.Providers.MultiProvider.Tests/ProviderExtensionsTests.cs`, `test/OpenFeature.Tests/OpenFeatureClientTests.cs`, `test/OpenFeature.Tests/OpenFeatureHookTests.cs`). [[1]](diffhunk://#diff-4ff88cc2082f0e2b07167c5f77f64082eaf749a0fe44631bae0d4a7f8cfd6ac1L322-R322) [[2]](diffhunk://#diff-b7fa02215eeade4ccd82b1b905fcd657b7c3769cb233d2640b3a8defd7a01599L223-R224) [[3]](diffhunk://#diff-b7fa02215eeade4ccd82b1b905fcd657b7c3769cb233d2640b3a8defd7a01599L286-R287) [[4]](diffhunk://#diff-97c93c206b866c1293c8c476783ad62d653cbac48716afc15d418b7701431e30L473-R473) [[5]](diffhunk://#diff-e20c7051aed538348fb60bb5761e45b22b13ac61036f2acbacc29b1908967770L676-R676) [[6]](diffhunk://#diff-e20c7051aed538348fb60bb5761e45b22b13ac61036f2acbacc29b1908967770L704-R704)

**Code simplification and initialization:**

* Simplified dictionary initialization in `InMemoryProvider` by using the `[]` shorthand for empty dictionaries and reducing conditional logic in constructors and update methods (`src/OpenFeature/Providers/Memory/InMemoryProvider.cs`). [[1]](diffhunk://#diff-4734ad108181b3c0b9f2c89e921b023e0d3e06d3c26ba1bed6352a75643469b0L29-R29) [[2]](diffhunk://#diff-4734ad108181b3c0b9f2c89e921b023e0d3e06d3c26ba1bed6352a75643469b0L46-R40)

**Logic corrections and refactoring:**

* Improved handler removal logic in `EventExecutor` by combining dictionary lookups into a single conditional, reducing nesting and improving clarity (`src/OpenFeature/EventExecutor.cs`).
* Made `_defaultClientName` a `readonly` static field to prevent accidental reassignment (`src/OpenFeature/EventExecutor.cs`).

**Minor bug fix:**

* Added a null check for `AsDouble` in `LoggingHook.ToString()` to prevent potential errors when handling numeric values (`src/OpenFeature/Hooks/LoggingHook.cs`).