### PR TITLE
fix: fix 'occured' -> 'occurred' in XML doc comment

### DIFF
--- a/src/OpenFeature/Constant/ErrorType.cs
+++ b/src/OpenFeature/Constant/ErrorType.cs
@@ -9,7 +9,7 @@ namespace OpenFeature.Constant;
 public enum ErrorType
 {
     /// <summary>
-    /// Default value, no error occured
+    /// Default value, no error occurred
     /// </summary>
     None,
 


### PR DESCRIPTION
XML doc comment in `src/OpenFeature/Constant/ErrorType.cs` line 12 reads `no error occured`. Fixed to `occurred`. Comment-only change.