### PR TITLE
feat: Add isolated API instance functionality

### DIFF
--- a/samples/Console/README.md
+++ b/samples/Console/README.md
@@ -43,3 +43,14 @@ The sample defines the following flags using the `InMemoryProvider`:
 ## NativeAOT
 
 This sample is published with [NativeAOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/) enabled (`PublishAot=true`), demonstrating that the OpenFeature .NET SDK is fully compatible with NativeAOT compilation. See the [AOT Compatibility Guide](../../../docs/AOT_COMPATIBILITY.md) for more details.
+
+## Isolated API Instance
+
+The sample also demonstrates how to create an **isolated API instance** using `Api.CreateIsolated()`. The isolated instance has its own provider with different flag values, proving that it operates independently from the global singleton.
+
+| Flag Key       | Type     | Variants                                                                           | Default Variant |
+| -------------- | -------- | ---------------------------------------------------------------------------------- | --------------- |
+| `bool-flag`    | `bool`   | `on` → `true`, `off` → `false`                                                     | `off`           |
+| `string-flag`  | `string` | `greeting` → `"Howdy, Isolated World!"`, `farewell` → `"See ya!"`                  | `greeting`      |
+
+The isolated instance evaluates flags from its own provider, then shuts down without affecting the global singleton. This is useful for testing, multi-tenant applications, and dependency injection scenarios. See the [specification](https://openfeature.dev/specification/sections/flag-evaluation#18-isolated-api-instances) for more details.

--- a/samples/Console/app.cs
+++ b/samples/Console/app.cs
@@ -44,3 +44,32 @@ Console.WriteLine("The `float-flag` flag returned {0}", floatResult);
 // Evaluate the `object-flag` flag and print the result to the console
 var objectResult = await client.GetObjectValueAsync("object-flag", new Value("Ben"));
 Console.WriteLine("The `object-flag` flag returned {0}", objectResult.AsString);
+
+// --- Isolated API Instance ---
+// Create an independent API instance with its own provider and state.
+// This is useful for testing, multi-tenant apps, and DI scenarios.
+
+var isolatedFlags = new Dictionary<string, Flag>
+{
+    { "bool-flag", new Flag<bool>(new Dictionary<string, bool> { { "on", true }, { "off", false } }, defaultVariant: "off") },
+    { "string-flag", new Flag<string>(new Dictionary<string, string> { { "greeting", "Howdy, Isolated World!" }, { "farewell", "See ya!" } }, defaultVariant: "greeting") },
+};
+
+var isolated = Api.CreateIsolated();
+await isolated.SetProviderAsync(new InMemoryProvider(isolatedFlags));
+
+var isolatedClient = isolated.GetClient();
+
+Console.WriteLine();
+Console.WriteLine("--- Isolated API Instance ---");
+
+// The isolated instance has its own flag values
+var isolatedBool = await isolatedClient.GetBooleanValueAsync("bool-flag", true);
+Console.WriteLine("Isolated `bool-flag`: {0} (singleton was: {1})", isolatedBool, helloWorldResult);
+
+var isolatedString = await isolatedClient.GetStringValueAsync("string-flag", "default");
+Console.WriteLine("Isolated `string-flag`: {0} (singleton was: {1})", isolatedString, stringResult);
+
+// Shut down the isolated instance — does not affect the global singleton
+await isolated.ShutdownAsync();
+Console.WriteLine("Isolated instance shut down. Singleton is unaffected.");

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -35,24 +35,6 @@ public sealed class Api : IEventBus
     internal Api() { }
 
     /// <summary>
-    /// Creates a new, independent instance of the OpenFeature API with fully isolated state.
-    /// <para>
-    /// Each isolated instance maintains its own providers, evaluation context, hooks, event handlers,
-    /// and transaction context propagators. It does not share state with the global <see cref="Instance"/>
-    /// singleton or with any other isolated instance.
-    /// </para>
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// A single provider instance should not be bound to more than one API instance at a time.
-    /// Attempting to do so will result in an <see cref="InvalidOperationException"/>.
-    /// </para>
-    /// </remarks>
-    /// <returns>A new, independent <see cref="Api"/> instance.</returns>
-    /// <seealso href="https://openfeature.dev/specification/sections/flag-evaluation#18-isolated-api-instances">Specification 1.8 - Isolated API Instances</seealso>
-    public static Api CreateIsolated() => new Api();
-
-    /// <summary>
     /// Sets the default feature provider. In order to wait for the provider to be set, and initialization to complete,
     /// await the returned task.
     /// </summary>

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -424,14 +424,12 @@ public sealed class Api : IEventBus
 
     /// <summary>
     /// Validates that the given provider is not already bound to a different API instance.
-    /// Uses <see cref="Interlocked.CompareExchange{T}"/> for thread-safe check-and-set.
     /// </summary>
     /// <param name="featureProvider">The provider to validate ownership for.</param>
     /// <exception cref="InvalidOperationException">Thrown if the provider is already bound to a different API instance.</exception>
     private void ValidateProviderOwnership(FeatureProvider featureProvider)
     {
-        var previous = Interlocked.CompareExchange(ref featureProvider._boundApiInstance, this, null);
-        if (previous is not null && !ReferenceEquals(previous, this))
+        if (!featureProvider.TryBindApiInstance(this))
         {
             throw new InvalidOperationException(
                 "This provider instance is already bound to a different API instance. " +

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -35,6 +35,24 @@ public sealed class Api : IEventBus
     internal Api() { }
 
     /// <summary>
+    /// Creates a new, independent instance of the OpenFeature API with fully isolated state.
+    /// <para>
+    /// Each isolated instance maintains its own providers, evaluation context, hooks, event handlers,
+    /// and transaction context propagators. It does not share state with the global <see cref="Instance"/>
+    /// singleton or with any other isolated instance.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A single provider instance should not be bound to more than one API instance at a time.
+    /// Attempting to do so will result in an <see cref="InvalidOperationException"/>.
+    /// </para>
+    /// </remarks>
+    /// <returns>A new, independent <see cref="Api"/> instance.</returns>
+    /// <seealso href="https://openfeature.dev/specification/sections/flag-evaluation#18-isolated-api-instances">Specification 1.8 - Isolated API Instances</seealso>
+    public static Api CreateIsolated() => new Api();
+
+    /// <summary>
     /// Sets the default feature provider. In order to wait for the provider to be set, and initialization to complete,
     /// await the returned task.
     /// </summary>
@@ -56,6 +74,7 @@ public sealed class Api : IEventBus
     /// <returns>A <see cref="Task"/> that completes once Provider initialization is complete.</returns>
     public async Task SetProviderAsync(FeatureProvider featureProvider, CancellationToken cancellationToken)
     {
+        this.ValidateProviderOwnership(featureProvider);
         this._eventExecutor.RegisterDefaultFeatureProvider(featureProvider);
         await this._repository.SetProviderAsync(featureProvider, this.GetContext(), this.AfterInitializationAsync, this.AfterErrorAsync, cancellationToken)
             .ConfigureAwait(false);
@@ -91,6 +110,7 @@ public sealed class Api : IEventBus
         {
             throw new ArgumentNullException(nameof(domain));
         }
+        this.ValidateProviderOwnership(featureProvider);
         this._eventExecutor.RegisterClientFeatureProvider(domain, featureProvider);
         await this._repository.SetProviderAsync(domain, featureProvider, this.GetContext(), this.AfterInitializationAsync, this.AfterErrorAsync, cancellationToken)
             .ConfigureAwait(false);
@@ -400,5 +420,22 @@ public sealed class Api : IEventBus
     internal static void SetInstance(Api api)
     {
         Instance = api;
+    }
+
+    /// <summary>
+    /// Validates that the given provider is not already bound to a different API instance.
+    /// Uses <see cref="Interlocked.CompareExchange{T}"/> for thread-safe check-and-set.
+    /// </summary>
+    /// <param name="featureProvider">The provider to validate ownership for.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the provider is already bound to a different API instance.</exception>
+    private void ValidateProviderOwnership(FeatureProvider featureProvider)
+    {
+        var previous = Interlocked.CompareExchange(ref featureProvider._boundApiInstance, this, null);
+        if (previous is not null && !ReferenceEquals(previous, this))
+        {
+            throw new InvalidOperationException(
+                "This provider instance is already bound to a different API instance. " +
+                "A provider should not be registered with more than one API instance simultaneously.");
+        }
     }
 }

--- a/src/OpenFeature/Constant/FeatureDiagnosticCodes.cs
+++ b/src/OpenFeature/Constant/FeatureDiagnosticCodes.cs
@@ -1,0 +1,38 @@
+namespace OpenFeature.Constant;
+
+/// <summary>
+/// Contains identifiers for experimental features and diagnostics in the OpenFeature framework.
+/// </summary>
+/// <remarks>
+/// <c>Experimental</c> - This class includes identifiers that allow developers to track and conditionally enable
+/// experimental features. Each identifier follows a structured code format to indicate the feature domain,
+/// maturity level, and unique identifier. Note that experimental features are subject to change or removal
+/// in future releases.
+/// <para>
+/// <strong>Basic Information</strong><br/>
+/// These identifiers conform to OpenFeature’s Diagnostics Specifications, allowing developers to recognize
+/// and manage experimental features effectively.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// Code Structure:
+///     - "OF" - Represents the OpenFeature library.
+///     - "ISO" - Indicates the Isolated API domain.
+///     - "001" - Unique identifier for a specific feature.
+/// </code>
+/// </example>
+internal static class FeatureDiagnosticCodes
+{
+    /// <summary>
+    /// Identifier for the experimental Isolated API features within the OpenFeature framework.
+    /// </summary>
+    /// <remarks>
+    /// <c>OFISO001</c> identifier marks experimental features in the Isolated (ISO) domain.
+    ///
+    /// Usage:
+    /// Developers can use this identifier to conditionally enable or test experimental Isolated API features.
+    /// It is part of the OpenFeature diagnostics system to help track experimental functionality.
+    /// </remarks>
+    public const string IsolatedApi = "OFISO001";
+}

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -101,9 +101,29 @@ public abstract class FeatureProvider
     /// <summary>
     /// Tracks which Api instance this provider is currently bound to.
     /// A provider should not be registered with more than one API instance simultaneously (spec 1.8.4).
-    /// Use <see cref="Interlocked.CompareExchange{T}"/> for thread-safe check-and-set.
     /// </summary>
-    internal Api? _boundApiInstance;
+    private Api? _boundApiInstance;
+
+    /// <summary>
+    /// Attempts to bind this provider to the given API instance.
+    /// Uses <see cref="Interlocked.CompareExchange{T}"/> for thread-safe check-and-set.
+    /// </summary>
+    /// <param name="api">The API instance to bind to.</param>
+    /// <returns><c>true</c> if the provider was successfully bound (or was already bound to the same instance);
+    /// <c>false</c> if the provider is already bound to a different API instance.</returns>
+    internal bool TryBindApiInstance(Api api)
+    {
+        var previous = Interlocked.CompareExchange(ref this._boundApiInstance, api, null);
+        return previous is null || ReferenceEquals(previous, api);
+    }
+
+    /// <summary>
+    /// Clears the API instance binding, allowing this provider to be registered with another API instance.
+    /// </summary>
+    internal void UnbindApiInstance()
+    {
+        this._boundApiInstance = null;
+    }
 
     /// <summary>
     /// <para>

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -101,7 +101,7 @@ public abstract class FeatureProvider
     /// <summary>
     /// Tracks which Api instance this provider is currently bound to.
     /// A provider should not be registered with more than one API instance simultaneously (spec 1.8.4).
-    /// Use <see cref="System.Threading.Interlocked.CompareExchange{T}"/> for thread-safe check-and-set.
+    /// Use <see cref="Interlocked.CompareExchange{T}"/> for thread-safe check-and-set.
     /// </summary>
     internal Api? _boundApiInstance;
 

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -99,6 +99,13 @@ public abstract class FeatureProvider
     internal virtual ProviderStatus Status { get; set; } = ProviderStatus.NotReady;
 
     /// <summary>
+    /// Tracks which Api instance this provider is currently bound to.
+    /// A provider should not be registered with more than one API instance simultaneously (spec 1.8.4).
+    /// Use <see cref="System.Threading.Interlocked.CompareExchange{T}"/> for thread-safe check-and-set.
+    /// </summary>
+    internal Api? _boundApiInstance;
+
+    /// <summary>
     /// <para>
     /// This method is called before a provider is used to evaluate flags. Providers can overwrite this method,
     /// if they have special initialization needed prior being called for flag evaluation.

--- a/src/OpenFeature/Isolated/OpenFeatureFactory.cs
+++ b/src/OpenFeature/Isolated/OpenFeatureFactory.cs
@@ -1,0 +1,29 @@
+namespace OpenFeature.Isolated;
+
+/// <summary>
+/// Factory for creating isolated instances of the OpenFeature API.
+/// </summary>
+/// <remarks>
+/// This factory provides a method to create new, independent instances of the OpenFeature API with fully isolated state. Each isolated instance maintains its own providers, evaluation context, hooks, event handlers,
+/// and transaction context propagators. It does not share state with the global <see cref="Api.Instance"/> singleton or with any other isolated instance.
+/// </remarks>
+public static class OpenFeatureFactory
+{
+    /// <summary>
+    /// Creates a new, independent instance of the OpenFeature API with fully isolated state.
+    /// <para>
+    /// Each isolated instance maintains its own providers, evaluation context, hooks, event handlers,
+    /// and transaction context propagators. It does not share state with the global <see cref="Api.Instance"/>
+    /// singleton or with any other isolated instance.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A single provider instance should not be bound to more than one API instance at a time.
+    /// Attempting to do so will result in an <see cref="InvalidOperationException"/>.
+    /// </para>
+    /// </remarks>
+    /// <returns>A new, independent <see cref="Api"/> instance.</returns>
+    /// <seealso href="https://openfeature.dev/specification/sections/flag-evaluation#18-isolated-api-instances">Specification 1.8 - Isolated API Instances</seealso>
+    public static Api CreateIsolated() => new Api();
+}

--- a/src/OpenFeature/Isolated/OpenFeatureFactory.cs
+++ b/src/OpenFeature/Isolated/OpenFeatureFactory.cs
@@ -1,3 +1,7 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+
 namespace OpenFeature.Isolated;
 
 /// <summary>
@@ -25,5 +29,8 @@ public static class OpenFeatureFactory
     /// </remarks>
     /// <returns>A new, independent <see cref="Api"/> instance.</returns>
     /// <seealso href="https://openfeature.dev/specification/sections/flag-evaluation#18-isolated-api-instances">Specification 1.8 - Isolated API Instances</seealso>
+#if NET8_0_OR_GREATER
+    [Experimental(Constant.FeatureDiagnosticCodes.IsolatedApi)]
+#endif
     public static Api CreateIsolated() => new Api();
 }

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -197,7 +197,7 @@ internal sealed partial class ProviderRepository : IAsyncDisposable
         // This prevents a race where async shutdown clears ownership after a re-registration.
         if (targetProvider != null)
         {
-            targetProvider._boundApiInstance = null;
+            targetProvider.UnbindApiInstance();
         }
 
         await this.SafeShutdownProviderAsync(targetProvider, cancellationToken).ConfigureAwait(false);
@@ -281,7 +281,7 @@ internal sealed partial class ProviderRepository : IAsyncDisposable
             // Clear ownership under the write lock for all providers being shut down.
             foreach (var provider in providers)
             {
-                provider._boundApiInstance = null;
+                provider.UnbindApiInstance();
             }
         }
         finally

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -193,6 +193,13 @@ internal sealed partial class ProviderRepository : IAsyncDisposable
             return;
         }
 
+        // Clear ownership while still under the write lock — the provider is confirmed unused.
+        // This prevents a race where async shutdown clears ownership after a re-registration.
+        if (targetProvider != null)
+        {
+            targetProvider._boundApiInstance = null;
+        }
+
         await this.SafeShutdownProviderAsync(targetProvider, cancellationToken).ConfigureAwait(false);
     }
 
@@ -270,6 +277,12 @@ internal sealed partial class ProviderRepository : IAsyncDisposable
             // Set a default provider so the Api is ready to be used again.
             this._defaultProvider = new NoOpFeatureProvider();
             this._featureProviders.Clear();
+
+            // Clear ownership under the write lock for all providers being shut down.
+            foreach (var provider in providers)
+            {
+                provider._boundApiInstance = null;
+            }
         }
         finally
         {

--- a/test/OpenFeature.AotCompatibility/OpenFeature.AotCompatibility.csproj
+++ b/test/OpenFeature.AotCompatibility/OpenFeature.AotCompatibility.csproj
@@ -14,6 +14,7 @@
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
         <WarningsNotAsErrors>NU1903</WarningsNotAsErrors>
         <RootNamespace>OpenFeature.AotCompatibility</RootNamespace>
+        <NoWarn>$(NoWarn);OFISO001</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -25,10 +26,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Include="System.Text.Json" />
     </ItemGroup>
 
 </Project>

--- a/test/OpenFeature.AotCompatibility/Program.cs
+++ b/test/OpenFeature.AotCompatibility/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenFeature.Constant;
+using OpenFeature.Isolated;
 using OpenFeature.Model;
 using OpenFeature.Providers.MultiProvider;
 using OpenFeature.Providers.MultiProvider.Models;
@@ -57,7 +58,7 @@ internal class Program
         Console.WriteLine("\nTesting isolated API instances...");
 
         // Create an isolated instance
-        var isolated = Api.CreateIsolated();
+        var isolated = OpenFeatureFactory.CreateIsolated();
         Console.WriteLine($"✓- Isolated API instance created: {isolated.GetType().Name}");
 
         // Verify it is distinct from the singleton

--- a/test/OpenFeature.AotCompatibility/Program.cs
+++ b/test/OpenFeature.AotCompatibility/Program.cs
@@ -27,6 +27,9 @@ internal class Program
             // Test basic API functionality
             await TestBasicApiAsync();
 
+            // Test isolated API instances
+            await TestIsolatedApiAsync();
+
             // Test MultiProvider AOT compatibility
             await TestMultiProviderAotCompatibilityAsync();
 
@@ -47,6 +50,41 @@ internal class Program
             Console.WriteLine(ex.StackTrace);
             Environment.Exit(1);
         }
