### PR TITLE
fix: pass cancellation token to provider initialization for DI service

### DIFF
--- a/src/OpenFeature.Hosting/Internal/FeatureLifecycleManager.cs
+++ b/src/OpenFeature.Hosting/Internal/FeatureLifecycleManager.cs
@@ -26,13 +26,13 @@ internal sealed partial class FeatureLifecycleManager : IFeatureLifecycleManager
         if (options.HasDefaultProvider)
         {
             var featureProvider = _serviceProvider.GetRequiredService<FeatureProvider>();
-            await _featureApi.SetProviderAsync(featureProvider).ConfigureAwait(false);
+            await _featureApi.SetProviderAsync(featureProvider, cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var name in options.ProviderNames)
         {
             var featureProvider = _serviceProvider.GetRequiredKeyedService<FeatureProvider>(name);
-            await _featureApi.SetProviderAsync(name, featureProvider).ConfigureAwait(false);
+            await _featureApi.SetProviderAsync(name, featureProvider, cancellationToken).ConfigureAwait(false);
         }
 
         var hooks = new List<Hook>();


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Passes the `CancellationToken` from the Worker during initialization to the Provider initialization. This means any attempts to stop the initialization can be propagated to any providers, allowing them to be cleanly shutdown.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes copilot comment: https://github.com/open-feature/dotnet-sdk/pull/818#discussion_r3992328418

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

