### PR TITLE
fix: provider ready events not publishing for DI service

### DIFF
--- a/src/OpenFeature.Hosting/Internal/FeatureLifecycleManager.cs
+++ b/src/OpenFeature.Hosting/Internal/FeatureLifecycleManager.cs
@@ -23,17 +23,6 @@ internal sealed partial class FeatureLifecycleManager : IFeatureLifecycleManager
         this.LogStartingInitializationOfFeatureProvider();
 
         var options = _serviceProvider.GetRequiredService<IOptions<OpenFeatureOptions>>().Value;
-        if (options.HasDefaultProvider)
-        {
-            var featureProvider = _serviceProvider.GetRequiredService<FeatureProvider>();
-            await _featureApi.SetProviderAsync(featureProvider).ConfigureAwait(false);
-        }
-
-        foreach (var name in options.ProviderNames)
-        {
-            var featureProvider = _serviceProvider.GetRequiredKeyedService<FeatureProvider>(name);
-            await _featureApi.SetProviderAsync(name, featureProvider).ConfigureAwait(false);
-        }
 
         var hooks = new List<Hook>();
         foreach (var hookName in options.HookNames)
@@ -48,6 +37,18 @@ internal sealed partial class FeatureLifecycleManager : IFeatureLifecycleManager
         foreach (var handler in handlers)
         {
             _featureApi.AddHandler(handler.ProviderEventType, handler.EventHandlerDelegate);
+        }
+
+        if (options.HasDefaultProvider)
+        {
+            var featureProvider = _serviceProvider.GetRequiredService<FeatureProvider>();
+            await _featureApi.SetProviderAsync(featureProvider).ConfigureAwait(false);
+        }
+
+        foreach (var name in options.ProviderNames)
+        {
+            var featureProvider = _serviceProvider.GetRequiredKeyedService<FeatureProvider>(name);
+            await _featureApi.SetProviderAsync(name, featureProvider).ConfigureAwait(false);
         }
     }
 

--- a/test/OpenFeature.Hosting.Tests/Internal/FeatureLifecycleManagerTests.cs
+++ b/test/OpenFeature.Hosting.Tests/Internal/FeatureLifecycleManagerTests.cs
@@ -100,8 +100,8 @@ public class FeatureLifecycleManagerTests : IAsyncLifetime
         });
         services.AddSingleton<FeatureProvider>(provider);
 
-        bool hookExecuted = false;
-        services.AddSingleton(new EventHandlerDelegateWrapper(ProviderEventTypes.ProviderReady, (p) => { hookExecuted = true; }));
+        var handlerInvoked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        services.AddSingleton(new EventHandlerDelegateWrapper(ProviderEventTypes.ProviderReady, (p) => handlerInvoked.TrySetResult(true)));
 
         var api = Api.Instance;
 
@@ -111,7 +111,37 @@ public class FeatureLifecycleManagerTests : IAsyncLifetime
         await lifecycleManager.EnsureInitializedAsync(TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.True(hookExecuted);
+        var completed = await Task.WhenAny(handlerInvoked.Task, Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+        Assert.Equal(handlerInvoked.Task, completed);
+        Assert.True(await handlerInvoked.Task);
+    }
+
+    [Fact]
+    public async Task EnsureInitializedAsync_AddHandlers_ForNamedProvider()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var provider = new NoOpFeatureProvider();
+        services.AddOptions<OpenFeatureOptions>().Configure(options =>
+        {
+            options.AddProviderName("my-domain");
+        });
+        services.AddKeyedSingleton<FeatureProvider>("my-domain", provider);
+
+        var handlerInvoked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        services.AddSingleton(new EventHandlerDelegateWrapper(ProviderEventTypes.ProviderReady, (p) => handlerInvoked.TrySetResult(true)));
+
+        var api = Api.Instance;
+
+        // Act
+        using var serviceProvider = services.BuildServiceProvider();
+        var lifecycleManager = new FeatureLifecycleManager(api, serviceProvider, NullLogger<FeatureLifecycleManager>.Instance);
+        await lifecycleManager.EnsureInitializedAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var completed = await Task.WhenAny(handlerInvoked.Task, Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+        Assert.Equal(handlerInvoked.Task, completed);
+        Assert.True(await handlerInvoked.Task);
     }
 
     [Fact]

--- a/test/OpenFeature.IntegrationTests/FeatureFlagIntegrationTest.cs
+++ b/test/OpenFeature.IntegrationTests/FeatureFlagIntegrationTest.cs
@@ -108,9 +108,10 @@ public class FeatureFlagIntegrationTest
         };
 
         var handlerSuccess = false;
