### PR TITLE
ci: Change to attest action and fix SBOM generator path

### DIFF
--- a/.github/actions/sbom-generator/action.yml
+++ b/.github/actions/sbom-generator/action.yml
@@ -37,5 +37,5 @@ runs:
     - name: Attest package
       uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       with:
-        subject-path: src/**/${{ inputs.project-name }}.*.nupkg
+        subject-path: src/${{ inputs.project-name }}/**/${{ inputs.project-name }}.*.nupkg
         sbom-path: ./artifacts/sboms/${{ inputs.project-name }}.bom.json

--- a/.github/actions/sbom-generator/action.yml
+++ b/.github/actions/sbom-generator/action.yml
@@ -35,7 +35,7 @@ runs:
         gh release upload ${{ inputs.release-tag }} ./artifacts/sboms/${{ inputs.project-name }}.bom.json
 
     - name: Attest package
-      uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3.0.0
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       with:
         subject-path: src/**/${{ inputs.project-name }}.*.nupkg
         sbom-path: ./artifacts/sboms/${{ inputs.project-name }}.bom.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       id-token: write # enable GitHub OIDC token issuance for this job (NuGet login)
       contents: write # for SBOM release
-      attestations: write # for actions/attest-sbom to create attestation
+      attestations: write # for actions/attest to create attestation
       packages: read # for internal nuget reading
     if: ${{ fromJSON(needs.release-please.outputs.release_created || false) }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         run: dotnet nuget push "src/**/*.nupkg" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: "src/**/*.nupkg"
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the GitHub Actions workflow to use the latest attestation action and improves the accuracy of artifact attestation paths. The main changes focus on upgrading from deprecated actions to their newer consolidated versions and refining path specifications for attestation.

**GitHub Actions upgrades:**

* Switched from `actions/attest-sbom` and `actions/attest-build-provenance` to the unified `actions/attest@v4.1.0` action in both `.github/actions/sbom-generator/action.yml` and `.github/workflows/release.yml`, ensuring future compatibility and access to new features. [[1]](diffhunk://#diff-60ded41cd4ae3a02293816c4cb3935cc3706eba7c24c8358207c24e6f361118fL38-R40) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L76-R76)

**Attestation path improvements:**

* Updated the `subject-path` for SBOM attestation to target the correct package directory: now uses `src/${{ inputs.project-name }}/**/${{ inputs.project-name }}.*.nupkg` instead of a broad glob, reducing the risk of incorrect matches.
* Clarified workflow comments to reference the new `actions/attest` action for attestation permissions, improving documentation and maintainability.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #712 