### PR TITLE
feat: allow providers to emit their own PROVIDER_READY/PROVIDER_ERROR events (spec v0.9.0)

### DIFF
--- a/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
+++ b/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
@@ -151,6 +151,14 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// The MultiProvider emits its own <see cref="ProviderEventTypes.ProviderReady"/> and
+    /// <see cref="ProviderEventTypes.ProviderError"/> lifecycle events from <see cref="InitializeAsync"/>,
+    /// so the SDK does not synthesize them (OpenFeature spec v0.9.0, Appendix E).
+    /// </remarks>
+    public override bool EmitsLifecycleEvents => true;
+
+    /// <inheritdoc/>
     public override async Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
     {
         if (this._disposed == 1)

--- a/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
+++ b/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
@@ -30,6 +30,8 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
     private readonly SemaphoreSlim _shutdownSemaphore = new(1, 1);
     private readonly object _providerStatusLock = new();
     private ProviderStatus _providerStatus = ProviderStatus.NotReady;
+
+    private volatile bool _initializing;
     // 0 = Not disposed, 1 = Disposed
     // This is to handle the dispose pattern correctly with the async initialization and shutdown methods
     private volatile int _disposed;
@@ -174,6 +176,8 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
                 return;
             }
 
+            this._initializing = true;
+
             var initializationTasks = this._registeredProviders.Select(async rp =>
             {
                 try
@@ -226,6 +230,7 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
         }
         finally
         {
+            this._initializing = false;
             this._initializationSemaphore.Release();
         }
     }
@@ -442,6 +447,12 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
                         ProviderStatus.Stale => ProviderEventTypes.ProviderStale,
                         _ => (ProviderEventTypes?)null
                     };
+
+                    if (this._initializing &&
+                        eventType is ProviderEventTypes.ProviderReady or ProviderEventTypes.ProviderError)
+                    {
+                        eventType = null;
+                    }
                 }
                 else
                 {

--- a/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
+++ b/src/OpenFeature.Providers.MultiProvider/MultiProvider.cs
@@ -394,7 +394,7 @@ public sealed partial class MultiProvider : FeatureProvider, IAsyncDisposable
                     return;
                 }
 
-                if (item is not Event { EventPayload: { } eventPayload })
+                if (item is not ProviderEventPayload eventPayload)
                 {
                     continue;
                 }

--- a/src/OpenFeature/Api.cs
+++ b/src/OpenFeature/Api.cs
@@ -359,6 +359,13 @@ public sealed class Api : IEventBus
     /// </summary>
     private async Task AfterInitializationAsync(FeatureProvider provider, CancellationToken cancellationToken = default)
     {
+        if (EmitsOwnLifecycleEvents(provider))
+        {
+            // The provider owns its lifecycle events; the SDK must not synthesize them (spec v0.9.0, Appendix E).
+            // Status is derived from the provider's emitted events via EventExecutor.UpdateProviderStatus.
+            return;
+        }
+
         provider.Status = ProviderStatus.Ready;
         var eventPayload = new ProviderEventPayload
         {
@@ -376,6 +383,13 @@ public sealed class Api : IEventBus
     /// </summary>
     private async Task AfterErrorAsync(FeatureProvider provider, Exception? ex, CancellationToken cancellationToken = default)
     {
+        if (EmitsOwnLifecycleEvents(provider))
+        {
+            // The provider owns its lifecycle events; the SDK must not synthesize them (spec v0.9.0, Appendix E).
+            // Status is derived from the provider's emitted events via EventExecutor.UpdateProviderStatus.
+            return;
+        }
+
         provider.Status = typeof(ProviderFatalException) == ex?.GetType() ? ProviderStatus.Fatal : ProviderStatus.Error;
         var eventPayload = new ProviderEventPayload
         {
@@ -387,6 +401,15 @@ public sealed class Api : IEventBus
         await this._eventExecutor.EventChannel.Writer.WriteAsync(new Event { Provider = provider, EventPayload = eventPayload }, cancellationToken)
             .ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Determines whether the SDK should defer to the provider for lifecycle event emission.
+    /// This is the case only when the provider opts in via <see cref="FeatureProvider.EmitsLifecycleEvents"/>
+    /// and defines an initialization function. Providers without an initialization function are treated as
+    /// READY from registration (spec Condition 2.8.5), so the SDK still emits READY on their behalf.
+    /// </summary>
+    private static bool EmitsOwnLifecycleEvents(FeatureProvider provider) =>
+        provider.EmitsLifecycleEvents && provider.OverridesInitialize();
 
     /// <summary>
     /// This method should only be using for testing purposes. It will reset the singleton instance of the API.

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -1,4 +1,8 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
+#if NET
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Threading.Channels;
 using OpenFeature.Constant;
 using OpenFeature.Model;
@@ -29,6 +33,46 @@ public abstract class FeatureProvider
     /// The event channel of the provider.
     /// </summary>
     protected readonly Channel<object> EventChannel = Channel.CreateBounded<object>(1);
+
+    /// <summary>
+    /// Indicates that the provider emits its own <see cref="ProviderEventTypes.ProviderReady"/> and
+    /// <see cref="ProviderEventTypes.ProviderError"/> lifecycle events (OpenFeature spec v0.9.0).
+    /// <para>
+    /// When <c>true</c>, the SDK does not emit synthetic lifecycle events on the provider's behalf and
+    /// instead derives the provider status solely from the events the provider emits on its
+    /// <see cref="GetEventChannel">event channel</see>. Providers that opt in must emit
+    /// <see cref="ProviderEventTypes.ProviderReady"/> before <see cref="InitializeAsync"/> terminates
+    /// normally, and <see cref="ProviderEventTypes.ProviderError"/> before it terminates abnormally.
+    /// </para>
+    /// <para>
+    /// When <c>false</c> (the default), the SDK emits synthetic lifecycle events after
+    /// <see cref="InitializeAsync"/> returns or throws. This legacy behavior is deprecated and will be
+    /// removed in a future major version.
+    /// </para>
+    /// </summary>
+    /// <seealso href="https://github.com/open-feature/spec/blob/v0.9.0/specification/appendix-e-migrations.md">Appendix E: Migrations</seealso>
+    public virtual bool EmitsLifecycleEvents => false;
+
+    /// <summary>
+    /// Caches, per concrete provider type, whether <see cref="InitializeAsync"/> is overridden.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Type, bool> OverridesInitializeCache = new();
+
+    /// <summary>
+    /// Determines whether this provider overrides <see cref="InitializeAsync"/>, i.e. it defines an
+    /// initialization function. Providers without an initialization function are treated as READY from
+    /// registration (spec Condition 2.8.5).
+    /// </summary>
+    /// <returns><c>true</c> if the concrete type overrides <see cref="InitializeAsync"/>; otherwise <c>false</c>.</returns>
+    internal bool OverridesInitialize() => OverridesInitializeCache.GetOrAdd(this.GetType(), ComputeOverridesInitialize);
+
+#if NET
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "InitializeAsync is a public virtual method invoked by the SDK for every registered provider, so it is always preserved and available for reflection.")]
+#endif
+    private static bool ComputeOverridesInitialize(Type type) =>
+        type.GetMethod(nameof(InitializeAsync), new[] { typeof(EvaluationContext), typeof(CancellationToken) })?.DeclaringType
+        != typeof(FeatureProvider);
 
     /// <summary>
     /// Metadata describing the provider.

--- a/src/OpenFeature/FeatureProvider.cs
+++ b/src/OpenFeature/FeatureProvider.cs
@@ -70,9 +70,17 @@ public abstract class FeatureProvider
     [UnconditionalSuppressMessage("Trimming", "IL2070",
         Justification = "InitializeAsync is a public virtual method invoked by the SDK for every registered provider, so it is always preserved and available for reflection.")]
 #endif
-    private static bool ComputeOverridesInitialize(Type type) =>
-        type.GetMethod(nameof(InitializeAsync), new[] { typeof(EvaluationContext), typeof(CancellationToken) })?.DeclaringType
-        != typeof(FeatureProvider);
+    private static bool ComputeOverridesInitialize(Type type)
+    {
+        var method = type.GetMethod(nameof(InitializeAsync), new[] { typeof(EvaluationContext), typeof(CancellationToken) });
+        if (method is null || !method.IsVirtual)
+        {
+            return false;
+        }
+
+        return method.DeclaringType != typeof(FeatureProvider)
+            && method.GetBaseDefinition().DeclaringType == typeof(FeatureProvider);
+    }
 
     /// <summary>
     /// Metadata describing the provider.

--- a/src/OpenFeature/ProviderRepository.cs
+++ b/src/OpenFeature/ProviderRepository.cs
@@ -86,11 +86,11 @@ internal sealed partial class ProviderRepository : IAsyncDisposable
             this._providersLock.ExitWriteLock();
         }
 
-        await InitProviderAsync(this._defaultProvider, context, afterInitSuccess, afterInitError, cancellationToken)
+        await this.InitProviderAsync(this._defaultProvider, context, afterInitSuccess, afterInitError, cancellationToken)
             .ConfigureAwait(false);
     }
 