+        var handlerInvoked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         Action<OpenFeatureBuilder> openFeatureBuilder = cfg =>
         {
-            cfg.AddHandler(ProviderEventTypes.ProviderReady, (_) => { handlerSuccess = true; });
+            cfg.AddHandler(ProviderEventTypes.ProviderReady, (_) => { handlerSuccess = true; handlerInvoked.TrySetResult(true); });
         };
 
         using var server = await CreateServerAsync(ServiceLifetime.Transient, configureServices, openFeatureBuilder)
@@ -124,7 +125,8 @@ public class FeatureFlagIntegrationTest
 
         // Assert
         Assert.True(response.IsSuccessStatusCode, "Expected HTTP status code 200 OK.");
-        await AssertUntilAsync(() => handlerSuccess, TestContext.Current.CancellationToken).ConfigureAwait(true);
+        await handlerInvoked.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+        Assert.True(handlerSuccess);
     }
 
     [Fact]
@@ -139,10 +141,12 @@ public class FeatureFlagIntegrationTest
         var counter = 0;
         var handler1Success = false;
         var handler2Success = false;
+        var handler1Invoked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler2Invoked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         Action<OpenFeatureBuilder> openFeatureBuilder = cfg =>
         {
-            cfg.AddHandler(ProviderEventTypes.ProviderReady, sp => { Interlocked.Increment(ref counter); return _ => { handler1Success = true; }; });
-            cfg.AddHandler(ProviderEventTypes.ProviderReady, sp => { Interlocked.Increment(ref counter); return _ => { handler2Success = true; }; });
+            cfg.AddHandler(ProviderEventTypes.ProviderReady, sp => { Interlocked.Increment(ref counter); return _ => { handler1Success = true; handler1Invoked.TrySetResult(true); }; });
+            cfg.AddHandler(ProviderEventTypes.ProviderReady, sp => { Interlocked.Increment(ref counter); return _ => { handler2Success = true; handler2Invoked.TrySetResult(true); }; });
         };
 
         using var server = await CreateServerAsync(ServiceLifetime.Transient, configureServices, openFeatureBuilder)
@@ -156,8 +160,14 @@ public class FeatureFlagIntegrationTest
 
         // Assert
         Assert.True(response.IsSuccessStatusCode, "Expected HTTP status code 200 OK.");
-        await AssertUntilAsync(() => handler1Success && handler2Success, TestContext.Current.CancellationToken).ConfigureAwait(true);
-        Assert.Equal(2, counter);
+        await handler1Invoked.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+        await handler2Invoked.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+        Assert.Multiple(() =>
+        {
+            Assert.Equal(2, counter);
+            Assert.True(handler1Success);
+            Assert.True(handler2Success);
+        });
     }
 
     [Fact]
@@ -165,9 +175,17 @@ public class FeatureFlagIntegrationTest
     {
         // Arrange
         var logs = string.Empty;
+        var handlerLogged = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         Action<IServiceCollection> configureServices = services =>
         {
-            services.AddFakeLogging(a => a.OutputSink = log => logs = string.Join('|', logs, log));
+            services.AddFakeLogging(a => a.OutputSink = log =>
+            {
+                logs = string.Join('|', logs, log);
+                if (log.Contains("Handler invoked from builder!"))
+                {
+                    handlerLogged.TrySetResult(true);
+                }
+            });
             services.AddTransient<IFeatureFlagConfigurationService, FlagConfigurationService>();
         };
 
@@ -191,21 +209,8 @@ public class FeatureFlagIntegrationTest
 
         // Assert
         Assert.True(response.IsSuccessStatusCode, "Expected HTTP status code 200 OK.");
-        await AssertUntilAsync(() => logs.Contains("Handler invoked from builder!"), TestContext.Current.CancellationToken).ConfigureAwait(true);
-    }
-
-    private static async Task AssertUntilAsync(Func<bool> condition, CancellationToken cancellationToken, int timeoutMs = 5000, int pollMs = 25)
-    {
-        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
-        while (!condition())
-        {
-            if (DateTime.UtcNow >= deadline)
-            {
-                Assert.Fail("Condition was not met within the allotted time.");
-            }
-
-            await Task.Delay(pollMs, cancellationToken).ConfigureAwait(false);
-        }
+        await handlerLogged.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+        Assert.Contains("Handler invoked from builder!", logs);
     }
 
     private static async Task<TestServer> CreateServerAsync(ServiceLifetime serviceLifetime,

--- a/test/OpenFeature.IntegrationTests/FeatureFlagIntegrationTest.cs
+++ b/test/OpenFeature.IntegrationTests/FeatureFlagIntegrationTest.cs
@@ -124,7 +124,7 @@ public class FeatureFlagIntegrationTest
 
         // Assert
         Assert.True(response.IsSuccessStatusCode, "Expected HTTP status code 200 OK.");
-        Assert.True(handlerSuccess);
+        await AssertUntilAsync(() => handlerSuccess, TestContext.Current.CancellationToken).ConfigureAwait(true);
     }
 
     [Fact]
@@ -156,12 +156,8 @@ public class FeatureFlagIntegrationTest
 
         // Assert
         Assert.True(response.IsSuccessStatusCode, "Expected HTTP status code 200 OK.");
-        Assert.Multiple(() =>
-        {
-            Assert.Equal(2, counter);
-            Assert.True(handler1Success);
-            Assert.True(handler2Success);
-        });
+        await AssertUntilAsync(() => handler1Success && handler2Success, TestContext.Current.CancellationToken).ConfigureAwait(true);
+        Assert.Equal(2, counter);
     }
 
     [Fact]
@@ -195,7 +191,21 @@ public class FeatureFlagIntegrationTest
 
         // Assert
         Assert.True(response.IsSuccessStatusCode, "Expected HTTP status code 200 OK.");
-        Assert.Contains("Handler invoked from builder!", logs);
+        await AssertUntilAsync(() => logs.Contains("Handler invoked from builder!"), TestContext.Current.CancellationToken).ConfigureAwait(true);
+    }
+
+    private static async Task AssertUntilAsync(Func<bool> condition, CancellationToken cancellationToken, int timeoutMs = 5000, int pollMs = 25)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (!condition())
+        {
+            if (DateTime.UtcNow >= deadline)
+            {
+                Assert.Fail("Condition was not met within the allotted time.");
+            }
+
+            await Task.Delay(pollMs, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private static async Task<TestServer> CreateServerAsync(ServiceLifetime serviceLifetime,


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Fixes a race condition where `PROVIDER_READY` (and other lifecycle) events registered through the DI/hosting package would fire inconsistently (and sometimes never).

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #817

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

You can run the sample WebApp and `.AddHandler()` with a Console WriteLine statement to verify the events are being published, e.g.

```csharp
.AddHandler(ProviderEventTypes.ProviderReady, evt => Console.WriteLine($"Provider ready: {evt!.ProviderName}"))
```

Below is a screenshot of the sample running with this event handler logging the provider ready event.

<img width="702" height="256" alt="image" src="https://github.com/user-attachments/assets/eec44fc0-a3ea-44c1-9b02-a100c2cf75fa" />
