### PR TITLE
feat: Add IsEmpty property on ImmutableMetadata class

### DIFF
--- a/src/OpenFeature/Model/ImmutableMetadata.cs
+++ b/src/OpenFeature/Model/ImmutableMetadata.cs
@@ -17,10 +17,7 @@ public sealed class ImmutableMetadata
     /// <value>
     ///   <c>true</c> if this instance is empty; otherwise, <c>false</c>.
     /// </value>
-    public bool IsEmpty
-    {
-        get { return this._metadata.Count == 0; }
-    }
+    public bool IsEmpty => this._metadata.Count == 0;
 
     /// <summary>
     /// Constructor for the <see cref="ImmutableMetadata"/> class.

--- a/test/OpenFeature.Tests/ImmutableMetadataTest.cs
+++ b/test/OpenFeature.Tests/ImmutableMetadataTest.cs
@@ -320,8 +320,7 @@ public class ImmutableMetadataTest
     public void IsEmpty_ShouldReturnTrue()
     {
         // Arrange
-        var metadata = new Dictionary<string, object>();
-        var flagMetadata = new ImmutableMetadata(metadata);
+        var flagMetadata = new ImmutableMetadata();
 
         // Act
         var result = flagMetadata.IsEmpty;


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Adds new IsEmpty property on the ImmutableMetadata class as a convience method. Count is internal, so if developers want to to check whether the ImmutableMetadata has any items they need to use reflection (see [here](https://github.com/open-feature/dotnet-sdk-contrib/pull/569/changes/BASE..6bd372c1a541e2ee26f1430ea89571f30c6d8d99#r2719818155))

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #693

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