-    private static async Task InitProviderAsync(
+    private async Task InitProviderAsync(
         FeatureProvider? newProvider,
         EvaluationContext context,
         Func<FeatureProvider, CancellationToken, Task>? afterInitialization,
@@ -101,6 +101,15 @@ internal sealed partial class ProviderRepository : IAsyncDisposable
         {
             return;
         }
+
+        // A provider that defines an initialization function but does not opt in to emitting its own
+        // lifecycle events relies on the SDK's deprecated synthetic PROVIDER_READY/PROVIDER_ERROR path
+        // (spec v0.9.0, Appendix E).
+        if (newProvider.OverridesInitialize() && !newProvider.EmitsLifecycleEvents)
+        {
+            this.LegacyLifecycleEventsDeprecated(newProvider.GetMetadata()?.Name);
+        }
+
         if (newProvider.Status == ProviderStatus.NotReady)
         {
             try
@@ -174,7 +183,7 @@ internal sealed partial class ProviderRepository : IAsyncDisposable
             this._providersLock.ExitWriteLock();
         }
 
-        await InitProviderAsync(featureProvider, context, afterInitSuccess, afterInitError, cancellationToken).ConfigureAwait(false);
+        await this.InitProviderAsync(featureProvider, context, afterInitSuccess, afterInitError, cancellationToken).ConfigureAwait(false);
     }
 
     /// <remarks>
@@ -298,4 +307,7 @@ internal sealed partial class ProviderRepository : IAsyncDisposable
 
     [LoggerMessage(EventId = 105, Level = LogLevel.Error, Message = "Error shutting down provider: {TargetProviderName}`")]
     partial void ErrorShuttingDownProvider(string? targetProviderName, Exception exception);
+
+    [LoggerMessage(EventId = 106, Level = LogLevel.Debug, Message = "Provider '{TargetProviderName}' relies on the SDK to emit synthetic PROVIDER_READY/PROVIDER_ERROR events. This behavior is deprecated (OpenFeature spec v0.9.0); providers should emit their own lifecycle events and set FeatureProvider.EmitsLifecycleEvents to true.")]
+    partial void LegacyLifecycleEventsDeprecated(string? targetProviderName);
 }

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
@@ -292,6 +292,39 @@ public class MultiProviderEventTests
             multiProvider.ResolveBooleanValueAsync(TestFlagKey, false, cancellationToken: TestContext.Current.CancellationToken));
     }
 
+    [Fact]
+    public async Task RegisteredViaApi_EmitsProviderReadyExactlyOnce()
+    {
+        // Arrange - MultiProvider opts in to emitting its own lifecycle events, so the SDK must not
+        // synthesize an additional PROVIDER_READY when it is registered (previously it double-emitted).
+        var multiProvider = CreateMultiProvider(new TestProvider("child1"), new TestProvider("child2"));
+        var eventHandler = Substitute.For<EventHandlerDelegate>();
+
+        try
+        {
+            Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
+
+            // Act
+            await Api.Instance.SetProviderAsync(multiProvider, TestContext.Current.CancellationToken);
+
+            // Assert - exactly one PROVIDER_READY reaches the handler, and it stays at one.
+            using var cts = new CancellationTokenSource(1000);
+            while (eventHandler.ReceivedCalls().Count() < 1 && !cts.Token.IsCancellationRequested)
+            {
+                await Task.Delay(50, cts.Token);
+            }
+
+            await Task.Delay(300, TestContext.Current.CancellationToken);
+            eventHandler.Received(1).Invoke(Arg.Is<ProviderEventPayload>(
+                payload => payload!.Type == ProviderEventTypes.ProviderReady));
+        }
+        finally
+        {
+            Api.Instance.RemoveHandler(ProviderEventTypes.ProviderReady, eventHandler);
+            await Api.Instance.ShutdownAsync();
+        }
+    }
+
     // Helper methods
     private MultiProvider CreateMultiProvider(params FeatureProvider[] providers)
     {

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
@@ -338,9 +338,12 @@ public class MultiProviderEventTests
 
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
-        var events = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 2, timeoutMs: 300);
+        var events = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 1);
         var evt = Assert.Single(events);
         AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderReady, "MultiProvider successfully initialized");
+
+        var extraEvents = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 1, timeoutMs: 300);
+        Assert.Empty(extraEvents);
     }
 
     [Fact]
@@ -353,9 +356,12 @@ public class MultiProviderEventTests
         await Assert.ThrowsAsync<AggregateException>(() => multiProvider.InitializeAsync(_context, TestContext.Current.CancellationToken));
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
-        var events = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 2, timeoutMs: 300);
+        var events = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 1);
         var evt = Assert.Single(events);
         AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderError, errorType: ErrorType.ProviderFatal);
+
+        var extraEvents = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 1, timeoutMs: 300);
+        Assert.Empty(extraEvents);
     }
 
     [Fact]

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
@@ -386,9 +386,12 @@ public class MultiProviderEventTests
         gate.SetResult(true);
         await initTask;
 
-        var events = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 2, timeoutMs: 300);
+        var events = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 1);
         var evt = Assert.Single(events);
         AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderReady, "MultiProvider successfully initialized");
