### PR TITLE
ci: add continuous BenchmarkDotNet publishing workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "src/**"
       - "test/OpenFeature.Benchmarks/**"
+      - "test/Directory.Build.props"
+      - "Directory.Packages.props"
+      - "global.json"
       - ".github/workflows/benchmark.yml"
   schedule:
     # Run daily at 03:00 UTC.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,6 +15,12 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+# Prevent overlapping runs (push + schedule + manual dispatch) from racing
+# when pushing results to the gh-pages branch.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -34,6 +40,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          # Only the "Publish benchmark results" step needs to push to gh-pages, and it
+          # authenticates using its own repo-token input rather than the checkout's
+          # persisted credentials, so keep the working tree's git config read-only.
+          persist-credentials: false
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
@@ -49,7 +59,7 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Restore
-        run: dotnet restore
+        run: dotnet restore test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj
 
       - name: Run benchmarks
         working-directory: test/OpenFeature.Benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,59 @@
+name: Benchmark
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "test/OpenFeature.Benchmarks/**"
+      - ".github/workflows/benchmark.yml"
+  schedule:
+    # Run daily at 03:00 UTC.
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    permissions:
+      contents: write
+
+    # TODO(https://github.com/open-feature/dotnet-sdk/issues/625): GitHub-hosted runners can suffer from
+    # noisy-neighbor effects and inconsistent performance. Consider migrating to self-hosted runners once
+    # a baseline is established, if benchmark results turn out to be too noisy to be useful.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', 'global.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Run benchmarks
+        working-directory: test/OpenFeature.Benchmarks
+        run: dotnet run -c Release --framework net10.0 -- --filter "*" --exporters json
+
+      - name: Publish benchmark results
+        uses: martincostello/benchmarkdotnet-results-publisher@b8fe7bb9691c4fdcda7dee630aa09493e81004b8 # v2.0.5
+        with:
+          branch: gh-pages
+          results-path: test/OpenFeature.Benchmarks/BenchmarkDotNet.Artifacts/results

--- a/test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj
+++ b/test/OpenFeature.Benchmarks/OpenFeature.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RootNamespace>OpenFeature.Benchmark</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
## This PR

- Adds a new `.github/workflows/benchmark.yml` GitHub Actions workflow that runs the BenchmarkDotNet benchmarks in `test/OpenFeature.Benchmarks` on push to `main` (path-filtered), on a daily schedule, and via manual dispatch.
- Publishes benchmark results to the `gh-pages` branch using [`martincostello/benchmarkdotnet-results-publisher`](https://github.com/martincostello/benchmarkdotnet-results-publisher), enabling tracking of performance over time via a GitHub Pages dashboard.
- Adds `net8.0` to `OpenFeature.Benchmarks.csproj`'s `TargetFrameworks`, since `OpenFeatureClientBenchmarks` declares `[SimpleJob(RuntimeMoniker.Net80, baseline: true)]` but the project previously didn't build for `net8.0`, which caused the baseline job to silently fail in CI.

### Related Issues

Fixes [#625](https://github.com/open-feature/dotnet-sdk/issues/625)

### Notes

- Per discussion in [#625](https://github.com/open-feature/dotnet-sdk/issues/625), this starts with GitHub-hosted runners as a baseline. A `TODO` comment is left in the workflow noting that self-hosted runners can be considered later if results turn out to be too noisy.
- This PR only adds CI plumbing to run/publish existing benchmarks; it does not add or modify benchmark test cases.
- A live preview of the resulting GitHub Pages dashboard is available on my fork: **https://berkslv.github.io/dotnet-sdk/**

### Follow-up Tasks

- Consider migrating to self-hosted runners if GitHub-hosted runner noise makes results unreliable (see #625 discussion).
- Consider whether the `gh-pages` dashboard (static HTML/JS charts) should be added upstream, or left as a maintainer decision. A working preview is available on my fork: https://berkslv.github.io/dotnet-sdk/

### How to test

- I validated this end-to-end on my fork (`berkslv/dotnet-sdk`): pushed to `main`, confirmed the `Benchmark` workflow runs the benchmarks and successfully publishes `data.json` to `gh-pages`.
- Live dashboard preview (from my fork): https://berkslv.github.io/dotnet-sdk/
- To test manually: trigger the `Benchmark` workflow via `workflow_dispatch` from the Actions tab, or push a change under `src/**` or `test/OpenFeature.Benchmarks/**` to `main`.