### PR TITLE
fix: add missing variant dimension in MetricsHook metrics

### DIFF
--- a/src/OpenFeature/Hooks/MetricsHook.cs
+++ b/src/OpenFeature/Hooks/MetricsHook.cs
@@ -68,6 +68,11 @@ public class MetricsHook : Hook
             { TelemetryConstants.Reason, details.Reason ?? Reason.Unknown.ToString() }
         };
 
+        if (details.Variant != null)
+        {
+            tagList.Add(TelemetryConstants.Variant, details.Variant);
+        }
+
         this.AddCustomDimensions(ref tagList);
         this.AddFlagMetadataDimensions(details.FlagMetadata, ref tagList);
 

--- a/test/OpenFeature.Tests/Hooks/MetricsHookTests.cs
+++ b/test/OpenFeature.Tests/Hooks/MetricsHookTests.cs
@@ -32,6 +32,35 @@ public class MetricsHookTest
         Assert.Equal("my-flag", measurements.Tags["feature_flag.key"]);
         Assert.Equal("my-provider", measurements.Tags["feature_flag.provider.name"]);
         Assert.Equal("STATIC", measurements.Tags["feature_flag.result.reason"]);
+        Assert.Equal("default", measurements.Tags["feature_flag.result.variant"]);
+    }
+
+    [Fact]
+    public async Task Without_Variant_After_Test_Does_Not_Include_Variant()
+    {
+        // Arrange
+        var metricsHook = new MetricsHook();
+
+        using var collector = new MetricCollector<long>(metricsHook._evaluationSuccessCounter);
+
+        var evaluationContext = EvaluationContext.Empty;
+        var ctx = new HookContext<string>("my-flag", "foo", Constant.FlagValueType.String,
+            new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
+
+        // Act
+        await metricsHook.AfterAsync(ctx,
+            new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", variant: null),
+            new Dictionary<string, object>()).ConfigureAwait(true);
+
+        var measurements = collector.LastMeasurement;
+
+        // Assert
+        Assert.NotNull(measurements);
+
+        Assert.Equal("my-flag", measurements.Tags["feature_flag.key"]);
+        Assert.Equal("my-provider", measurements.Tags["feature_flag.provider.name"]);
+        Assert.Equal("STATIC", measurements.Tags["feature_flag.result.reason"]);
+        Assert.DoesNotContain("feature_flag.result.variant", measurements.Tags.Keys);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #741

The `MetricsHook.AfterAsync` method was not including `feature_flag.result.variant` as a dimension/tag on the `feature_flag.evaluation_success_total` metric. This is inconsistent with:
- The [Java SDK](https://github.com/open-feature/java-sdk-contrib/blob/e8c35f9aa70173bb7aaec7a377266a942cdff854/hooks/open-telemetry/src/main/java/dev/openfeature/contrib/hooks/otel/MetricsHook.java#L110-L112)
- The [Go SDK](https://github.com/open-feature/go-sdk-contrib/blob/ddfb84ee4b53896e5fb9a4843edacef40f5ca8fa/hooks/open-telemetry/pkg/metrics.go#L97-L99)
- The [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/feature-flag/#feature-flag-result-variant)

## Changes

- **`src/OpenFeature/Hooks/MetricsHook.cs`**: Added `details.Variant` to the tag list in `AfterAsync`, guarded by a null check (matching the Java SDK pattern). Uses the existing `TelemetryConstants.Variant` constant.
- **`test/OpenFeature.Tests/Hooks/MetricsHookTests.cs`**: 
  - Updated `After_Test` to assert the variant tag is present on success metrics.
  - Added `Without_Variant_After_Test_Does_Not_Include_Variant` test to verify the tag is omitted when variant is null.
  
## Notes
Metrics now include the missing `variant`. See screenshot:
<img width="1267" height="618" alt="Screenshot 2026-04-15 at 16 28 28" src="https://github.com/user-attachments/assets/62ae36e9-098a-4afe-b304-d716767ac8e0" />