+
+        var extraEvents = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 1, timeoutMs: 300);
+        Assert.Empty(extraEvents);
     }
 
     // Helper methods

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
@@ -411,8 +411,7 @@ public class MultiProviderEventTests
     private static async Task EmitEventToProvider(FeatureProvider provider, ProviderEventPayload eventPayload)
     {
         var eventChannel = provider.GetEventChannel();
-        var eventWrapper = new Event { EventPayload = eventPayload, Provider = provider };
-        await eventChannel.Writer.WriteAsync(eventWrapper);
+        await eventChannel.Writer.WriteAsync(eventPayload);
     }
 
     private static async Task<List<ProviderEventPayload>> ReadEvents(Channel<object> channel, int expectedCount = 1, int timeoutMs = 1000)

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
@@ -358,6 +358,33 @@ public class MultiProviderEventTests
         AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderError, errorType: ErrorType.ProviderFatal);
     }
 
+    [Fact]
+    public async Task InitializeAsync_WhenChildReadyProcessedDuringInit_SuppressesDuplicateReadyEmission()
+    {
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var child = new TestProvider("child1", emitsLifecycleEvents: true, initGate: gate.Task);
+        var multiProvider = CreateMultiProvider(child);
+
+        var initTask = multiProvider.InitializeAsync(_context, TestContext.Current.CancellationToken);
+
+        using (var cts = new CancellationTokenSource(2000))
+        {
+            while (multiProvider.Status != ProviderStatus.Ready && !cts.Token.IsCancellationRequested)
+            {
+                await Task.Delay(20, cts.Token);
+            }
+        }
+
+        Assert.Equal(ProviderStatus.Ready, multiProvider.Status);
+
+        gate.SetResult(true);
+        await initTask;
+
+        var events = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 2, timeoutMs: 300);
+        var evt = Assert.Single(events);
+        AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderReady, "MultiProvider successfully initialized");
+    }
+
     // Helper methods
     private MultiProvider CreateMultiProvider(params FeatureProvider[] providers)
     {

--- a/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/MultiProviderEventTests.cs
@@ -42,8 +42,8 @@ public class MultiProviderEventTests
 
         // Assert
         var events = await ReadEvents(multiProvider.GetEventChannel());
-        Assert.Single(events);
-        AssertEvent(events[0], "MultiProvider", ProviderEventTypes.ProviderReady, "MultiProvider successfully initialized");
+        var evt = Assert.Single(events);
+        AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderReady, "MultiProvider successfully initialized");
     }
 
     [Fact]
@@ -58,8 +58,8 @@ public class MultiProviderEventTests
 
         // Verify the error event was emitted
         var events = await ReadEvents(multiProvider.GetEventChannel());
-        Assert.Single(events);
-        AssertEvent(events[0], "MultiProvider", ProviderEventTypes.ProviderError, errorType: ErrorType.ProviderFatal);
+        var evt = Assert.Single(events);
+        AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderError, errorType: ErrorType.ProviderFatal);
     }
 
     [Fact]
@@ -78,8 +78,8 @@ public class MultiProviderEventTests
 
         // Verify the error event was emitted
         var events = await ReadEvents(multiProvider.GetEventChannel());
-        Assert.Single(events);
-        AssertEvent(events[0], "MultiProvider", ProviderEventTypes.ProviderError, errorType: ErrorType.ProviderFatal);
+        var evt = Assert.Single(events);
+        AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderError, errorType: ErrorType.ProviderFatal);
     }
 
     [Fact]
@@ -100,8 +100,8 @@ public class MultiProviderEventTests
 
         // Verify the error event was emitted
         var events = await ReadEvents(multiProvider.GetEventChannel());
-        Assert.Single(events);
-        AssertEvent(events[0], "MultiProvider", ProviderEventTypes.ProviderError, errorType: ErrorType.General);
+        var evt = Assert.Single(events);
+        AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderError, errorType: ErrorType.General);
     }
 
     [Fact]
@@ -123,9 +123,9 @@ public class MultiProviderEventTests
 
         // Assert
         var events = await ReadEvents(multiProvider.GetEventChannel());
-        Assert.Single(events);
-        AssertEvent(events[0], $"MultiProvider/{Provider1Name}", ProviderEventTypes.ProviderConfigurationChanged, "Config changed");
-        Assert.Contains(TestFlagKey, events[0].FlagsChanged!);
+        var evt = Assert.Single(events);
+        AssertEvent(evt, $"MultiProvider/{Provider1Name}", ProviderEventTypes.ProviderConfigurationChanged, "Config changed");
+        Assert.Contains(TestFlagKey, evt.FlagsChanged!);
     }
 
     [Fact]
@@ -160,8 +160,8 @@ public class MultiProviderEventTests
 
         // Assert
         var events = await ReadEvents(multiProvider.GetEventChannel());
-        Assert.Single(events);
-        AssertEvent(events[0], "MultiProvider", ProviderEventTypes.ProviderError, errorType: ErrorType.ProviderFatal);
+        var evt = Assert.Single(events);
+        AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderError, errorType: ErrorType.ProviderFatal);
     }
 
     [Fact]
@@ -177,8 +177,8 @@ public class MultiProviderEventTests
 
         // Assert
         var events = await ReadEvents(multiProvider.GetEventChannel());
-        Assert.Single(events);
-        AssertEvent(events[0], "MultiProvider", ProviderEventTypes.ProviderStale);
+        var evt = Assert.Single(events);
+        AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderStale);
     }
 
     [Fact]
@@ -237,9 +237,10 @@ public class MultiProviderEventTests
 
         // Assert
         var events = await ReadEvents(multiProvider.GetEventChannel());
-        Assert.Single(events);
-        Assert.NotNull(events[0].EventMetadata);
-        Assert.Equal("test", events[0].EventMetadata?.GetString("source"));
+        var evt = Assert.Single(events);
+        AssertEvent(evt, $"MultiProvider/{Provider1Name}", ProviderEventTypes.ProviderConfigurationChanged);
+        Assert.NotNull(evt.EventMetadata);
+        Assert.Equal("test", evt.EventMetadata?.GetString("source"));
     }
 
     [Fact]
@@ -323,6 +324,38 @@ public class MultiProviderEventTests
             Api.Instance.RemoveHandler(ProviderEventTypes.ProviderReady, eventHandler);
             await Api.Instance.ShutdownAsync();
         }
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithLifecycleEmittingChildren_EmitsProviderReadyExactlyOnce()
+    {
+        var child1 = new TestProvider("child1", emitsLifecycleEvents: true);
+        var child2 = new TestProvider("child2", emitsLifecycleEvents: true);
+        var multiProvider = CreateMultiProvider(child1, child2);
+
+        // Act
+        await multiProvider.InitializeAsync(_context, TestContext.Current.CancellationToken);
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        var events = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 2, timeoutMs: 300);
+        var evt = Assert.Single(events);
+        AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderReady, "MultiProvider successfully initialized");
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithLifecycleEmittingChildFailure_EmitsProviderErrorExactlyOnce()
+    {
+        var failingChild = new TestProvider("child1", new InvalidOperationException("Init failed"), emitsLifecycleEvents: true);
+        var healthyChild = new TestProvider("child2", emitsLifecycleEvents: true);
+        var multiProvider = CreateMultiProvider(failingChild, healthyChild);
+
+        await Assert.ThrowsAsync<AggregateException>(() => multiProvider.InitializeAsync(_context, TestContext.Current.CancellationToken));
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        var events = await ReadEvents(multiProvider.GetEventChannel(), expectedCount: 2, timeoutMs: 300);
+        var evt = Assert.Single(events);
+        AssertEvent(evt, "MultiProvider", ProviderEventTypes.ProviderError, errorType: ErrorType.ProviderFatal);
     }
 
     // Helper methods

--- a/test/OpenFeature.Providers.MultiProvider.Tests/Utils/TestProvider.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/Utils/TestProvider.cs
@@ -118,6 +118,6 @@ public class TestProvider : FeatureProvider
             ProviderName = this._name,
             ErrorType = errorType
         };
-        await this.EventChannel.Writer.WriteAsync(new Event { EventPayload = payload, Provider = this }, cancellationToken);
+        await this.EventChannel.Writer.WriteAsync(payload, cancellationToken);
     }
 }

--- a/test/OpenFeature.Providers.MultiProvider.Tests/Utils/TestProvider.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/Utils/TestProvider.cs
@@ -29,14 +29,16 @@ public class TestProvider : FeatureProvider
     private readonly Exception? _initException;
     private readonly Exception? _shutdownException;
     private readonly bool _emitsLifecycleEvents;
+    private readonly Task? _initGate;
     private readonly List<TrackingInvocation> _trackingInvocations = new();
 
-    public TestProvider(string name, Exception? initException = null, Exception? shutdownException = null, bool emitsLifecycleEvents = false)
+    public TestProvider(string name, Exception? initException = null, Exception? shutdownException = null, bool emitsLifecycleEvents = false, Task? initGate = null)
     {
         this._name = name;
         this._initException = initException;
         this._shutdownException = shutdownException;
         this._emitsLifecycleEvents = emitsLifecycleEvents;
+        this._initGate = initGate;
     }
 
     public override bool EmitsLifecycleEvents => this._emitsLifecycleEvents;
@@ -64,7 +66,10 @@ public class TestProvider : FeatureProvider
             await this.SendProviderEventAsync(ProviderEventTypes.ProviderReady, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        await Task.CompletedTask;
+        if (this._initGate != null)
+        {
+            await this._initGate.ConfigureAwait(false);
+        }
     }
 
     public override async Task ShutdownAsync(CancellationToken cancellationToken = default)
@@ -113,6 +118,6 @@ public class TestProvider : FeatureProvider
             ProviderName = this._name,
             ErrorType = errorType
         };
-        await this.EventChannel.Writer.WriteAsync(payload, cancellationToken);
+        await this.EventChannel.Writer.WriteAsync(new Event { EventPayload = payload, Provider = this }, cancellationToken);
     }
 }

--- a/test/OpenFeature.Providers.MultiProvider.Tests/Utils/TestProvider.cs
+++ b/test/OpenFeature.Providers.MultiProvider.Tests/Utils/TestProvider.cs
@@ -28,14 +28,18 @@ public class TestProvider : FeatureProvider
     private readonly string _name;
     private readonly Exception? _initException;
     private readonly Exception? _shutdownException;
+    private readonly bool _emitsLifecycleEvents;
     private readonly List<TrackingInvocation> _trackingInvocations = new();
 
-    public TestProvider(string name, Exception? initException = null, Exception? shutdownException = null)
+    public TestProvider(string name, Exception? initException = null, Exception? shutdownException = null, bool emitsLifecycleEvents = false)
     {
         this._name = name;
         this._initException = initException;
         this._shutdownException = shutdownException;
+        this._emitsLifecycleEvents = emitsLifecycleEvents;
     }
+
+    public override bool EmitsLifecycleEvents => this._emitsLifecycleEvents;
 
     public IReadOnlyList<TrackingInvocation> GetTrackingInvocations() => this._trackingInvocations.AsReadOnly();
 
@@ -47,7 +51,17 @@ public class TestProvider : FeatureProvider
     {
         if (this._initException != null)
         {
+            if (this._emitsLifecycleEvents)
+            {
+                await this.SendProviderEventAsync(ProviderEventTypes.ProviderError, ErrorType.ProviderFatal, cancellationToken).ConfigureAwait(false);
+            }
+
             throw this._initException;
+        }
+
+        if (this._emitsLifecycleEvents)
+        {
+            await this.SendProviderEventAsync(ProviderEventTypes.ProviderReady, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         await Task.CompletedTask;

--- a/test/OpenFeature.Tests/FeatureProviderTests.cs
+++ b/test/OpenFeature.Tests/FeatureProviderTests.cs
@@ -123,4 +123,68 @@ public class FeatureProviderTests : ClearOpenFeatureInstanceFixture
         Assert.Equal(ErrorType.TargetingKeyMissing, boolRes2.ErrorType);
         Assert.Null(boolRes2.ErrorMessage);
     }
+
+    [Fact]
+    public void OverridesInitialize_WhenProviderOverridesInitialize_ReturnsTrue()
+    {
+        var provider = new TestProvider();
+
+        Assert.True(provider.OverridesInitialize());
+    }
+
+    [Fact]
+    public void OverridesInitialize_WhenProviderDoesNotDefineInitialize_ReturnsFalse()
+    {
+        var provider = new NoInitProvider();
+
+        Assert.False(provider.OverridesInitialize());
+    }
+
+    [Fact]
+    public void OverridesInitialize_WhenInitializeHiddenWithNew_ReturnsFalse()
+    {
+        var provider = new NewHidingProvider();
+
+        Assert.False(provider.OverridesInitialize());
+    }
+
+    [Fact]
+    public void OverridesInitialize_WhenInitializeHiddenWithNewVirtual_ReturnsFalse()
+    {
+        var provider = new NewVirtualHidingProvider();
+
+        Assert.False(provider.OverridesInitialize());
+    }
+
+    private class NoInitProvider : FeatureProvider
+    {
+        public override Metadata GetMetadata() => new("no-init");
+
+        public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ResolutionDetails<bool>(flagKey, defaultValue));
+
+        public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ResolutionDetails<string>(flagKey, defaultValue));
+
+        public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ResolutionDetails<int>(flagKey, defaultValue));
+
+        public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ResolutionDetails<double>(flagKey, defaultValue));
+
+        public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ResolutionDetails<Value>(flagKey, defaultValue));
+    }
+
+    private sealed class NewHidingProvider : NoInitProvider
+    {
+        public new Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+
+    private class NewVirtualHidingProvider : NoInitProvider
+    {
+        public new virtual Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
 }

--- a/test/OpenFeature.Tests/OpenFeatureEventTests.cs
+++ b/test/OpenFeature.Tests/OpenFeatureEventTests.cs
@@ -1,7 +1,10 @@
 using AutoFixture;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using NSubstitute;
 using OpenFeature.Constant;
 using OpenFeature.Model;
+using OpenFeature.Providers.Memory;
 using OpenFeature.Tests.Internal;
 
 namespace OpenFeature.Tests;
@@ -508,5 +511,92 @@ public class OpenFeatureEventTest : ClearOpenFeatureInstanceFixture
         await Api.Instance.SetProviderAsync("5.3.5", provider, TestContext.Current.CancellationToken);
         _ = provider.SendEventAsync(type, TestContext.Current.CancellationToken);
         await Utils.AssertUntilAsync(_ => Assert.True(provider.Status == status));
+    }
+
+    [Fact]
+    [Specification("2.8.1", "The `provider` MUST emit an event to signal each status transition, including transitions resulting from lifecycle methods.")]
+    [Specification("2.8.2", "The `provider` MUST emit the `PROVIDER_READY` event before its `initialize` function terminates normally.")]
+    public async Task Provider_That_Emits_Own_Lifecycle_Events_Should_Not_Get_Synthetic_Ready()
+    {
+        var eventHandler = Substitute.For<EventHandlerDelegate>();
+        Api.Instance.AddHandler(ProviderEventTypes.ProviderReady, eventHandler);
+
+        var provider = new LifecycleEmittingTestProvider();
+        await Api.Instance.SetProviderAsync(provider, TestContext.Current.CancellationToken);
+
+        // The provider's own PROVIDER_READY should reach the handler exactly once.
+        await Utils.AssertUntilAsync(_ => eventHandler
+            .Received(1)
+            .Invoke(Arg.Is<ProviderEventPayload>(
+                payload => payload!.ProviderName == provider.GetMetadata().Name && payload.Type == ProviderEventTypes.ProviderReady)));
+
+        // Give any (erroneously) synthesized event time to arrive, then confirm the count is still one.
+        await Task.Delay(300, TestContext.Current.CancellationToken);
+        eventHandler
+            .Received(1)
+            .Invoke(Arg.Is<ProviderEventPayload>(
+                payload => payload!.ProviderName == provider.GetMetadata().Name && payload.Type == ProviderEventTypes.ProviderReady));
+
+        Assert.Equal(ProviderStatus.Ready, provider.Status);
+    }
+
+    [Fact]
+    [Specification("2.8.3", "The `provider` MUST emit the `PROVIDER_ERROR` event before its `initialize` function terminates abnormally.")]
+    [Specification("5.3.5", "If the provider emits an event, the value of the client's provider status MUST be updated accordingly.")]
+    public async Task Provider_That_Emits_Own_Error_Event_Should_Not_Get_Synthetic_Error()
+    {
+        var eventHandler = Substitute.For<EventHandlerDelegate>();
+        Api.Instance.AddHandler(ProviderEventTypes.ProviderError, eventHandler);
+
+        var provider = new LifecycleEmittingTestProvider(initErrorType: ErrorType.ProviderFatal);
+        await Api.Instance.SetProviderAsync(provider, TestContext.Current.CancellationToken);
+
+        await Utils.AssertUntilAsync(_ => eventHandler
+            .Received(1)
+            .Invoke(Arg.Is<ProviderEventPayload>(
+                payload => payload!.ProviderName == provider.GetMetadata().Name && payload.Type == ProviderEventTypes.ProviderError)));
+
+        // No synthetic error should follow the provider's own event.
+        await Task.Delay(300, TestContext.Current.CancellationToken);
+        eventHandler
+            .Received(1)
+            .Invoke(Arg.Is<ProviderEventPayload>(
+                payload => payload!.ProviderName == provider.GetMetadata().Name && payload.Type == ProviderEventTypes.ProviderError));
+
+        // The provider emitted PROVIDER_FATAL, so status must be derived as Fatal.
+        Assert.Equal(ProviderStatus.Fatal, provider.Status);
+    }
+
+    [Fact]
+    [Specification("5.3.1", "If the provider's `initialize` function terminates normally, `PROVIDER_READY` handlers MUST run.")]
+    public async Task Legacy_Provider_Registration_Should_Log_Deprecation_Warning()
+    {
+        var logger = new FakeLogger();
+        Api.Instance.SetLogger(logger);
+
+        // TestProvider overrides InitializeAsync but does not opt in to emitting its own lifecycle events.
+        var provider = new TestProvider();
+        await Api.Instance.SetProviderAsync(provider, TestContext.Current.CancellationToken);
+
+        Assert.Contains(logger.Collector.GetSnapshot(),
+            record => record.Level == LogLevel.Debug && record.Id.Id == 106);
+    }
+
+    [Fact]
+    [Specification("2.8.5", "The `provider` defines a mechanism to gracefully shutdown and dispose of resources.")]
+    public async Task NoInit_Provider_Registration_Should_Not_Log_Deprecation_Warning_And_Be_Ready()
+    {
+        var logger = new FakeLogger();
+        Api.Instance.SetLogger(logger);
+
+        // InMemoryProvider does not define an initialization function (Condition 2.8.5).
+        var provider = new InMemoryProvider();
+        await Api.Instance.SetProviderAsync(provider, TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(logger.Collector.GetSnapshot(),
+            record => record.Level == LogLevel.Debug && record.Id.Id == 106);
+
+        // Providers with no initialize function are treated as READY from registration.
+        await Utils.AssertUntilAsync(_ => Assert.Equal(ProviderStatus.Ready, provider.Status));
     }
 }

--- a/test/OpenFeature.Tests/TestImplementations.cs
+++ b/test/OpenFeature.Tests/TestImplementations.cs
@@ -149,3 +149,55 @@ public class TestProvider : FeatureProvider
         return this.EventChannel.Writer.WriteAsync(new ProviderEventPayload { Type = eventType, ProviderName = this.GetMetadata().Name, }, cancellationToken);
     }
 }
+
+/// <summary>
+/// A provider that opts in to emitting its own PROVIDER_READY / PROVIDER_ERROR lifecycle events
+/// (spec v0.9.0). It emits the appropriate event from <see cref="InitializeAsync"/>, so the SDK must
+/// not synthesize lifecycle events on its behalf.
+/// </summary>
+public class LifecycleEmittingTestProvider : TestProvider
+{
+    private readonly ErrorType? _initErrorType;
+    private readonly bool _throwOnError;
+
+    public LifecycleEmittingTestProvider(string? name = null, ErrorType? initErrorType = null, bool throwOnError = true)
+        : base(name)
+    {
+        this._initErrorType = initErrorType;
+        this._throwOnError = throwOnError;
+    }
+
+    /// <inheritdoc/>
+    public override bool EmitsLifecycleEvents => true;
+
+    /// <inheritdoc/>
+    public override async Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
+    {
+        if (this._initErrorType.HasValue)
+        {
+            // Emit PROVIDER_ERROR before terminating abnormally (spec 2.8.3).
+            await this.EventChannel.Writer.WriteAsync(new ProviderEventPayload
+            {
+                Type = ProviderEventTypes.ProviderError,
+                ProviderName = this.GetMetadata().Name,
+                ErrorType = this._initErrorType,
+                Message = "Provider failed to initialize",
+            }, cancellationToken).ConfigureAwait(false);
+
+            if (this._throwOnError)
+            {
+                throw new InvalidOperationException("Provider failed to initialize");
+            }
+
+            return;
+        }
+
+        // Emit PROVIDER_READY before terminating normally (spec 2.8.2).
+        await this.EventChannel.Writer.WriteAsync(new ProviderEventPayload
+        {
+            Type = ProviderEventTypes.ProviderReady,
+            ProviderName = this.GetMetadata().Name,
+            Message = "Provider is ready",
+        }, cancellationToken).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
## Summary

Aligns the SDK with OpenFeature spec **v0.9.0** ([Appendix E](https://github.com/open-feature/spec/blob/v0.9.0/specification/appendix-e-migrations.md), [2.8](https://github.com/open-feature/spec/blob/v0.9.0/specification/sections/02-providers.md#condition-285)). Previously the SDK *synthesized* `PROVIDER_READY`/`PROVIDER_ERROR` after `InitializeAsync` returned or threw. Providers that emit their own lifecycle events then collided with these synthetic events, producing duplicate events and inconsistent status - the first-party `MultiProvider` already double-emitted for exactly this reason.

Fixes #799.

## Changes

- **Opt-in marker** - new virtual `FeatureProvider.EmitsLifecycleEvents` (default `false`). When a provider opts in, the SDK no longer emits synthetic lifecycle events and derives status solely from the provider's event stream (`EventExecutor.UpdateProviderStatus`).
- **Synthetic-event suppression** - `Api.AfterInitializationAsync`/`AfterErrorAsync` skip emission when `EmitsLifecycleEvents && OverridesInitialize()`. Providers without an `initialize` function stay on the synthetic-READY path (spec Condition 2.8.5), so existing no-init providers (`NoOp`, `InMemory`) are unaffected.
- **Deprecation notice** - legacy providers (define `initialize`, no marker) log a `Debug`-level message on registration. Kept at `Debug` because the audience is the provider's developer, not consuming applications.
- **MultiProvider migrated** - now sets `EmitsLifecycleEvents => true`; it already emitted its own READY/ERROR from `InitializeAsync`.

## Behavior matrix

| Provider | Overrides `InitializeAsync`? | Marker? | SDK behavior |
|---|---|---|---|
| `NoOp` / `InMemory` | No | No | Synthetic READY on registration ([2.8.5](https://github.com/open-feature/spec/blob/v0.9.0/specification/sections/02-providers.md#condition-285)) - unchanged |
| Legacy w/ init | Yes | No | Synthetic READY/ERROR + Debug deprecation notice |
| `MultiProvider` / new | Yes | **Yes** | No synthetic events; status from the provider's event stream |
| Marker but no init | No | Yes | Synthetic READY on registration ([2.8.5](https://github.com/open-feature/spec/blob/v0.9.0/specification/sections/02-providers.md#condition-285)) |

## Alternative considered: marker interface

Instead of a virtual `bool` property, the opt-in could have been a **marker interface** (e.g. `IEmitLifecycleEvents`) detected via `provider is IEmitLifecycleEvents`. It's purely additive and adds no member to the base class. We chose the virtual property because it matches the existing opt-in pattern on `FeatureProvider` (`GetProviderHooks`, `InitializeAsync`) and is more discoverable via IntelliSense for provider authors. Both are permitted by [Appendix E](https://github.com/open-feature/spec/blob/v0.9.0/specification/appendix-e-migrations.md) ("interface, boolean property, or type-level tag").