+    }
+
+    private static async Task TestIsolatedApiAsync()
+    {
+        Console.WriteLine("\nTesting isolated API instances...");
+
+        // Create an isolated instance
+        var isolated = Api.CreateIsolated();
+        Console.WriteLine($"✓- Isolated API instance created: {isolated.GetType().Name}");
+
+        // Verify it is distinct from the singleton
+        if (ReferenceEquals(isolated, Api.Instance))
+        {
+            throw new InvalidOperationException("Isolated instance should not be the same as the singleton.");
+        }
+        Console.WriteLine("✓- Isolated instance is distinct from singleton");
+
+        // Set a provider on the isolated instance
+        var provider = new TestProvider();
+        await isolated.SetProviderAsync(provider);
+        Console.WriteLine($"✓- Provider set on isolated instance: {isolated.GetProviderMetadata()?.Name}");
+
+        // Create a client and evaluate a flag
+        var client = isolated.GetClient("isolated-client");
+        var result = await client.GetBooleanValueAsync("test-flag", false);
+        Console.WriteLine($"✓- Isolated client flag evaluation: {result}");
+
+        // Set context on isolated instance and verify independence
+        var context = EvaluationContext.Builder().Set("scope", "isolated").Build();
+        isolated.SetContext(context);
+        Console.WriteLine($"✓- Isolated context set with {context.Count} attributes");
+
+        // Shutdown the isolated instance
+        await isolated.ShutdownAsync();
+        Console.WriteLine("✓- Isolated instance shut down successfully");
     }
 
     private static async Task TestBasicApiAsync()

--- a/test/OpenFeature.Tests/Isolated/IsolatedApiTests.cs
+++ b/test/OpenFeature.Tests/Isolated/IsolatedApiTests.cs
@@ -2,8 +2,9 @@ using NSubstitute;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
+using OpenFeature.Isolated;
 
-namespace OpenFeature.Tests;
+namespace OpenFeature.Tests.Isolated;
 
 /// <summary>
 /// Tests for isolated API instances (spec section 1.8).
@@ -16,7 +17,7 @@ public class IsolatedApiTests
     [Specification("1.8.1", "The API MUST expose a factory function which creates and returns a new, independent instance of the API.")]
     public void CreateIsolated_Should_Return_New_Instance()
     {
-        var isolated = Api.CreateIsolated();
+        var isolated = OpenFeatureFactory.CreateIsolated();
 
         Assert.NotNull(isolated);
         Assert.NotSame(Api.Instance, isolated);
@@ -26,8 +27,8 @@ public class IsolatedApiTests
     [Specification("1.8.1", "The API MUST expose a factory function which creates and returns a new, independent instance of the API.")]
     public void CreateIsolated_Should_Return_Distinct_Instances()
     {
-        var isolated1 = Api.CreateIsolated();
-        var isolated2 = Api.CreateIsolated();
+        var isolated1 = OpenFeatureFactory.CreateIsolated();
+        var isolated2 = OpenFeatureFactory.CreateIsolated();
 
         Assert.NotSame(isolated1, isolated2);
     }
@@ -36,7 +37,7 @@ public class IsolatedApiTests
     [Specification("1.8.2", "Instances returned by the factory function MUST conform to the same API contract as the global singleton.")]
     public async Task Isolated_Instance_Should_Support_Full_Api_Contract()
     {
-        var isolated = Api.CreateIsolated();
+        var isolated = OpenFeatureFactory.CreateIsolated();
         try
         {
             // Provider management
@@ -78,7 +79,7 @@ public class IsolatedApiTests
     public async Task Isolated_Provider_Should_Not_Affect_Singleton()
     {
         Api.ResetApi();
-        var isolated = Api.CreateIsolated();
+        var isolated = OpenFeatureFactory.CreateIsolated();
         try
         {
             var provider = new TestProvider("isolated-provider");
@@ -98,8 +99,8 @@ public class IsolatedApiTests
     [Specification("1.8.1", "The API MUST expose a factory function which creates and returns a new, independent instance of the API.")]
     public async Task Isolated_Provider_Should_Not_Affect_Other_Isolated_Instance()
     {
-        var isolated1 = Api.CreateIsolated();
-        var isolated2 = Api.CreateIsolated();
+        var isolated1 = OpenFeatureFactory.CreateIsolated();
+        var isolated2 = OpenFeatureFactory.CreateIsolated();
         try
         {
             var provider1 = new TestProvider("provider-1");
@@ -121,8 +122,8 @@ public class IsolatedApiTests
     [Specification("1.8.1", "The API MUST expose a factory function which creates and returns a new, independent instance of the API.")]
     public void Isolated_Hooks_Should_Not_Affect_Other_Instances()
     {
-        var isolated1 = Api.CreateIsolated();
-        var isolated2 = Api.CreateIsolated();
+        var isolated1 = OpenFeatureFactory.CreateIsolated();
+        var isolated2 = OpenFeatureFactory.CreateIsolated();
 
         var hook1 = Substitute.For<Hook>();
         var hook2 = Substitute.For<Hook>();
@@ -141,8 +142,8 @@ public class IsolatedApiTests
     [Specification("1.8.1", "The API MUST expose a factory function which creates and returns a new, independent instance of the API.")]
     public void Isolated_Context_Should_Not_Affect_Other_Instances()
     {
-        var isolated1 = Api.CreateIsolated();
-        var isolated2 = Api.CreateIsolated();
+        var isolated1 = OpenFeatureFactory.CreateIsolated();
+        var isolated2 = OpenFeatureFactory.CreateIsolated();
 
         var context1 = EvaluationContext.Builder().Set("instance", "one").Build();
         var context2 = EvaluationContext.Builder().Set("instance", "two").Build();
@@ -158,8 +159,8 @@ public class IsolatedApiTests
     [Specification("1.8.4", "A provider instance SHOULD NOT be registered with more than one API instance simultaneously.")]
     public async Task Same_Provider_Should_Throw_When_Bound_To_Multiple_Api_Instances()
     {
-        var isolated1 = Api.CreateIsolated();
-        var isolated2 = Api.CreateIsolated();
+        var isolated1 = OpenFeatureFactory.CreateIsolated();
+        var isolated2 = OpenFeatureFactory.CreateIsolated();
         try
         {
             var provider = new TestProvider("shared-provider");
@@ -182,8 +183,8 @@ public class IsolatedApiTests
     [Specification("1.8.4", "A provider instance SHOULD NOT be registered with more than one API instance simultaneously.")]
     public async Task Same_Provider_Should_Throw_When_Bound_To_Multiple_Api_Instances_Domain()
     {
-        var isolated1 = Api.CreateIsolated();
-        var isolated2 = Api.CreateIsolated();
+        var isolated1 = OpenFeatureFactory.CreateIsolated();
+        var isolated2 = OpenFeatureFactory.CreateIsolated();
         try
         {
             var provider = new TestProvider("shared-provider");
@@ -208,7 +209,7 @@ public class IsolatedApiTests
     {
         const int instanceCount = 10;
         var provider = new TestProvider("contested-provider");
-        var instances = Enumerable.Range(0, instanceCount).Select(_ => Api.CreateIsolated()).ToList();
+        var instances = Enumerable.Range(0, instanceCount).Select(_ => OpenFeatureFactory.CreateIsolated()).ToList();
         try
         {
             var tasks = instances.Select(api => api.SetProviderAsync(provider)).ToList();
@@ -237,8 +238,8 @@ public class IsolatedApiTests
     [Specification("1.8.4", "A provider instance SHOULD NOT be registered with more than one API instance simultaneously.")]
     public async Task Provider_Can_Be_Rebound_After_Shutdown()
     {
-        var isolated1 = Api.CreateIsolated();
-        var isolated2 = Api.CreateIsolated();
+        var isolated1 = OpenFeatureFactory.CreateIsolated();
+        var isolated2 = OpenFeatureFactory.CreateIsolated();
         try
         {
             var provider = new TestProvider("rebindable-provider");
@@ -261,7 +262,7 @@ public class IsolatedApiTests
     [Specification("1.8.4", "A provider instance SHOULD NOT be registered with more than one API instance simultaneously.")]
     public async Task Same_Provider_Can_Be_Bound_To_Multiple_Domains_Within_Same_Api()
     {
-        var isolated = Api.CreateIsolated();
+        var isolated = OpenFeatureFactory.CreateIsolated();
         try
         {
             var provider = new TestProvider("multi-domain-provider");
@@ -284,7 +285,7 @@ public class IsolatedApiTests
         var singletonProvider = new TestProvider("singleton-provider");
         await Api.Instance.SetProviderAsync(singletonProvider);
 
-        var isolated = Api.CreateIsolated();
+        var isolated = OpenFeatureFactory.CreateIsolated();
         var isolatedProvider = new TestProvider("isolated-provider");
         await isolated.SetProviderAsync(isolatedProvider);
 
@@ -301,8 +302,8 @@ public class IsolatedApiTests
     [Fact]
     public async Task Shutdown_Isolated_Should_Not_Affect_Other_Isolated()
     {
-        var isolated1 = Api.CreateIsolated();
-        var isolated2 = Api.CreateIsolated();
+        var isolated1 = OpenFeatureFactory.CreateIsolated();
+        var isolated2 = OpenFeatureFactory.CreateIsolated();
         try
         {
             var provider1 = new TestProvider("provider-1");
@@ -324,8 +325,8 @@ public class IsolatedApiTests
     [Fact]
     public async Task Provider_Can_Be_Rebound_After_Replacement()
     {
-        var isolated1 = Api.CreateIsolated();
-        var isolated2 = Api.CreateIsolated();
+        var isolated1 = OpenFeatureFactory.CreateIsolated();
+        var isolated2 = OpenFeatureFactory.CreateIsolated();
         try
         {
             var providerA = new TestProvider("provider-a");
@@ -354,7 +355,7 @@ public class IsolatedApiTests
     [Specification("1.8.2", "Instances returned by the factory function MUST conform to the same API contract as the global singleton.")]
     public async Task Isolated_Client_Should_Evaluate_Flags()
     {
-        var isolated = Api.CreateIsolated();
+        var isolated = OpenFeatureFactory.CreateIsolated();
         try
         {
             var provider = new TestProvider("eval-provider");

--- a/test/OpenFeature.Tests/Isolated/IsolatedApiTests.cs
+++ b/test/OpenFeature.Tests/Isolated/IsolatedApiTests.cs
@@ -11,6 +11,9 @@ namespace OpenFeature.Tests.Isolated;
 /// Each test creates its own isolated instances and cleans them up,
 /// so no shared state fixture is needed.
 /// </summary>
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(FeatureDiagnosticCodes.IsolatedApi)]
+#endif
 public class IsolatedApiTests
 {
     [Fact]

--- a/test/OpenFeature.Tests/Isolated/IsolatedApiTests.cs
+++ b/test/OpenFeature.Tests/Isolated/IsolatedApiTests.cs
@@ -1,8 +1,8 @@
 using NSubstitute;
 using OpenFeature.Constant;
+using OpenFeature.Isolated;
 using OpenFeature.Model;
 using OpenFeature.Tests.Internal;
-using OpenFeature.Isolated;
 
 namespace OpenFeature.Tests.Isolated;
 

--- a/test/OpenFeature.Tests/IsolatedApiTests.cs
+++ b/test/OpenFeature.Tests/IsolatedApiTests.cs
@@ -1,0 +1,368 @@
+using NSubstitute;
+using OpenFeature.Constant;
+using OpenFeature.Model;
+using OpenFeature.Tests.Internal;
+
+namespace OpenFeature.Tests;
+
+/// <summary>
+/// Tests for isolated API instances (spec section 1.8).
+/// Each test creates its own isolated instances and cleans them up,
+/// so no shared state fixture is needed.
+/// </summary>
+public class IsolatedApiTests
+{
+    [Fact]
+    [Specification("1.8.1", "The API MUST expose a factory function which creates and returns a new, independent instance of the API.")]
+    public void CreateIsolated_Should_Return_New_Instance()
+    {
+        var isolated = Api.CreateIsolated();
+
+        Assert.NotNull(isolated);
+        Assert.NotSame(Api.Instance, isolated);
+    }
+
+    [Fact]
+    [Specification("1.8.1", "The API MUST expose a factory function which creates and returns a new, independent instance of the API.")]
+    public void CreateIsolated_Should_Return_Distinct_Instances()
+    {
+        var isolated1 = Api.CreateIsolated();
+        var isolated2 = Api.CreateIsolated();
+
+        Assert.NotSame(isolated1, isolated2);
+    }
+
+    [Fact]
+    [Specification("1.8.2", "Instances returned by the factory function MUST conform to the same API contract as the global singleton.")]
+    public async Task Isolated_Instance_Should_Support_Full_Api_Contract()
+    {
+        var isolated = Api.CreateIsolated();
+        try
+        {
+            // Provider management
+            var provider = new TestProvider();
+            await isolated.SetProviderAsync(provider);
+            Assert.Equal(provider, isolated.GetProvider());
+            Assert.Equal(provider.GetMetadata()?.Name, isolated.GetProviderMetadata()?.Name);
+
+            // Client creation
+            var client = isolated.GetClient("test-client");
+            Assert.NotNull(client);
+            Assert.Equal("test-client", client.GetMetadata().Name);
+
+            // Hooks
+            var hook = Substitute.For<Hook>();
+            isolated.AddHooks(hook);
+            Assert.Contains(hook, isolated.GetHooks());
+
+            // Context
+            var context = EvaluationContext.Builder().Set("key", "value").Build();
+            isolated.SetContext(context);
+            Assert.Equal(context, isolated.GetContext());
+
+            // Event handling (just verify it doesn't throw)
+            isolated.AddHandler(ProviderEventTypes.ProviderReady, _ => { });
+
+            // Transaction context
+            var propagator = Substitute.For<ITransactionContextPropagator>();
+            isolated.SetTransactionContextPropagator(propagator);
+        }
+        finally
+        {
+            await isolated.ShutdownAsync();
+        }
+    }
+
+    [Fact]
+    [Specification("1.8.1", "The API MUST expose a factory function which creates and returns a new, independent instance of the API.")]
+    public async Task Isolated_Provider_Should_Not_Affect_Singleton()
+    {
+        Api.ResetApi();
+        var isolated = Api.CreateIsolated();
+        try
+        {
+            var provider = new TestProvider("isolated-provider");
+            await isolated.SetProviderAsync(provider);
+
+            // The singleton should still have the default NoOp provider
+            Assert.Equal(NoOpProvider.NoOpProviderName, Api.Instance.GetProviderMetadata()?.Name);
+            Assert.Equal("isolated-provider", isolated.GetProviderMetadata()?.Name);
+        }
+        finally
+        {
+            await isolated.ShutdownAsync();
+        }
+    }
+
+    [Fact]
+    [Specification("1.8.1", "The API MUST expose a factory function which creates and returns a new, independent instance of the API.")]
+    public async Task Isolated_Provider_Should_Not_Affect_Other_Isolated_Instance()
+    {
+        var isolated1 = Api.CreateIsolated();
+        var isolated2 = Api.CreateIsolated();
+        try
+        {
+            var provider1 = new TestProvider("provider-1");
+            var provider2 = new TestProvider("provider-2");
+            await isolated1.SetProviderAsync(provider1);
+            await isolated2.SetProviderAsync(provider2);
+
+            Assert.Equal("provider-1", isolated1.GetProviderMetadata()?.Name);
+            Assert.Equal("provider-2", isolated2.GetProviderMetadata()?.Name);
+        }
+        finally
+        {
+            await isolated1.ShutdownAsync();
+            await isolated2.ShutdownAsync();
+        }
+    }
+
+    [Fact]
+    [Specification("1.8.1", "The API MUST expose a factory function which creates and returns a new, independent instance of the API.")]
+    public void Isolated_Hooks_Should_Not_Affect_Other_Instances()
+    {
+        var isolated1 = Api.CreateIsolated();
+        var isolated2 = Api.CreateIsolated();
+
+        var hook1 = Substitute.For<Hook>();
+        var hook2 = Substitute.For<Hook>();
+
+        isolated1.AddHooks(hook1);
+        isolated2.AddHooks(hook2);
+
+        Assert.Contains(hook1, isolated1.GetHooks());
+        Assert.DoesNotContain(hook2, isolated1.GetHooks());
+
+        Assert.Contains(hook2, isolated2.GetHooks());
+        Assert.DoesNotContain(hook1, isolated2.GetHooks());
+    }
+
+    [Fact]
+    [Specification("1.8.1", "The API MUST expose a factory function which creates and returns a new, independent instance of the API.")]
+    public void Isolated_Context_Should_Not_Affect_Other_Instances()
+    {
+        var isolated1 = Api.CreateIsolated();
+        var isolated2 = Api.CreateIsolated();
+
+        var context1 = EvaluationContext.Builder().Set("instance", "one").Build();
+        var context2 = EvaluationContext.Builder().Set("instance", "two").Build();
+
+        isolated1.SetContext(context1);
+        isolated2.SetContext(context2);
+
+        Assert.Equal(context1, isolated1.GetContext());
+        Assert.Equal(context2, isolated2.GetContext());
+    }
+
+    [Fact]
+    [Specification("1.8.4", "A provider instance SHOULD NOT be registered with more than one API instance simultaneously.")]
+    public async Task Same_Provider_Should_Throw_When_Bound_To_Multiple_Api_Instances()
+    {
+        var isolated1 = Api.CreateIsolated();
+        var isolated2 = Api.CreateIsolated();
+        try
+        {
+            var provider = new TestProvider("shared-provider");
+            await isolated1.SetProviderAsync(provider);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => isolated2.SetProviderAsync(provider));
+        }
+        finally
+        {
+            await isolated1.ShutdownAsync();
+            await isolated2.ShutdownAsync();
+        }
+    }
+
+    [Fact]
+    [Specification("1.8.4", "A provider instance SHOULD NOT be registered with more than one API instance simultaneously.")]
+    public async Task Same_Provider_Should_Throw_When_Bound_To_Multiple_Api_Instances_Domain()
+    {
+        var isolated1 = Api.CreateIsolated();
+        var isolated2 = Api.CreateIsolated();
+        try
+        {
+            var provider = new TestProvider("shared-provider");
+            await isolated1.SetProviderAsync("domain-1", provider);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => isolated2.SetProviderAsync("domain-2", provider));
+        }
+        finally
+        {
+            await isolated1.ShutdownAsync();
+            await isolated2.ShutdownAsync();
+        }
+    }
+
+    [Fact]
+    [Specification("1.8.4", "A provider instance SHOULD NOT be registered with more than one API instance simultaneously.")]
+    public async Task Concurrent_Binding_Should_Allow_Only_One_Api_Instance()
+    {
+        const int instanceCount = 10;
+        var provider = new TestProvider("contested-provider");
+        var instances = Enumerable.Range(0, instanceCount).Select(_ => Api.CreateIsolated()).ToList();
+        try
+        {
+            var tasks = instances.Select(api => api.SetProviderAsync(provider)).ToList();
+            var results = await Task.WhenAll(tasks.Select(async t =>
+            {
+                try { await t; return (Exception?)null; }
+                catch (Exception ex) { return ex; }
+            }));
+
+            var successes = results.Count(r => r is null);
+            var failures = results.Count(r => r is InvalidOperationException);
+
+            Assert.Equal(1, successes);
+            Assert.Equal(instanceCount - 1, failures);
+        }
+        finally
+        {
+            foreach (var api in instances)
+            {
+                await api.ShutdownAsync();
+            }
+        }
+    }
+
+    [Fact]
+    [Specification("1.8.4", "A provider instance SHOULD NOT be registered with more than one API instance simultaneously.")]
+    public async Task Provider_Can_Be_Rebound_After_Shutdown()
+    {
+        var isolated1 = Api.CreateIsolated();
+        var isolated2 = Api.CreateIsolated();
+        try
+        {
+            var provider = new TestProvider("rebindable-provider");
+            await isolated1.SetProviderAsync(provider);
+
+            // Shut down first instance — this frees the provider
+            await isolated1.ShutdownAsync();
+
+            // Now the provider should be bindable to another instance
+            await isolated2.SetProviderAsync(provider);
+            Assert.Equal("rebindable-provider", isolated2.GetProviderMetadata()?.Name);
+        }
+        finally
+        {
+            await isolated2.ShutdownAsync();
+        }
+    }
+
+    [Fact]
+    [Specification("1.8.4", "A provider instance SHOULD NOT be registered with more than one API instance simultaneously.")]
+    public async Task Same_Provider_Can_Be_Bound_To_Multiple_Domains_Within_Same_Api()
+    {
+        var isolated = Api.CreateIsolated();
+        try
+        {
+            var provider = new TestProvider("multi-domain-provider");
+            await isolated.SetProviderAsync("domain-a", provider);
+            await isolated.SetProviderAsync("domain-b", provider);
+
+            Assert.Equal(provider, isolated.GetProvider("domain-a"));
+            Assert.Equal(provider, isolated.GetProvider("domain-b"));
+        }
+        finally
+        {
+            await isolated.ShutdownAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Shutdown_Isolated_Should_Not_Affect_Singleton()
+    {
+        Api.ResetApi();
+        var singletonProvider = new TestProvider("singleton-provider");
+        await Api.Instance.SetProviderAsync(singletonProvider);
+
+        var isolated = Api.CreateIsolated();
+        var isolatedProvider = new TestProvider("isolated-provider");
+        await isolated.SetProviderAsync(isolatedProvider);
+
+        // Shutting down isolated instance
+        await isolated.ShutdownAsync();
+
+        // Singleton should be unaffected
+        Assert.Equal("singleton-provider", Api.Instance.GetProviderMetadata()?.Name);
+
+        // Cleanup
+        await Api.Instance.ShutdownAsync();
+    }
+
+    [Fact]
+    public async Task Shutdown_Isolated_Should_Not_Affect_Other_Isolated()
+    {
+        var isolated1 = Api.CreateIsolated();
+        var isolated2 = Api.CreateIsolated();
+        try
+        {
+            var provider1 = new TestProvider("provider-1");
+            var provider2 = new TestProvider("provider-2");
+            await isolated1.SetProviderAsync(provider1);
+            await isolated2.SetProviderAsync(provider2);
+
+            await isolated1.ShutdownAsync();
+
+            // isolated2 should be unaffected
+            Assert.Equal("provider-2", isolated2.GetProviderMetadata()?.Name);
+        }
+        finally
+        {
+            await isolated2.ShutdownAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Provider_Can_Be_Rebound_After_Replacement()
+    {
+        var isolated1 = Api.CreateIsolated();
+        var isolated2 = Api.CreateIsolated();
+        try
+        {
+            var providerA = new TestProvider("provider-a");
+            var providerB = new TestProvider("provider-b");
+
+            await isolated1.SetProviderAsync(providerA);
+
+            // Replace providerA with providerB in isolated1 — providerA should be unbound
+            await isolated1.SetProviderAsync(providerB);
+
+            // Allow some time for the async shutdown to complete
+            await Task.Delay(100);
+
+            // providerA should now be free to bind to isolated2
+            await isolated2.SetProviderAsync(providerA);
+            Assert.Equal("provider-a", isolated2.GetProviderMetadata()?.Name);
+        }
+        finally
+        {
+            await isolated1.ShutdownAsync();
+            await isolated2.ShutdownAsync();
+        }
+    }
+
+    [Fact]
+    [Specification("1.8.2", "Instances returned by the factory function MUST conform to the same API contract as the global singleton.")]
+    public async Task Isolated_Client_Should_Evaluate_Flags()
+    {
+        var isolated = Api.CreateIsolated();
+        try
+        {
+            var provider = new TestProvider("eval-provider");
+            await isolated.SetProviderAsync(provider);
+
+            var client = isolated.GetClient();
+
+            // TestProvider inverts boolean defaults
+            var result = await client.GetBooleanValueAsync("test-flag", false);
+            Assert.True(result);
+        }
+        finally
+        {
+            await isolated.ShutdownAsync();
+        }
+    }
+}

--- a/test/OpenFeature.Tests/IsolatedApiTests.cs
+++ b/test/OpenFeature.Tests/IsolatedApiTests.cs
@@ -165,8 +165,11 @@ public class IsolatedApiTests
             var provider = new TestProvider("shared-provider");
             await isolated1.SetProviderAsync(provider);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => isolated2.SetProviderAsync(provider));
+
+            Assert.Equal("This provider instance is already bound to a different API instance. " +
+                "A provider should not be registered with more than one API instance simultaneously.", exception.Message);
         }
         finally
         {
@@ -186,8 +189,11 @@ public class IsolatedApiTests
             var provider = new TestProvider("shared-provider");
             await isolated1.SetProviderAsync("domain-1", provider);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => isolated2.SetProviderAsync("domain-2", provider));
+
+            Assert.Equal("This provider instance is already bound to a different API instance. " +
+                "A provider should not be registered with more than one API instance simultaneously.", exception.Message);
         }
         finally
         {

--- a/test/OpenFeature.Tests/IsolatedApiTests.cs
+++ b/test/OpenFeature.Tests/IsolatedApiTests.cs
@@ -215,7 +215,7 @@ public class IsolatedApiTests
             var results = await Task.WhenAll(tasks.Select(async t =>
             {
                 try { await t; return (Exception?)null; }
-                catch (Exception ex) { return ex; }
+                catch (InvalidOperationException ex) { return ex; }
             }));
 
             var successes = results.Count(r => r is null);


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request introduces support for isolated API instances in the OpenFeature .NET SDK, enabling the creation of independent API objects that do not share state with the global singleton. This is particularly useful for testing, multi-tenant applications, and dependency injection scenarios. The changes also enforce provider ownership rules to prevent a provider from being registered with more than one API instance at a time, and update documentation and tests to demonstrate and verify this new functionality.

**Isolated API Instance Support:**

* Added a new static method `Api.CreateIsolated()` that creates a fully independent `Api` instance, with its own providers, context, hooks, and event handlers. These instances do not share state with the global singleton or with each other.
* Enforced provider ownership by adding a `_boundApiInstance` field to `FeatureProvider` and validating that a provider is not registered with more than one API instance at a time. Attempts to do so will throw an `InvalidOperationException`. Ownership is cleared when a provider is shut down. [[1]](diffhunk://#diff-96ebc8fc507d0a19d55b9a5cb57b72a0e8058e09f31ee7d0b39e99b00c5029d8R101-R107) [[2]](diffhunk://#diff-dc150fbd3b7be797470374ee7e38c7ab8a31eb9b6b7a52345e05114c2d32a15eR77) [[3]](diffhunk://#diff-dc150fbd3b7be797470374ee7e38c7ab8a31eb9b6b7a52345e05114c2d32a15eR113) [[4]](diffhunk://#diff-dc150fbd3b7be797470374ee7e38c7ab8a31eb9b6b7a52345e05114c2d32a15eR424-R440) [[5]](diffhunk://#diff-0c3f76ece1b10ab5874b65fadf5eabfe902e2fdac76db734ae03a17a4d9b958bR196-R202) [[6]](diffhunk://#diff-0c3f76ece1b10ab5874b65fadf5eabfe902e2fdac76db734ae03a17a4d9b958bR280-R285)

**Documentation and Sample Updates:**

* Updated `samples/Console/README.md` and `samples/Console/app.cs` to demonstrate the creation and use of isolated API instances, including example flag definitions and evaluation. [[1]](diffhunk://#diff-adee2b65df9cf9200d0ca9dedea6a718db206693fc5ef43af8cb008e8b6bcb37R46-R56) [[2]](diffhunk://#diff-e56b0bb1c7c90622236610cfe9c9c531b8f64da4b4f844c07152e539cf3f8a2eR47-R75)

**Testing Enhancements:**

* Added a new test `TestIsolatedApiAsync()` in `test/OpenFeature.AotCompatibility/Program.cs` to verify the creation, independence, and shutdown of isolated API instances. [[1]](diffhunk://#diff-2385141758cef849759e29b09a7c8507a8f0c46015f7487aa41a9789aef8bb02R30-R32) [[2]](diffhunk://#diff-2385141758cef849759e29b09a7c8507a8f0c46015f7487aa41a9789aef8bb02R55-R89)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #734