### PR TITLE
fix: Change registration to use the Isolated API instead of global singleton

### DIFF
--- a/src/OpenFeature.Hosting/OpenFeatureServiceCollectionExtensions.cs
+++ b/src/OpenFeature.Hosting/OpenFeatureServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ public static partial class OpenFeatureServiceCollectionExtensions
 
         // Register core OpenFeature services as singletons.
 #pragma warning disable OFISO001 // Registering the isolated API instance as a singleton is intentional to ensure that all components within the application use the same isolated instance of the OpenFeature API. This design choice allows for the container to manage the lifecycle of the isolated API instance effectively.
-        services.TryAddSingleton(OpenFeatureFactory.CreateIsolated());
+        services.TryAddSingleton(_ => OpenFeatureFactory.CreateIsolated());
 #pragma warning restore OFISO001
         services.TryAddSingleton<IFeatureLifecycleManager, FeatureLifecycleManager>();
 

--- a/src/OpenFeature.Hosting/OpenFeatureServiceCollectionExtensions.cs
+++ b/src/OpenFeature.Hosting/OpenFeatureServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using OpenFeature.Hosting;
 using OpenFeature.Hosting.Internal;
+using OpenFeature.Isolated;
 
 namespace OpenFeature;
 
@@ -24,7 +25,9 @@ public static partial class OpenFeatureServiceCollectionExtensions
         Guard.ThrowIfNull(configure);
 
         // Register core OpenFeature services as singletons.
-        services.TryAddSingleton(Api.Instance);
+#pragma warning disable OFISO001 // Registering the isolated API instance as a singleton is intentional to ensure that all components within the application use the same isolated instance of the OpenFeature API. This design choice allows for consistent state management and behavior across the application while still providing isolation from the global API instance.
+        services.TryAddSingleton(OpenFeatureFactory.CreateIsolated());
+#pragma warning restore OFISO001
         services.TryAddSingleton<IFeatureLifecycleManager, FeatureLifecycleManager>();
 
         var builder = new OpenFeatureBuilder(services);

--- a/src/OpenFeature.Hosting/OpenFeatureServiceCollectionExtensions.cs
+++ b/src/OpenFeature.Hosting/OpenFeatureServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ public static partial class OpenFeatureServiceCollectionExtensions
         Guard.ThrowIfNull(configure);
 
         // Register core OpenFeature services as singletons.
-#pragma warning disable OFISO001 // Registering the isolated API instance as a singleton is intentional to ensure that all components within the application use the same isolated instance of the OpenFeature API. This design choice allows for consistent state management and behavior across the application while still providing isolation from the global API instance.
+#pragma warning disable OFISO001 // Registering the isolated API instance as a singleton is intentional to ensure that all components within the application use the same isolated instance of the OpenFeature API. This design choice allows for the container to manage the lifecycle of the isolated API instance effectively.
         services.TryAddSingleton(OpenFeatureFactory.CreateIsolated());
 #pragma warning restore OFISO001
         services.TryAddSingleton<IFeatureLifecycleManager, FeatureLifecycleManager>();


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates how the OpenFeature API instance is registered within the dependency injection container. Instead of registering the global `Api.Instance`, it now registers an isolated API instance using `OpenFeatureFactory.CreateIsolated()`. This ensures that all components in the application share the same isolated instance, allowing for better lifecycle management and isolation from global state.

Dependency injection and API registration:

* Replaced registration of the global `Api.Instance` singleton with an isolated API instance created by `OpenFeatureFactory.CreateIsolated()` in `AddOpenFeature` to ensure application-wide isolation and improved lifecycle management.
* Added `using OpenFeature.Isolated;` to support the creation of isolated API instances.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #759